### PR TITLE
74 - refine login flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,38 +2,32 @@ import React from 'react';
 import { compose } from 'recompose';
 import { injectState } from 'freactal';
 import './App.css';
-import { provideLoggedInUser, provideModalState } from 'stateProviders';
+import { provideLoggedInUser, provideModalState, provideToast } from 'stateProviders';
 import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { css } from 'react-emotion';
 import { ThemeProvider } from 'emotion-theming';
 import { Dashboard as ArrangerDashboard } from '@arranger/components';
 import Modal from 'react-modal';
 
+import Toast from 'uikit/Toast';
 import UserProfile from 'components/UserProfile';
 import FileRepo from 'components/FileRepo';
 import Join from 'components/Join';
+import LoginPage from 'components/LoginPage';
 import AuthRedirect from 'components/AuthRedirect';
-import JoinHeader from 'components/JoinHeader';
 import Header from 'components/Header';
 import Footer from 'components/Footer';
 import theme from 'theme/defaultTheme';
 
 import scienceBgPath from 'theme/images/background-science.jpg';
 
-const enhance = compose(provideLoggedInUser, provideModalState, injectState);
-
-const LandingContent = () => (
-  <div>
-    <h1 style={{ display: 'flex', justifyContent: 'center' }}>Kids First Data Portal</h1>
-    Pretty picture here 👶🌳🎈
-  </div>
-);
+const enhance = compose(provideLoggedInUser, provideModalState, provideToast, injectState);
 
 const Page = ({ Component, ...props }) => (
   <div
     css={`
       position: relative;
-      min-height: 100vh;
+      height: 100vh;
       min-width: 1024;
     `}
   >
@@ -41,10 +35,10 @@ const Page = ({ Component, ...props }) => (
       className={css`
         background-image: url(${scienceBgPath});
         background-repeat: repeat;
+        height: 100%;
         width: 100%;
         display: flex;
         flex-direction: column;
-        padding-bottom: 120px;
       `}
     >
       <Header />
@@ -68,7 +62,7 @@ const render = ({
   effects,
   appElement = document.getElementById('root'),
 }) => {
-  const { loggedInUser, modalState } = state;
+  const { loggedInUser, modalState, toast } = state;
   return (
     <Router>
       <ThemeProvider theme={theme}>
@@ -98,32 +92,8 @@ const render = ({
               exact
               render={props => forceSelectRole({ Component: UserProfile, loggedInUser, ...props })}
             />
-            <Route
-              path="/join"
-              exact
-              render={props => (
-                <div
-                  className={css`
-                    background-image: url(${scienceBgPath});
-                    background-repeat: repeat;
-                    height: 100%;
-                    width: 100%;
-                    display: flex;
-                    flex-direction: column;
-                  `}
-                >
-                  <JoinHeader />
-                  <Join />
-                </div>
-              )}
-            />
-            <Route
-              exact
-              path="/"
-              render={props =>
-                forceSelectRole({ Component: LandingContent, loggedInUser, ...props })
-              }
-            />
+            <Route path="/join" exact render={props => <Page Component={Join} {...props} />} />
+            <Route path="/" exact render={props => <Page Component={LoginPage} {...props} />} />
           </Switch>
           <Modal
             isOpen={!!modalState.component}
@@ -153,6 +123,7 @@ const render = ({
           >
             {modalState.component}
           </Modal>
+          <Toast {...toast}>{Object.keys(toast).length && toast.component}</Toast>
         </div>
       </ThemeProvider>
     </Router>

--- a/src/App.js
+++ b/src/App.js
@@ -27,18 +27,19 @@ const Page = ({ Component, ...props }) => (
   <div
     css={`
       position: relative;
-      height: 100vh;
+      min-height: 100vh;
       min-width: 1024;
+      background-image: url(${scienceBgPath});
     `}
   >
     <div
       className={css`
-        background-image: url(${scienceBgPath});
         background-repeat: repeat;
         height: 100%;
         width: 100%;
         display: flex;
         flex-direction: column;
+        padding-bottom: 120px;
       `}
     >
       <Header />

--- a/src/App.js
+++ b/src/App.js
@@ -124,7 +124,7 @@ const render = ({
           >
             {modalState.component}
           </Modal>
-          <Toast {...toast}>{Object.keys(toast).length && toast.component}</Toast>
+          <Toast {...toast}>{toast.component}</Toast>
         </div>
       </ThemeProvider>
     </Router>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
-import { css } from 'react-emotion';
+import styled, { css } from 'react-emotion';
 
 import { compose } from 'recompose';
 import { injectState } from 'freactal';
@@ -25,27 +25,13 @@ const navBar = css`
   font-size: 14px;
   line-height: 1.86;
   letter-spacing: 0.2px;
-
-  li {
-    a {
-      display: block;
-      color: #90278e;
-      padding: 6px 16px;
-      margin: 0px 4px;
-      text-decoration: none;
-      border: solid 2px transparent;
-    }
-
-    a:hover {
-      border-radius: 19px;
-      background-color: #404c9a;
-      border: solid 2px #dcdde3;
-      color: #ffffff;
-    }
-  }
 `;
 
-const Header = ({ state: { loggedInUser }, theme, history }) => {
+const NavLink = styled(Link)`
+  ${props => props.theme.navLink};
+`;
+
+const Header = ({ state: { loggedInUser }, theme, history, match: { path } }) => {
   const hasRoleSelected = !loggedInUser || (loggedInUser.roles && loggedInUser.roles[0]);
   return (
     <div
@@ -79,15 +65,15 @@ const Header = ({ state: { loggedInUser }, theme, history }) => {
               `}
             />
           </Link>
-          <ul className={navBar}>
+          <ul css={navBar}>
             <li>
-              <Link to="/">
+              <NavLink to="/">
                 <HouseIcon /> Dashboard
-              </Link>
+              </NavLink>
             </li>
             {loggedInUser && (
               <li>
-                <ToSearchPage index="file">
+                <ToSearchPage index="file" css={theme.navLink}>
                   <DatabaseIcon /> File Repository
                 </ToSearchPage>
               </li>
@@ -111,14 +97,20 @@ const Header = ({ state: { loggedInUser }, theme, history }) => {
           {loggedInUser &&
             hasRoleSelected && (
               <li>
-                <Link to={`/user/${loggedInUser.egoId}`}>User Profile</Link>
+                <NavLink to={`/user/${loggedInUser.egoId}`}>User Profile</NavLink>
               </li>
             )}
           {!loggedInUser && (
             <li>
-              <button className={theme.button} onClick={() => history.push('/join')}>
-                Sign-Up/Login
-              </button>
+              {path === '/' ? (
+                <Link css={theme.linkAsButton} to="/join">
+                  JOIN NOW
+                </Link>
+              ) : (
+                <Link css={theme.linkAsButton} to="/">
+                  LOGIN
+                </Link>
+              )}
             </li>
           )}
           {loggedInUser && (

--- a/src/components/Join.js
+++ b/src/components/Join.js
@@ -205,7 +205,7 @@ const JoinContent = compose(injectState, withRouter, withTheme)(
                       className={theme.wizardButton}
                       onClick={() => {
                         setToast({
-                          id: Date.now(),
+                          id: `${Date.now()}`,
                           action: 'success',
                           component: (
                             <div>

--- a/src/components/Join.js
+++ b/src/components/Join.js
@@ -13,6 +13,7 @@ import Login from 'components/Login';
 import DeleteButton from 'components/loginButtons/DeleteButton';
 import SelectRoleForm from 'components/forms/SelectRoleForm';
 import { updateProfile } from 'services/profiles';
+import ToSearchPage from 'components/links/ToSearchPage';
 
 const Consent = compose(
   injectState,
@@ -121,100 +122,116 @@ const ButtonsDiv = styled('div')`
   padding-top: 20px;
 `;
 
-const JoinContent = compose(withRouter, withTheme)(({ history, theme }) => (
-  <div
-    className={css`
-      width: 80%;
-      margin: 0px auto;
-    `}
-  >
-    <h2 className={theme.h2}>Join Kids First</h2>
-    <div className={theme.card}>
-      <Wizard
-        steps={[
-          {
-            title: 'Connect',
-            render: ({ nextStep }) => (
-              <div>
-                <h3 className={theme.h3}>
-                  Select a way to connect to the Kids First Data Resource Portal
-                </h3>
-                <p>
-                  Don’t worry, the information you provide Kids First will not be shared with any of
-                  these providers.
-                </p>
-                <Login
-                  shouldNotRedirect={true}
-                  onFinish={user => {
-                    if (!user.roles || user.roles.length === 0 || !user.acceptedTerms) {
-                      nextStep();
-                    } else {
-                      history.push('search/file');
-                    }
-                  }}
-                />
-              </div>
-            ),
-            renderButtons: () => <div />,
-            canGoBack: false,
-          },
-          {
-            title: 'Basic Info',
-            render: ({ nextStep, disableNextStep }) => (
-              <div>
-                <h3 className={theme.h3}>A bit about you</h3>
-                <p>
-                  Please provide a bit about yourself to help us provide you with a personalized
-                  experience.
-                </p>
-                <SelectRoleForm
-                  onValidateFinish={errors => disableNextStep(!!Object.keys(errors).length)}
-                  onValidChange={isValid => disableNextStep(!isValid)}
-                />
-              </div>
-            ),
-            renderButtons: ({ nextStep, prevStep, nextDisabled, prevDisabled }) => (
-              <ButtonsDiv
-                className={css`
-                  justify-content: flex-end;
-                `}
-              >
-                <DeleteButton className={theme.wizardButton}>Cancel</DeleteButton>
-                <button className={theme.wizardButton} onClick={nextStep} disabled={nextDisabled}>
-                  Next
-                  <RightIcon />
-                </button>
-              </ButtonsDiv>
-            ),
-            canGoBack: true,
-          },
-          {
-            title: 'Consent',
-            render: ({ disableNextStep }) => <Consent disableNextStep={disableNextStep} />,
-            renderButtons: ({ nextStep, prevStep, nextDisabled, prevDisabled }) => (
-              <ButtonsDiv>
-                <button className={theme.wizardButton} onClick={prevStep} disabled={prevDisabled}>
-                  <LeftIcon />
-                  Back
-                </button>
-                <div className={theme.row}>
+const JoinContent = compose(injectState, withRouter, withTheme)(
+  ({ state: { loggedInUser }, effects: { setToast, closeToast }, history, theme }) => (
+    <div
+      className={css`
+        width: 80%;
+        margin: 5% auto 0 auto;
+      `}
+    >
+      <div className={theme.card}>
+        <h2 className={theme.h2}>Join Kids First</h2>
+        <Wizard
+          steps={[
+            {
+              title: 'Connect',
+              render: ({ nextStep }) => (
+                <div>
+                  <h3 className={theme.h3}>
+                    Select a way to connect to the Kids First Data Resource Portal
+                  </h3>
+                  <p>
+                    Don’t worry, the information you provide Kids First will not be shared with any
+                    of these providers.
+                  </p>
+                  <Login
+                    shouldNotRedirect={true}
+                    onFinish={user => {
+                      if (!user.roles || user.roles.length === 0 || !user.acceptedTerms) {
+                        nextStep();
+                      } else {
+                        history.push('search/file');
+                      }
+                    }}
+                  />
+                </div>
+              ),
+              renderButtons: () => <div />,
+              canGoBack: false,
+            },
+            {
+              title: 'Basic Info',
+              render: ({ nextStep, disableNextStep }) => (
+                <div>
+                  <h3 className={theme.h3}>A bit about you</h3>
+                  <p>
+                    Please provide a bit about yourself to help us provide you with a personalized
+                    experience.
+                  </p>
+                  <SelectRoleForm
+                    onValidateFinish={errors => disableNextStep(!!Object.keys(errors).length)}
+                    onValidChange={isValid => disableNextStep(!isValid)}
+                  />
+                </div>
+              ),
+              renderButtons: ({ nextStep, prevStep, nextDisabled, prevDisabled }) => (
+                <ButtonsDiv
+                  className={css`
+                    justify-content: flex-end;
+                  `}
+                >
                   <DeleteButton className={theme.wizardButton}>Cancel</DeleteButton>
-                  <button
-                    className={theme.wizardButton}
-                    onClick={() => history.push('/search/file')}
-                    disabled={nextDisabled}
-                  >
-                    Finish
+                  <button className={theme.wizardButton} onClick={nextStep} disabled={nextDisabled}>
+                    Next
                     <RightIcon />
                   </button>
-                </div>
-              </ButtonsDiv>
-            ),
-            canGoBack: false,
-          },
-        ]}
-      />
+                </ButtonsDiv>
+              ),
+              canGoBack: true,
+            },
+            {
+              title: 'Consent',
+              render: ({ disableNextStep }) => <Consent disableNextStep={disableNextStep} />,
+              renderButtons: ({ nextStep, prevStep, nextDisabled, prevDisabled }) => (
+                <ButtonsDiv>
+                  <button className={theme.wizardButton} onClick={prevStep} disabled={prevDisabled}>
+                    <LeftIcon />
+                    Back
+                  </button>
+                  <div className={theme.row}>
+                    <DeleteButton className={theme.wizardButton}>Cancel</DeleteButton>
+                    <button
+                      className={theme.wizardButton}
+                      onClick={() => {
+                        setToast({
+                          id: Date.now(),
+                          action: 'success',
+                          component: (
+                            <div>
+                              Fill out your profile, or skip and{' '}
+                              <ToSearchPage index="file" onClick={() => closeToast()}>
+                                browse data
+                              </ToSearchPage>
+                            </div>
+                          ),
+                        });
+                        history.push(`/user/${loggedInUser.egoId}`);
+                      }}
+                      disabled={nextDisabled}
+                    >
+                      Finish
+                      <RightIcon />
+                    </button>
+                  </div>
+                </ButtonsDiv>
+              ),
+              canGoBack: false,
+            },
+          ]}
+        />
+      </div>
     </div>
-  </div>
-));
+  ),
+);
 export default JoinContent;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -22,6 +22,7 @@ const styles = {
     justify-content: center;
     height: 100%;
     width: 100%;
+    padding-bottom: 10px;
   `,
   googleSignin: css`
     margin-top: 0;

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { withRouter, Link } from 'react-router-dom';
+import { compose } from 'recompose';
+import { withTheme } from 'emotion-theming';
+import RightIcon from 'react-icons/lib/fa/angle-right';
+
+import Login from 'components/Login';
+
+const LoginPage = compose(withRouter, withTheme)(({ history, theme }) => (
+  <div
+    css={`
+      margin: 5% auto 0 auto;
+    `}
+  >
+    <div css={theme.card}>
+      <h2 css={theme.h2}>Log in</h2>
+
+      <Login
+        shouldNotRedirect={true}
+        onFinish={user => {
+          if (!user.roles || user.roles.length === 0 || !user.acceptedTerms) {
+            history.push('/join');
+          } else {
+            history.push('search/file');
+          }
+        }}
+      />
+      <div
+        css={`
+          ${theme.section};
+          text-align: center;
+          border-top: 1px solid ${theme.greyScale8};
+          margin-top: 10px;
+          padding: 10px 10px 0 10px;
+        `}
+      >
+        New to Kids First?{' '}
+        <Link to="/join">
+          Join now<RightIcon />
+        </Link>
+      </div>
+    </div>
+  </div>
+));
+export default LoginPage;

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -128,7 +128,7 @@ export default compose(
         background-color: #1094d5;
         height: 330px;
         align-items: center;
-        padding: 0;
+        padding: 20px 0;
         display: flex;
         justify-content: center;
       `}

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -128,7 +128,6 @@ export default compose(
         background-color: #1094d5;
         height: 330px;
         align-items: center;
-        padding: 20px 0;
         display: flex;
         justify-content: center;
       `}

--- a/src/stateProviders/index.js
+++ b/src/stateProviders/index.js
@@ -1,3 +1,4 @@
 export { default as provideLoggedInUser } from './provideLoggedInUser';
 export { default as provideLocalSqon } from './provideLocalSqon';
 export { default as provideModalState } from './provideModalState';
+export { default as provideToast } from './provideToast';

--- a/src/stateProviders/provideToast.js
+++ b/src/stateProviders/provideToast.js
@@ -1,0 +1,17 @@
+import { provideState } from 'freactal';
+
+export default provideState({
+  initialState: props => ({
+    toast: { action: null, id: null, component: null, closed: false },
+  }),
+  effects: {
+    setToast: (effects, { action, id, component }) => state => ({
+      ...state,
+      toast: { action, id, component, closed: false },
+    }),
+    closeToast: effects => state => ({
+      ...state,
+      toast: { ...state.toast, closed: true },
+    }),
+  },
+});

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -10,24 +10,50 @@ const colors = {
   active: '#00afed', //light blue
   inactive: '#dedfe4', //grey
 
+  greyScale8: '#d4d6dd',
   greyScale7: 'rgb(107,98,98)',
   greyScale6: 'rgb(245,245,245)',
   greyScale5: 'rgb(222,222,222)',
   greyScale4: 'rgb(200, 200, 200)',
   greyScale3: 'rgb(144,144,144)', // not enough contrast on white background
   greyScale2: 'rgb(61,61,61)',
-  greyScale1: 'rgb(36,36,36)',
+  greyScale1: 'rgb(52, 52, 52)', //#343434
+  greyScale0: 'rgb(36,36,36)',
 };
 
 const components = {
+  linkAsButton: css`
+    font-family: Montserrat;
+    font-size: 12px;
+    line-height: 2.17;
+    letter-spacing: 0.2px;
+    text-align: left;
+    color: #ffffff;
+    display: block;
+    padding: 6px 16px;
+    margin: 0px 4px;
+    text-decoration: none;
+    border: solid 2px transparent;
+    background-color: ${colors.primary};
+    color: #fff;
+    letter-spacing: 0.2px;
+    border-radius: 19px;
+    border: solid 2px transparent;
+
+    &:hover {
+      border-radius: 19px;
+      background-color: #404c9a;
+      border: solid 2px #dcdde3;
+      color: #ffffff;
+    }
+  `,
   button: css`
     outline: none;
     border: 0;
     background: none;
     box-shadow: none;
-    border-radius: 0px;
     background-color: ${colors.primary};
-    color: white;
+    color: #fff;
     padding: 6px 16px;
     font-family: montserrat;
     font-size: 14px;
@@ -37,14 +63,17 @@ const components = {
     border-radius: 19px;
     border: solid 2px transparent;
 
+    a:hover,
     &:hover {
       background-color: ${colors.primaryHover};
       border: solid 2px #dcdde3;
       color: #ffffff;
     }
 
+    a,
     &:link {
-      color: #ffffff;
+      color: #ffffff !important;
+      text-decoration: none;
     }
   `,
   pill: css`
@@ -183,9 +212,9 @@ const components = {
   card: css`
     border-radius: 10px;
     background-color: #ffffff;
-    box-shadow: 0 0 4.9px 0.1px ${colors.greyScale5};
-    border: solid 1px ${colors.greyScale4};
-    padding: 20px 10px;
+    padding: 20px 30px;
+    box-shadow: 0 0 4.9px 0.1px #bbbbbb;
+    border: solid 1px #e0e1e6;
   `,
   profileH3: css`
     font-family: Montserrat;
@@ -209,8 +238,13 @@ const components = {
   `,
   h2: css`
     text-align: center;
-    font-family: 'Open Sans';
     color: ${colors.secondary};
+    font-family: Montserrat;
+    font-size: 30px;
+    line-height: 0.87;
+    letter-spacing: 0.4px;
+    color: #2b388f;
+    font-weight: 500;
   `,
   h3: css`
     font-family: 'Open Sans';
@@ -248,6 +282,21 @@ const components = {
   row: css`
     display: flex;
     flex-direction: row;
+  `,
+  navLink: css`
+    display: block;
+    color: #90278e;
+    padding: 6px 16px;
+    margin: 0px 4px;
+    text-decoration: none;
+    border: solid 2px transparent;
+
+    &:hover {
+      border-radius: 19px;
+      background-color: #404c9a;
+      border: solid 2px #dcdde3;
+      color: #ffffff;
+    }
   `,
   secondaryNav: css`
     list-style-type: none;
@@ -369,6 +418,26 @@ const components = {
     width: 100%;
     font-family: montserrat;
     font-size: 14px;
+  `,
+  section: css`
+    font-family: 'Open Sans';
+    font-size: 14px;
+    line-height: 2.57;
+    letter-spacing: 0.2px;
+    text-align: left;
+    color: ${colors.greyScale1};
+
+    a {
+      color: ${colors.primary};
+      font-weight: 500;
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: ${colors.highlight};
+      font-weight: 500;
+      text-decoration: none;
+    }
   `,
 };
 

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -6,6 +6,7 @@ const colors = {
   primaryHover: '#404c9a', //purple
   tertiary: '#009bb8', //teal-blue
   highlight: '#e83a9c', //pink
+  hover: '#c03299', //also pink
 
   active: '#00afed', //light blue
   inactive: '#dedfe4', //grey
@@ -439,6 +440,34 @@ const components = {
       text-decoration: none;
     }
   `,
+  //toasts
+  success: css`
+    font-family: OpenSans;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.85;
+    text-align: left;
+
+    color: ${colors.greyScale1};
+    border-radius: 5px;
+    background-color: #d9eaed;
+    box-shadow: 0 0 5.8px 0.2px #9b9b9d;
+    border: solid 2px ${colors.tertiary};
+    width: 469px;
+
+    a {
+      color: ${colors.primary};
+      text-decoration: underline;
+    }
+    a:hover {
+      color: ${colors.hover};
+      text-decoration: underline;
+    }
+  `,
+  //no styles for these yet
+  error: css``,
+  warning: css``,
+  info: css``,
 };
 
 export default {

--- a/src/uikit/Toast.js
+++ b/src/uikit/Toast.js
@@ -1,0 +1,158 @@
+// @flow
+
+// Vendor
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose, withState, shouldUpdate, mapProps } from 'recompose';
+import CloseIcon from 'react-icons/lib/md/close';
+
+/*----------------------------------------------------------------------------*/
+
+const styles = {
+  wrapper: {
+    position: 'fixed',
+    top: 0,
+    width: '100vw',
+    zIndex: 100,
+    pointerEvents: 'none',
+    textAlign: 'center',
+    wordBreak: 'break-word',
+    overflow: 'hidden',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  container: {
+    margin: '1rem 0',
+    transition: 'transform 0.25s ease',
+  },
+  inactive: {
+    transform: 'translateY(-140%)',
+  },
+  active: {
+    transform: 'translateY(0)',
+  },
+  info: {
+    color: '#5C5151',
+    backgroundColor: '#EDF8FB',
+    border: '1px solid #B4CCD4',
+  },
+  success: {
+    color: '#3c763d',
+    backgroundColor: '#dff0d8',
+    border: '1px solid #d6e9c6',
+  },
+  error: {
+    color: '#773c63',
+    backgroundColor: '#f0d8dd',
+    border: '1px solid #e9c6c6',
+  },
+  warning: {
+    color: '#8a6d3b',
+    backgroundColor: '#fcf8e3',
+    border: '1px solid #faebcc',
+  },
+  toast: {
+    position: 'relative',
+    padding: '1.5rem',
+    width: '40rem',
+    borderRadius: '10px',
+    pointerEvents: 'all',
+    boxShadow: '0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)',
+  },
+  closeIcon: {
+    position: 'absolute',
+    top: '5px',
+    right: '5px',
+    cursor: 'pointer',
+    ':hover': {
+      color: 'red',
+    },
+  },
+};
+
+const Toast = ({ style, visible, action, close, closed, children, className }) => (
+  <div style={styles.wrapper} className={className}>
+    <div
+      style={{
+        ...styles.container,
+        ...(visible && !closed ? styles.active : styles.inactive),
+        ...style,
+      }}
+      className="test-notification"
+    >
+      <div style={{ ...styles.toast, ...(styles[action] || styles.success) }}>
+        <CloseIcon style={styles.closeIcon} onClick={close} />
+        {children}
+      </div>
+    </div>
+  </div>
+);
+
+Toast.propTypes = {
+  style: PropTypes.object,
+  children: PropTypes.node,
+  id: PropTypes.string,
+  visible: PropTypes.bool,
+  action: PropTypes.string,
+  close: PropTypes.func,
+  delay: PropTypes.number,
+};
+
+let timeoutId;
+let pageload = false;
+
+const enhance = compose(
+  withState('visible', 'setState', false),
+  shouldUpdate((props, nextProps) => {
+    // Do not render on the first prop update, such as store rehydration
+    if (pageload) {
+      pageload = false;
+      return false;
+    }
+
+    // Do not render if no children
+    if (!nextProps.children) return false;
+
+    // Do not render if the notification is not up and its children don't change.
+    // This catches prop changes that should not affect the notification
+    if (props.id === nextProps.id && (!props.visible && !nextProps.visible)) {
+      return false;
+    }
+
+    function startTimer() {
+      timeoutId = setTimeout(() => {
+        props.setState(() => false);
+      }, nextProps.delay || 5000);
+    }
+
+    // If the notification is not up, pop it up and begin the removal timeout
+    if (!props.visible && !nextProps.visible) {
+      props.setState(() => true);
+      if (!nextProps.delay || nextProps.delay > 0) {
+        startTimer();
+      }
+    }
+
+    // If notification is up, refresh timeout when id changes
+    if (props.visible && props.id !== nextProps.id) {
+      clearTimeout(timeoutId);
+      if (!nextProps.delay || nextProps.delay > 0) {
+        startTimer();
+      }
+    }
+
+    return true;
+  }),
+  mapProps(({ setState, ...rest }) => ({
+    close: () => {
+      setState(() => false);
+      if (timeoutId) clearTimeout(timeoutId);
+    },
+    ...rest,
+  })),
+);
+
+/*----------------------------------------------------------------------------*/
+
+export default enhance(Toast);

--- a/src/uikit/Toast.js
+++ b/src/uikit/Toast.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { compose, withState, shouldUpdate, mapProps } from 'recompose';
 import CloseIcon from 'react-icons/lib/md/close';
+import { withTheme } from 'emotion-theming';
 
 /*----------------------------------------------------------------------------*/
 
@@ -32,38 +33,17 @@ const styles = {
   active: {
     transform: 'translateY(0)',
   },
-  info: {
-    color: '#5C5151',
-    backgroundColor: '#EDF8FB',
-    border: '1px solid #B4CCD4',
-  },
-  success: {
-    color: '#3c763d',
-    backgroundColor: '#dff0d8',
-    border: '1px solid #d6e9c6',
-  },
-  error: {
-    color: '#773c63',
-    backgroundColor: '#f0d8dd',
-    border: '1px solid #e9c6c6',
-  },
-  warning: {
-    color: '#8a6d3b',
-    backgroundColor: '#fcf8e3',
-    border: '1px solid #faebcc',
-  },
   toast: {
     position: 'relative',
     padding: '1.5rem',
-    width: '40rem',
-    borderRadius: '10px',
     pointerEvents: 'all',
-    boxShadow: '0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)',
   },
   closeIcon: {
     position: 'absolute',
     top: '5px',
     right: '5px',
+    width: '15px',
+    height: '15px',
     cursor: 'pointer',
     ':hover': {
       color: 'red',
@@ -71,7 +51,7 @@ const styles = {
   },
 };
 
-const Toast = ({ style, visible, action, close, closed, children, className }) => (
+const Toast = ({ style, theme, visible, action, close, closed, children, className }) => (
   <div style={styles.wrapper} className={className}>
     <div
       style={{
@@ -81,7 +61,7 @@ const Toast = ({ style, visible, action, close, closed, children, className }) =
       }}
       className="test-notification"
     >
-      <div style={{ ...styles.toast, ...(styles[action] || styles.success) }}>
+      <div style={{ ...styles.toast }} css={theme[action] || theme.success}>
         <CloseIcon style={styles.closeIcon} onClick={close} />
         {children}
       </div>
@@ -103,6 +83,7 @@ let timeoutId;
 let pageload = false;
 
 const enhance = compose(
+  withTheme,
   withState('visible', 'setState', false),
   shouldUpdate((props, nextProps) => {
     // Do not render on the first prop update, such as store rehydration


### PR DESCRIPTION
- Root route changed to login page, this displays same OAuth provider login buttons as Join wiz but different text to guide UX.
- Pulled in GDC toast Notifications, renamed to Toast because there was always confusion with these and BannerNotifications in GDC.
- Toast with 'Fill out Profile or Skip and Browse Files' on complete of join wiz.
![screen shot 2018-03-01 at 2 02 50 pm](https://user-images.githubusercontent.com/1314446/36864209-0f99490c-1d5a-11e8-8861-de836d4a9149.png)
