### PR TITLE
🔥 remove service worker to test share url cache fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
 import { getAppElement } from './services/globalDomNodes.js';
 
 ReactDOM.render(<App />, getAppElement());
-registerServiceWorker();


### PR DESCRIPTION
going to a shared url doesn't work if you've already been to the app on the same url. i suspect this is a service worker issue. I think it's worth merging this for the demo to test since it won't break anything and might potentially fix this.

then we can fiddle with the manifest.json later if we want to keep the service worker at all.