### PR TITLE
🐛 if no filters selected, don't create filters

### DIFF
--- a/src/components/FamilyManifestModal/FamilyManifestModal.js
+++ b/src/components/FamilyManifestModal/FamilyManifestModal.js
@@ -84,25 +84,27 @@ const enhance = compose(
         .map(([key]) => key);
 
       fileManifestParticipantsAndFamily({
-        sqon: {
-          op: 'or',
-          content: [
-            sqon,
-            {
-              op: 'and',
+        sqon: sqon
+          ? {
+              op: 'or',
               content: [
+                sqon,
                 {
-                  op: 'in',
-                  content: { field: 'data_type', value: selectedDataTypes },
-                },
-                {
-                  op: 'in',
-                  content: { field: 'participants.kf_id', value: familyMemberIds },
+                  op: 'and',
+                  content: [
+                    {
+                      op: 'in',
+                      content: { field: 'data_type', value: selectedDataTypes },
+                    },
+                    {
+                      op: 'in',
+                      content: { field: 'participants.kf_id', value: familyMemberIds },
+                    },
+                  ],
                 },
               ],
-            },
-          ],
-        },
+            }
+          : sqon,
         columns: columns,
       })().then(async profile => unsetModal(), errors => setSubmitting(false));
     },


### PR DESCRIPTION
It was injecting `null` into the filters
but if filters is `null` it will return all files anyways, so it can just return null in that case