### PR TITLE
🐛 don't set the JWT if it's invalid

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -37,26 +37,29 @@ const styles = {
 
 const enhance = compose(injectState, withRouter);
 
-export const handleJWT = async ({ jwt, onFinish, setToken, setUser }) => {
+export const validateJWT = ({ jwt }) => {
+  if (!jwt) return false;
   const data = jwtDecode(jwt);
   const currentTime = Date.now();
   const tokenExpiry = new Date(data.exp * 1000).valueOf();
-  const user = data.context.user;
-  const egoId = data.sub;
+  return tokenExpiry > currentTime && data;
+};
+
+export const handleJWT = async ({ jwt, onFinish, setToken, setUser }) => {
+  const jwtData = validateJWT({ jwt });
+  if (!jwtData) return;
+
   await setToken(jwt);
+  const user = jwtData.context.user;
+  const egoId = jwtData.sub;
   const existingProfile = await getProfile({ egoId });
   const newProfile = !existingProfile ? await createProfile({ ...user, egoId }) : {};
-  const loggedInUser =
-    tokenExpiry > currentTime
-      ? {
-          ...(existingProfile || newProfile),
-          email: user.email,
-        }
-      : null;
+  const loggedInUser = {
+    ...(existingProfile || newProfile),
+    email: user.email,
+  };
   await setUser(loggedInUser);
-  if (onFinish) {
-    onFinish(loggedInUser);
-  }
+  onFinish && onFinish(loggedInUser);
 };
 
 /**

--- a/src/stateProviders/provideLoggedInUser.js
+++ b/src/stateProviders/provideLoggedInUser.js
@@ -29,7 +29,7 @@ export default provideState({
         });
         return { ...state, isLoadingUser: true };
       }
-      localStorage.removeItem('EGO_JWT');
+      setToken(null);
       return { ...state, isLoadingUser: false };
     },
     setUser: (effects, user) =>


### PR DESCRIPTION
this introduces a check to see if a user's JWT is expired before setting it in state (on load). it'll get us around the persona api errors on page load, however a subsequent PR should address persona authentication issues in the case of a token expiring within the context of a single session.