### PR TITLE
🐛 the missing bucket was throwing counts off by 1

### DIFF
--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -15,7 +15,17 @@ const Line = () => {
   );
 };
 
-const Stat = ({ sqon, index, icon = '', accessor = '', label = '', query, fragment, ...props }) => {
+const Stat = ({
+  sqon,
+  index,
+  icon = '',
+  accessor = '',
+  label = '',
+  query,
+  fragment,
+  variables = {},
+  ...props
+}) => {
   const getValue = typeof accessor() === 'function' ? accessor() : data => get(data, accessor());
 
   return (
@@ -43,7 +53,7 @@ const Stat = ({ sqon, index, icon = '', accessor = '', label = '', query, fragme
           name={`${index}StatQuery`}
           {...props}
           query={query(fragment())}
-          variables={{ sqon }}
+          variables={{ sqon, ...variables }}
           index={index}
           render={({ data, loading }) =>
             loading ? (


### PR DESCRIPTION
the missing bucket was throwing counts off by one. I've added a PR to arranger to give the gql client the ability to specify whether or not to include the missing bucket, this uses that to fix the issue.

depends on https://github.com/overture-stack/arranger/pull/346