### PR TITLE
🐛 shouldn't assume user is loaded from the get-go

### DIFF
--- a/src/components/FileRepo.js
+++ b/src/components/FileRepo.js
@@ -186,7 +186,7 @@ const AggregationsWrapper = enhance(({ state, effects, theme, setSQON, ...props 
         <QuickSearch
           {...{ ...props, setSQON }}
           placeholder="Enter Identifiers"
-          translateSQONValue={translateSQONValue({ sets: state.loggedInUser.sets })}
+          translateSQONValue={translateSQONValue({ sets: (state.loggedInUser || {}).sets })}
           LoadingIcon={
             <Spinner
               fadeIn="none"


### PR DESCRIPTION
just a 'lil bug