### PR TITLE
🐛 adds and implements default ajax headers

### DIFF
--- a/src/services/ajax.js
+++ b/src/services/ajax.js
@@ -10,9 +10,10 @@ ajax.interceptors.request.use(
   config => {
     // set Authorization headers on a per request basis
     // setting headers on axios get/put/post or common seems to be shared accross all axios instances
-    config.headers['Authorization'] = `Bearer ${
-      config.url.startsWith(gen3ApiRoot) ? gen3Token : token
-    }`;
+    config.headers = {
+      ...config.headers,
+      'Authorization': `Bearer ${config.url.startsWith(gen3ApiRoot) ? gen3Token : token}`,
+    };
     return config;
   },
   err => {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -7,11 +7,13 @@ export const initializeApi = ({ onUnauthorized }) => ({
   method = 'post',
   endpoint = '',
   body,
-  headers,
+  headers = {},
   url,
 }) => {
   const uri = url || urlJoin(arrangerApiRoot, endpoint);
-  return ajax[method.toLowerCase()](uri, body)
+  return ajax[method.toLowerCase()](uri, body, {
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
     .then(response => {
       return response.data;
     })


### PR DESCRIPTION
This makes sure unless indicated otherwise, `'Content-Type': 'application/json'` is set in the header