### PR TITLE
🐛 accurately udpate CompleteOMeter per user role

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,6 +4,29 @@ import HealthIcon from 'icons/HealthIcon';
 import HealthBanner from 'assets/user-banner-health.png';
 import ResearchBanner from 'assets/user-banner-research.png';
 import CommunityBanner from 'assets/user-banner-community.png';
+import { without } from 'lodash';
+
+const DEFAULT_PROFILE_FIELDS = [
+      '_id',
+      'title',
+      'firstName',
+      'lastName',
+      'egoId',
+      'roles',
+      'acceptedTerms',
+      'email',
+      'story',
+      'bio',
+      'jobTitle',
+      'institution',
+      'city',
+      'state',
+      'country',
+      'website',
+      'googleScholarId',
+      'interests',
+      'sets',
+    ]
 
 export const ROLES = [
   {
@@ -20,6 +43,7 @@ export const ROLES = [
       gradientLight: '#1297d7',
       pillBkg: '#00afed',
     },
+    profileFields: DEFAULT_PROFILE_FIELDS,
   },
   {
     type: 'community',
@@ -35,6 +59,7 @@ export const ROLES = [
       gradientLight: '#cd5162',
       pillBkg: '#e83a9c',
     },
+    profileFields: without(DEFAULT_PROFILE_FIELDS, 'institution', 'jobTitle'),
   },
   {
     type: 'health',
@@ -50,6 +75,7 @@ export const ROLES = [
       gradientLight: '#1ca39e',
       pillBkg: '#1f9bb6',
     },
+    profileFields: without(DEFAULT_PROFILE_FIELDS, 'institution', 'jobTitle'),
   },
 ];
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,29 +4,6 @@ import HealthIcon from 'icons/HealthIcon';
 import HealthBanner from 'assets/user-banner-health.png';
 import ResearchBanner from 'assets/user-banner-research.png';
 import CommunityBanner from 'assets/user-banner-community.png';
-import { without } from 'lodash';
-
-const DEFAULT_PROFILE_FIELDS = [
-      '_id',
-      'title',
-      'firstName',
-      'lastName',
-      'egoId',
-      'roles',
-      'acceptedTerms',
-      'email',
-      'story',
-      'bio',
-      'jobTitle',
-      'institution',
-      'city',
-      'state',
-      'country',
-      'website',
-      'googleScholarId',
-      'interests',
-      'sets',
-    ]
 
 export const ROLES = [
   {
@@ -43,7 +20,6 @@ export const ROLES = [
       gradientLight: '#1297d7',
       pillBkg: '#00afed',
     },
-    profileFields: DEFAULT_PROFILE_FIELDS,
   },
   {
     type: 'community',
@@ -59,7 +35,6 @@ export const ROLES = [
       gradientLight: '#cd5162',
       pillBkg: '#e83a9c',
     },
-    profileFields: without(DEFAULT_PROFILE_FIELDS, 'institution', 'jobTitle'),
   },
   {
     type: 'health',
@@ -75,7 +50,6 @@ export const ROLES = [
       gradientLight: '#1ca39e',
       pillBkg: '#1f9bb6',
     },
-    profileFields: without(DEFAULT_PROFILE_FIELDS, 'institution', 'jobTitle'),
   },
 ];
 


### PR DESCRIPTION
accounts for some user roles not having all default fields. 

Use Case: 
if you created an account with the Community Role and filled out all available fields on the screen the CompleteOMeter would not show 100% because it accounted for all fields for all roles