### PR TITLE
💄 table height should shrink when fewer rows are present

### DIFF
--- a/src/components/FileRepo/FileRepo.js
+++ b/src/components/FileRepo/FileRepo.js
@@ -124,17 +124,14 @@ const TableContainer = styled('div')`
 `;
 
 const ToolbarContainer = styled('div')`
-  flex: none;
-  display: flex;
+  ${({ theme }) => theme.row};
 `;
 
 const TableWrapper = styled('div')`
   ${({ theme }) => theme.column};
-  flex-basis: 100%;
   min-height: 300px;
   & .ReactTable {
-    flex-grow: 1;
-    height: 1px;
+    min-height: 1px;
   }
 `;
 

--- a/src/components/UserDashboard/index.js
+++ b/src/components/UserDashboard/index.js
@@ -15,7 +15,7 @@ import { StyledH2 } from './styles';
 
 const UserDashboard = styled('div')`
   ${({ theme }) => theme.row};
-  min-height: 900px;
+  min-height: 600px;
 `;
 
 export default compose(


### PR DESCRIPTION
2 changes:
- table height respects the viewport AND collapses when there are fewer rows
- user dashboard 900px was a bit much, 600 seems to be a more realistic minimum