### PR TITLE
:chart_with_upwards_trend: gen3 tracking update

### DIFF
--- a/src/components/UserProfile/UserIntegrations/index.js
+++ b/src/components/UserProfile/UserIntegrations/index.js
@@ -215,10 +215,20 @@ const UserIntegrations = withApi(
                                     </Row>
                                   ),
                                 });
+                                trackUserInteraction({
+                                  category: TRACKING_EVENTS.categories.user.profile,
+                                  action: TRACKING_EVENTS.actions.integration.connected,
+                                  label: TRACKING_EVENTS.gen3,
+                                });
                               })
                               .catch(err => {
                                 console.log('err: ', err);
                                 setState({ loading: false });
+                                trackUserInteraction({
+                                  category: TRACKING_EVENTS.categories.user.profile,
+                                  action: TRACKING_EVENTS.actions.integration.failed,
+                                  label: TRACKING_EVENTS.gen3,
+                                });
                               });
                           }}
                         />


### PR DESCRIPTION
adds `trackUserInteraction` calls to Gen3 connection calls in the profile settings area.

@hlminh2000 wasn't able to test successful connections on my local as it threw a incorrect redirect url error