### PR TITLE
📈 tracking events for  query abandonment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
     <title>Portal</title>
   </head>
   <body>
@@ -38,5 +39,13 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <script src="https://apis.google.com/js/platform.js"></script>
+    <script>
+      <!-- track when users exit the site after starting a query -->
+      window.onbeforeunload = function () {
+        if(window.localStorage.getItem('KF_GA_TIMING_INIT_FILE_QUERY_TO_CAVATICA_COPY') || window.localStorage.getItem('KF_GA_TIMING_INIT_FILE_QUERY_TO_DOWNLOAD') ){
+          window.ga('send', 'event', 'File Repo', 'Query Abandoned', 'exited site', 3);
+        }
+      }
+    </script>
   </body>
 </html>

--- a/src/components/FileRepo/FileRepo.js
+++ b/src/components/FileRepo/FileRepo.js
@@ -110,6 +110,12 @@ const FileRepo = compose(injectState, withTheme, withApi)(
                                   category: TRACKING_EVENTS.categories.fileRepo.dataTable,
                                   action: TRACKING_EVENTS.actions.query.clear,
                                 });
+                                trackFileRepoInteraction({
+                                  category: 'File Repo',
+                                  action: TRACKING_EVENTS.actions.query.abandoned,
+                                  label: 'cleared SQON',
+                                  value: 1,
+                                });
                               }}
                             />
                             {url.sqon &&

--- a/src/services/analyticsTracking.js
+++ b/src/services/analyticsTracking.js
@@ -165,8 +165,8 @@ export const trackUserInteraction = async ({ category, action, label }) => {
       break;
     case TRACKING_EVENTS.categories.fileRepo.actionsSidebar:
       if (
-        TRACKING_EVENTS.actions.download.report ||
-        'Download Manifest ' + TRACKING_EVENTS.actions.click
+        action === TRACKING_EVENTS.actions.download.report ||
+        action === `${TRACKING_EVENTS.actions.download.manifest} ${TRACKING_EVENTS.actions.click}`
       ) {
         stopAnalyticsTiming(TRACKING_EVENTS.timings.queryToDownload, {
           category: 'File Acquisition',


### PR DESCRIPTION
simple events to track when people bail out of completing query actions