### PR TITLE
👷  Adds Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+@Library(value='kids-first/aws-infra-jenkins-shared-libraries', changelog=false) _
+cloudfront_default {
+    projectName = "kf-portal-ui"
+}


### PR DESCRIPTION
Adds Jenkinsfile to use the cloudfront module.
This will allow us to deploy portal using the standard cloudfront deployment pipeline, but will not interfere with the current netlify deployment.