### PR TITLE
📈 adds tracking events to Saved Queries widget

### DIFF
--- a/src/components/UserDashboard/QueryBlock.js
+++ b/src/components/UserDashboard/QueryBlock.js
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 import { compose } from 'recompose';
 
 import { injectState } from 'freactal';
-
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 import { Box, Flex, Span, Link } from 'uikit/Core';
 import Column from 'uikit/Column';
 import Row from 'uikit/Row';
@@ -37,14 +37,33 @@ const QueryBlock = compose(injectState, withApi, withTheme)(
     <Query inactive={inactive}>
       <Column width="100%">
         <Row justifyContent="space-between" width="100%">
-          <Link fontSize={1} fontWeight="bold" color={theme.primary} to={q.link}>
+          <Link
+            onClick={() => {
+              trackUserInteraction({
+                category: TRACKING_EVENTS.categories.user.dashboard.widgets.savedQueries,
+                action: `${TRACKING_EVENTS.actions.click} Saved Query Title`,
+                label: JSON.stringify(q),
+              });
+            }}
+            fontSize={1}
+            fontWeight="bold"
+            color={theme.primary}
+            to={q.link}
+          >
             {q.alias}
           </Link>
           <Box pr={2} pl={2}>
             <Span
               color={theme.primary}
               hover={{ cursor: 'pointer', color: theme.hover }}
-              onClick={() => deleteQuery({ api, queryId: q.id })}
+              onClick={() => {
+                trackUserInteraction({
+                  category: TRACKING_EVENTS.categories.user.dashboard.widgets.savedQueries,
+                  action: TRACKING_EVENTS.actions.query.delete,
+                  label: JSON.stringify(q),
+                });
+                deleteQuery({ api, queryId: q.id });
+              }}
             >
               <TrashIcon />
             </Span>

--- a/src/services/analyticsTracking.js
+++ b/src/services/analyticsTracking.js
@@ -24,7 +24,13 @@ export const TRACKING_EVENTS = {
     modals: 'Modals',
     user: {
       profile: 'User Profile',
+      dashboard: {
+        widgets: {
+          savedQueries: 'User Dashboard: Saved Queries widget',
+        },
+      },
     },
+
     fileRepo: {
       filters: 'File Repo: Filters',
       dataTable: 'File Repo: Data Table',
@@ -53,6 +59,7 @@ export const TRACKING_EVENTS = {
       save: 'Query Saved',
       share: 'Query Shared',
       clear: 'Clear Query (sqon)',
+      delete: 'Query Deleted ',
     },
     userRoleSelected: 'User Role Updated',
     integration: {


### PR DESCRIPTION
Tracks when queries are deleted and when the user clicks on a saved query title