### PR TITLE
Bug/chart label misalignment

### DIFF
--- a/src/chartkit/components/HorizontalBar.js
+++ b/src/chartkit/components/HorizontalBar.js
@@ -13,6 +13,12 @@ const HorizontalBarWrapper = styled('div')`
   height: 90%;
 `;
 
+/**
+ * Ref: https://github.com/kids-first/kf-portal-ui/pull/1006
+ * IE, FF and Chrome all deal with svg text alignment differently
+ * Nivo uses alignment-baseline which FF does not support
+ * TextBugWrapper provides FF with correct attribute
+ */
 const TextBugWrapper = styled('div')`
   width: 100%;
   height: 100%;

--- a/src/chartkit/components/HorizontalBar.js
+++ b/src/chartkit/components/HorizontalBar.js
@@ -13,6 +13,14 @@ const HorizontalBarWrapper = styled('div')`
   height: 90%;
 `;
 
+const TextBugWrapper = styled('div')`
+  width: 100%;
+  height: 100%;
+  & text {
+    dominant-baseline: ${({ baseline }) => baseline};
+  }
+`;
+
 class HorizontalBar extends Component {
   constructor(props) {
     super(props);
@@ -173,13 +181,15 @@ class HorizontalBar extends Component {
     return (
       <HorizontalBarWrapper>
         {!legends ? null : <Legend legends={legends} theme={defaultTheme.legend} />}
-        <ChartDisplayContainer>
-          {height ? (
-            <ResponsiveBar {...chartData} height={height} />
-          ) : (
-            <ResponsiveBar {...chartData} />
-          )}
-        </ChartDisplayContainer>
+        <TextBugWrapper baseline="text-before-edge">
+          <ChartDisplayContainer>
+            {height ? (
+              <ResponsiveBar {...chartData} height={height} />
+            ) : (
+              <ResponsiveBar {...chartData} />
+            )}
+          </ChartDisplayContainer>
+        </TextBugWrapper>
       </HorizontalBarWrapper>
     );
   }

--- a/src/chartkit/components/Legend/SvgText.js
+++ b/src/chartkit/components/Legend/SvgText.js
@@ -10,6 +10,7 @@ const defaultStyle = {
 const SvgText = ({
   textAnchor = 'start',
   alignmentBaseline = 'middle',
+  dominantBaseline = 'middle', // firefox
   x = '0',
   y = '0',
   style = defaultStyle,
@@ -19,6 +20,7 @@ const SvgText = ({
   <text
     textAnchor={textAnchor}
     alignmentBaseline={alignmentBaseline}
+    dominantBaseline={dominantBaseline}
     x={x}
     y={y}
     style={style}


### PR DESCRIPTION
IE, FF and Chrome all deal with svg text alignment differently
Nivo uses `alignment-baseline` which FF does not support

Known issue in Nivo - https://github.com/plouc/nivo/issues/164

This PR fixes in FF. Looking like you have to manually manipulate the `dy` for IE :(