### PR TITLE
#688 Align facet text

### DIFF
--- a/src/components/FileRepo/ui.js
+++ b/src/components/FileRepo/ui.js
@@ -78,6 +78,17 @@ export const ArrangerContainer = styled(Row)`
       .bucket-link {
         ${arrangerValueText};
         color: ${({ theme }) => theme.greyScale1};
+        input[type=checkbox] {
+          float: left;
+        }
+        .textHighlight, .bucket-count {
+          display: table;
+        }
+      }
+      .bucket-count {
+        display: table;
+        min-width: 50px;
+        text-align: right;
       }
     }
   }


### PR DESCRIPTION
After discussing with @rosibaj, also made the following changes:
- made the number "chip" the same height for text lines > 1
- number value aligned to the right within the "chip: