### PR TITLE
🐛 prevents refetch on aggs panel expansion

### DIFF
--- a/src/components/FileRepo/AggregationSidebar/AggregationSidebar.js
+++ b/src/components/FileRepo/AggregationSidebar/AggregationSidebar.js
@@ -61,10 +61,6 @@ const CollapsibleAggregationWrapper = styled(AggregationWrapper)`
   overflow: hidden;
 `;
 
-const CollapsibleCustomAggregationsPanel = styled(CustomAggregationsPanel)`
-  display: ${({ expanded }) => (expanded ? `block` : `none`)};
-`;
-
 const AggregationSidebar = compose(
   injectState,
   withTheme,
@@ -146,32 +142,31 @@ const AggregationSidebar = compose(
               />
             )}
           </AggregationHeader>
-          {expanded ? (
-            <CollapsibleCustomAggregationsPanel
-              {...{
-                ...props,
-                state,
-                effects,
-                setSQON,
-                containerRef: aggregationsWrapperRef,
-                translateSQONValue,
-                onValueChange: ({ active, field, value }) => {
-                  if (active) {
-                    trackFileRepoInteraction({
-                      category: TRACKING_EVENTS.categories.fileRepo.filters,
-                      action: 'Filter Selected',
-                      label: { type: 'filter', value, field },
-                    });
-                  }
-                },
-                componentProps: {
-                  getTermAggProps: () => ({
-                    InputComponent: FilterInput,
-                  }),
-                },
-              }}
-            />
-          ) : null}
+          <CustomAggregationsPanel
+            {...{
+              ...props,
+              hidden: !expanded,
+              state,
+              effects,
+              setSQON,
+              containerRef: aggregationsWrapperRef,
+              translateSQONValue,
+              onValueChange: ({ active, field, value }) => {
+                if (active) {
+                  trackFileRepoInteraction({
+                    category: TRACKING_EVENTS.categories.fileRepo.filters,
+                    action: 'Filter Selected',
+                    label: { type: 'filter', value, field },
+                  });
+                }
+              },
+              componentProps: {
+                getTermAggProps: () => ({
+                  InputComponent: FilterInput,
+                }),
+              },
+            }}
+          />
         </CollapsibleAggregationWrapper>
       )}
     </ScrollbarSize>

--- a/src/components/FileRepo/AggregationSidebar/CustomAggregationsPanel.js
+++ b/src/components/FileRepo/AggregationSidebar/CustomAggregationsPanel.js
@@ -97,6 +97,7 @@ export default compose(
   }) => (
     <Component initialState={{ selectedTab: 'CLINICAL' }}>
       {({ state: { selectedTab }, setState }) => (
+        // css rather than conditional rendering to prevent rerender
         <Container style={{ display: hidden ? 'none' : 'block' }}>
           <Tabs
             selectedTab={selectedTab}

--- a/src/components/FileRepo/AggregationSidebar/CustomAggregationsPanel.js
+++ b/src/components/FileRepo/AggregationSidebar/CustomAggregationsPanel.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { compose } from 'recompose';
 import { injectState } from 'freactal';
 import { withTheme } from 'emotion-theming';
@@ -45,9 +45,14 @@ const Tabs = ({ selectedTab, onTabSelect, options }) => (
   </TabsRow>
 );
 
-const Wrapper = styled('div')`
+const AggsListWrapper = styled('div')`
   position: relative;
   flex: 1 1 auto;
+  height: 100%;
+`;
+
+const Container = styled('div')`
+  height: 100%;
 `;
 
 const Scroll = styled('div')`
@@ -87,11 +92,12 @@ export default compose(
     theme,
     state,
     effects,
+    hidden = false,
     ...props
   }) => (
     <Component initialState={{ selectedTab: 'CLINICAL' }}>
       {({ state: { selectedTab }, setState }) => (
-        <Fragment>
+        <Container style={{ display: hidden ? 'none' : 'block' }}>
           <Tabs
             selectedTab={selectedTab}
             options={[
@@ -100,7 +106,7 @@ export default compose(
             ]}
             onTabSelect={({ id }) => setState({ selectedTab: id })}
           />
-          <Wrapper>
+          <AggsListWrapper>
             <Scroll>
               <Query
                 renderError
@@ -156,7 +162,6 @@ export default compose(
                           componentProps: {
                             getTermAggProps: () => ({
                               InputComponent: FilterInput,
-                              headerTitle: '# files',
                             }),
                           },
                           getCustomItems: ({ aggs }) =>
@@ -239,8 +244,8 @@ export default compose(
                 }}
               />
             </Scroll>
-          </Wrapper>
-        </Fragment>
+          </AggsListWrapper>
+        </Container>
       )}
     </Component>
   ),


### PR DESCRIPTION
Eventually we should look into introducing client-side caching at the data-fetching layer, but that's a bigger task