### PR TITLE
:chart_with_upwards_trend: File Entity Page tracking

### DIFF
--- a/src/components/EntityPage/File/fileProperties.js
+++ b/src/components/EntityPage/File/fileProperties.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { pickData } from './utils';
 import { formatToGB } from './utils';
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 
-import ExternalLink from 'uikit/ExternalLink';
+import { Link } from 'react-router-dom';
 
 export const toFilePropertiesSummary = data => {
   const participants = data.participants.hits.edges[0].node;
@@ -15,7 +16,25 @@ export const toFilePropertiesSummary = data => {
     { title: 'Name:', summary: pickData(data, 'file_name') },
     {
       title: 'Study:',
-      summary: <ExternalLink href={null}>{`${study.short_name} (${study.kf_id})`}</ExternalLink>,
+      summary: (
+        <Link
+          to={
+            `/search/file?sqon=` +
+            encodeURIComponent(
+              `{"op":"and","content":[{"op":"in","content":{"field":"participants.study.short_name","value":["${
+                study.short_name
+              }"]}}]}`,
+            )
+          }
+          onClick={e => {
+            trackUserInteraction({
+              category: TRACKING_EVENTS.categories.entityPage.file,
+              action: TRACKING_EVENTS.actions.click + ` File Property: Study`,
+              label: `${study.short_name} (${study.kf_id})`,
+            });
+          }}
+        >{`${study.short_name} (${study.kf_id})`}</Link>
+      ),
     },
     { title: 'Access:', summary: data.controlled_access ? 'Controlled' : 'Open' },
     { title: 'Consent Codes:', summary: pickData(biospecimens, 'dbgap_consent_code') },

--- a/src/components/EntityPage/File/fileProperties.js
+++ b/src/components/EntityPage/File/fileProperties.js
@@ -29,7 +29,7 @@ export const toFilePropertiesSummary = data => {
           onClick={e => {
             trackUserInteraction({
               category: TRACKING_EVENTS.categories.entityPage.file,
-              action: TRACKING_EVENTS.actions.click + ` File Property: Study`,
+              action: TRACKING_EVENTS.actions.click + `: File Property: Study`,
               label: `${study.short_name} (${study.kf_id})`,
             });
           }}

--- a/src/components/EntityPage/File/fileProperties.js
+++ b/src/components/EntityPage/File/fileProperties.js
@@ -18,14 +18,7 @@ export const toFilePropertiesSummary = data => {
       title: 'Study:',
       summary: (
         <Link
-          to={
-            `/search/file?sqon=` +
-            encodeURIComponent(
-              `{"op":"and","content":[{"op":"in","content":{"field":"participants.study.short_name","value":["${
-                study.short_name
-              }"]}}]}`,
-            )
-          }
+          to={''}
           onClick={e => {
             trackUserInteraction({
               category: TRACKING_EVENTS.categories.entityPage.file,

--- a/src/components/EntityPage/File/index.js
+++ b/src/components/EntityPage/File/index.js
@@ -73,7 +73,7 @@ const fileQuery = `query ($sqon: JSON) {
           reference_genome
           size
           instrument_models
-          experiment_strategies	
+          experiment_strategies 
           is_paired_end
           platforms
           sequencing_experiments {

--- a/src/components/EntityPage/File/index.js
+++ b/src/components/EntityPage/File/index.js
@@ -341,6 +341,10 @@ const FileEntity = ({ api, fileId }) => {
                 <EntityContentDivider />
                 <EntityContentSection title="Associated Participants/Biospecimens">
                   <BaseDataTable
+                    analyticsTracking={{
+                      title: 'Associated Participants/Biospecimens',
+                      category: TRACKING_EVENTS.categories.entityPage.file,
+                    }}
                     loading={file.isLoading}
                     data={toParticpantBiospecimenData(data)}
                     columns={particpantBiospecimenColumns}
@@ -350,6 +354,10 @@ const FileEntity = ({ api, fileId }) => {
                 <EntityContentDivider />
                 <EntityContentSection title="Associated Experimental Strategies">
                   <BaseDataTable
+                    analyticsTracking={{
+                      title: 'Associated Experimental Strategies',
+                      category: TRACKING_EVENTS.categories.entityPage.file,
+                    }}
                     loading={file.isLoading}
                     data={toExperimentalStrategiesData(data)}
                     columns={experimentalStrategiesColumns}

--- a/src/components/EntityPage/File/participantBiospecimenTable.js
+++ b/src/components/EntityPage/File/participantBiospecimenTable.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import _ from 'lodash';
-import ExternalLink from 'uikit/ExternalLink';
+// import ExternalLink from 'uikit/ExternalLink';
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
+import { Link } from 'react-router-dom';
 import { pickData } from './utils';
 
 export const particpantBiospecimenColumns = [
@@ -22,15 +24,32 @@ export const toParticpantBiospecimenData = data =>
       return p.biospecimens.hits.edges.map(bio => {
         const biospecimen = bio.node;
         return {
-          participant_id: pickData(p, 'kf_id', d => (
-            <ExternalLink hasExternalIcon={false} href="">
-              {d}
-            </ExternalLink>
-          )),
+          participant_id: pickData(p, 'kf_id'),
           external_id: pickData(p, 'external_id'),
           study_name: pickData(p, 'study.short_name', d => (
-            <ExternalLink href="">{d}</ExternalLink>
-          )),
+            <Link
+              to={
+                `/search/file?sqon=` +
+                encodeURIComponent(
+                  `{"op":"and","content":[{"op":"in","content":{"field":"participants.study.short_name","value":["${pickData(
+                    p,
+                    'study.short_name',
+                  )}"]}}]}`,
+                )
+              }
+              onClick={e => {
+                trackUserInteraction({
+                  category: TRACKING_EVENTS.categories.entityPage.file,
+                  action:
+                    TRACKING_EVENTS.actions.click +
+                    `: Associated Participants/Biospecimens: Study Name`,
+                  label: pickData(p, 'study.short_name'),
+                });
+              }}
+            >
+              {d}
+            </Link>
+          ),
           proband: pickData(p, 'is_proband', val => (typeof val === 'boolean' ? 'Yes' : 'No')),
           biospecimen_id: pickData(biospecimen, 'kf_id'),
           analyte_type: pickData(biospecimen, 'analyte_type'),

--- a/src/components/EntityPage/File/participantBiospecimenTable.js
+++ b/src/components/EntityPage/File/participantBiospecimenTable.js
@@ -24,7 +24,30 @@ export const toParticpantBiospecimenData = data =>
       return p.biospecimens.hits.edges.map(bio => {
         const biospecimen = bio.node;
         return {
-          participant_id: pickData(p, 'kf_id'),
+          participant_id: (
+            <Link
+              to={
+                `/search/file?sqon=` +
+                encodeURIComponent(
+                  `{"op":"and","content":[{"op":"in","content":{"field":"participants.kf_id","value":["${pickData(
+                    p,
+                    'kf_id',
+                  )}"]}}]}`,
+                )
+              }
+              onClick={e => {
+                trackUserInteraction({
+                  category: TRACKING_EVENTS.categories.entityPage.file,
+                  action:
+                    TRACKING_EVENTS.actions.click +
+                    `: Associated Participants/Biospecimens: Participant ID`,
+                  label: pickData(p, 'kf_id'),
+                });
+              }}
+            >
+              {pickData(p, 'kf_id')}
+            </Link>
+          ),
           external_id: pickData(p, 'external_id'),
           study_name: pickData(p, 'study.short_name', d => (
             <Link

--- a/src/components/EntityPage/File/participantBiospecimenTable.js
+++ b/src/components/EntityPage/File/participantBiospecimenTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-// import ExternalLink from 'uikit/ExternalLink';
 import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 import { Link } from 'react-router-dom';
 import { pickData } from './utils';
@@ -24,55 +23,39 @@ export const toParticpantBiospecimenData = data =>
       return p.biospecimens.hits.edges.map(bio => {
         const biospecimen = bio.node;
         return {
-          participant_id: (
+          participant_id: pickData(p, 'kf_id', kfId => (
             <Link
-              to={
-                `/search/file?sqon=` +
-                encodeURIComponent(
-                  `{"op":"and","content":[{"op":"in","content":{"field":"participants.kf_id","value":["${pickData(
-                    p,
-                    'kf_id',
-                  )}"]}}]}`,
-                )
-              }
+              to={''}
               onClick={e => {
                 trackUserInteraction({
                   category: TRACKING_EVENTS.categories.entityPage.file,
                   action:
                     TRACKING_EVENTS.actions.click +
                     `: Associated Participants/Biospecimens: Participant ID`,
-                  label: pickData(p, 'kf_id'),
+                  label: kfId,
                 });
               }}
             >
-              {pickData(p, 'kf_id')}
+              {kfId}
             </Link>
-          ),
+          )),
           external_id: pickData(p, 'external_id'),
-          study_name: pickData(p, 'study.short_name', d => (
+          study_name: pickData(p, 'study.short_name', studyShortName => (
             <Link
-              to={
-                `/search/file?sqon=` +
-                encodeURIComponent(
-                  `{"op":"and","content":[{"op":"in","content":{"field":"participants.study.short_name","value":["${pickData(
-                    p,
-                    'study.short_name',
-                  )}"]}}]}`,
-                )
-              }
+              to={''}
               onClick={e => {
                 trackUserInteraction({
                   category: TRACKING_EVENTS.categories.entityPage.file,
                   action:
                     TRACKING_EVENTS.actions.click +
                     `: Associated Participants/Biospecimens: Study Name`,
-                  label: pickData(p, 'study.short_name'),
+                  label: studyShortName,
                 });
               }}
             >
-              {d}
+              {studyShortName}
             </Link>
-          ),
+          )),
           proband: pickData(p, 'is_proband', val => (typeof val === 'boolean' ? 'Yes' : 'No')),
           biospecimen_id: pickData(biospecimen, 'kf_id'),
           analyte_type: pickData(biospecimen, 'analyte_type'),

--- a/src/uikit/DataTable/BaseDataTable.js
+++ b/src/uikit/DataTable/BaseDataTable.js
@@ -5,7 +5,7 @@ import Table from './Table';
 import TableToolbar from './TableToolbar';
 import ColumnFilter from './ToolbarButtons/ColumnFilter';
 import Export from './ToolbarButtons/Export';
-
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 import { configureCols } from './utils/columns';
 
 const enhance = compose(
@@ -25,6 +25,7 @@ const BaseDataTable = ({
   setPageIndex,
   downloadName,
   header = true,
+  analyticsTracking,
 }) => (
   <Fragment>
     {header ? (
@@ -33,9 +34,21 @@ const BaseDataTable = ({
           columns={columns}
           onChange={item => {
             const index = columns.findIndex(c => c.index === item.index);
-            setColumns(
-              columns.map((col, i) => (i === index ? { ...col, ...{ show: !item.show } } : col)),
+            const cols = columns.map((col, i) =>
+              i === index ? { ...col, ...{ show: !item.show } } : col,
             );
+            const colActedUpon = cols[index];
+            if (analyticsTracking) {
+              trackUserInteraction({
+                category: analyticsTracking.category,
+                action: `Datatable: ${analyticsTracking.title}: Column Filter: ${
+                  colActedUpon.show ? 'show' : 'hide'
+                }`,
+                label: colActedUpon.Header,
+              });
+            }
+
+            setColumns(cols);
           }}
         />
 

--- a/src/uikit/DataTable/ToolbarButtons/Export.js
+++ b/src/uikit/DataTable/ToolbarButtons/Export.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ToolbarItem, ToolbarButton, FileDownloadIcon } from './styles';
 import { saveAs } from 'file-saver';
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 
 const exportTSV = (data, columns, filename) => {
   const visbleCols = columns.filter(c => c.show);
@@ -8,6 +9,11 @@ const exportTSV = (data, columns, filename) => {
   const rows = data.map(d => visbleCols.map(header => d[header.accessor]).join('\t')).join('\n');
 
   const blob = new Blob([headers + '\n' + rows], { type: 'data:text/tab-separated-values' });
+  trackUserInteraction({
+    category: TRACKING_EVENTS.categories.entityPage.file,
+    action: TRACKING_EVENTS.actions.download.report,
+    label: filename,
+  });
   saveAs(blob, `${filename}.tsv`);
 };
 


### PR DESCRIPTION
Hooked up GA events to the page. Swapped the `<ExternalLink>` components for react-router `<Link>` that have hardcoded file repo urls. These are just temp so that we can launch and track engagement while the other entity pages are being built 