### PR TITLE
fixed #1088 -  FileEntityPage header shadows being too dark

### DIFF
--- a/src/components/EntityPage/EntityActionBar.js
+++ b/src/components/EntityPage/EntityActionBar.js
@@ -16,12 +16,13 @@ const enhance = compose(
 );
 
 const ActionBar = styled(Flex)`
-  height: 56px;
+  height: 62px;
   width: 100%;
 
-  box-shadow: 0 0 4.9px 0.1px ${({ theme }) => theme.shadow};
-  border-top: solid 1px #${({ theme }) => theme.borderGrey};
+  box-shadow: 0 0 4.9px 0.1px ${({ theme }) => theme.lighterShadow};
+  border: solid 1px ${({ theme }) => theme.greyScale5};
   background-color: ${({ theme }) => theme.white};
+  z-index: -1;
 
   align-items: center;
   justify-content: flex-end;

--- a/src/components/Header/ui.js
+++ b/src/components/Header/ui.js
@@ -84,7 +84,7 @@ export const DropdownExternalLink = applyDefaultStyles(styled(ExternalLink)`
 
 export const HeaderContainer = styled('div')`
   background: ${({ theme }) => theme.white};
-  box-shadow: 0 0 4.9px 0.1px ${({ theme }) => theme.shadow};
+  box-shadow: 0 0 4.9px 0.1px ${({ theme }) => theme.lighterShadow};
   flex: none;
   z-index: 1;
 `;

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -40,6 +40,7 @@ const colors = {
 
   shadow: 'rgba(0, 0, 0, 0.5)',
   lightShadow: '#a0a0a3',
+  lighterShadow: '#bbbbbb',
 
   // error
   errorDark: '#d8202f', //red


### PR DESCRIPTION
I had to add a new color in the `defaultTheme` for those shadows since they don't match any other shadows at the `colors` level.

They are the same shadows as in `components.card`, though. I'm not sure if I should just use the value I added in `colors` inside `components.card` to avoid creating duplication.

What do you think?