### PR TITLE
Fix/1102 no token

### DIFF
--- a/src/services/fileAccessControl.js
+++ b/src/services/fileAccessControl.js
@@ -182,7 +182,13 @@ export const getUserStudyPermission = api => async ({
 };
 
 export const checkUserFilePermission = api => async ({ fileId }) => {
-  const userDetails = await getGen3User(api);
+  let userDetails;
+  try {
+    userDetails = await getGen3User(api);
+  } catch (err) {
+    return Promise.resolve(false);
+  }
+
   const approvedAcls = Object.keys(userDetails.projects);
 
   return graphql(api)({


### PR DESCRIPTION
Avoided the propagation of a rejected promise when the token request returns an error.