### PR TITLE
fixes 1094 - sets default value of 'Proband' correctly.

### DIFF
--- a/src/components/EntityPage/File/index.js
+++ b/src/components/EntityPage/File/index.js
@@ -38,7 +38,7 @@ import {
 } from './experimentalStrategies';
 
 import { toFilePropertiesSummary } from './fileProperties';
-import { toSequencingReadProperties } from './sequencingProperties';
+import { hasSequencingReadProperties, toSequencingReadProperties } from './sequencingProperties';
 
 import CavaticaAnalyse from './CavaticaAnalyse';
 import Download from './Download';
@@ -288,109 +288,111 @@ const FileEntity = compose(withTheme)(
               <LoadingSpinner color={theme.greyScale11} size={'50px'} />
             </div>
           );
-        } else {
-          const data = _.get(file, 'data.hits.edges[0].node');
-
-          const fileType = data.file_format;
-
-          return (
-            <Container>
-              <EntityTitleBar>
-                <EntityTitle
-                  icon="file"
-                  title={fileId}
-                  tags={file.isLoading ? [] : getTags(data)}
-                />
-              </EntityTitleBar>
-              <EntityActionBar>
-                <CavaticaAnalyse fileId={fileId} disabled={!hasFilePermission} />
-                <Download
-                  onSuccess={url => {
-                    trackUserInteraction({
-                      category: TRACKING_EVENTS.categories.entityPage.file,
-                      action: 'Download File',
-                      label: url,
-                    });
-                  }}
-                  onError={err => {
-                    trackUserInteraction({
-                      category: TRACKING_EVENTS.categories.entityPage.file,
-                      action: 'Download File FAILED',
-                      label: JSON.stringify(err, null, 2),
-                    });
-                  }}
-                  kfId={data.kf_id}
-                  disabled={!hasFilePermission}
-                />
-                <ShareButton link={window.location.href} />
-              </EntityActionBar>
-
-              <EntityContent>
-                <EntityContentSection title="File Properties">
-                  <Row
-                    className={css`
-                      width: '100%';
-                    `}
-                  >
-                    <SummaryTable rows={toFilePropertiesSummary(data)} rowMax={6} />
-                  </Row>
-                </EntityContentSection>
-                <EntityContentDivider />
-                <EntityContentSection title="Associated Participants/Biospecimens">
-                  <BaseDataTable
-                    analyticsTracking={{
-                      title: 'Associated Participants/Biospecimens',
-                      category: TRACKING_EVENTS.categories.entityPage.file,
-                    }}
-                    loading={file.isLoading}
-                    data={toParticpantBiospecimenData(data)}
-                    transforms={{
-                      study_name: studyShortName => (
-                        <ExternalLink
-                          href={`${kfWebRoot}/support/studies-and-access`}
-                          onClick={e => {
-                            trackUserInteraction({
-                              category: TRACKING_EVENTS.categories.entityPage.file,
-                              action:
-                                TRACKING_EVENTS.actions.click +
-                                `: Associated Participants/Biospecimens: Study Name`,
-                              label: studyShortName,
-                            });
-                          }}
-                        >
-                          {studyShortName}
-                        </ExternalLink>
-                      ),
-                    }}
-                    columns={particpantBiospecimenColumns}
-                    downloadName="participants_biospecimens"
-                  />
-                </EntityContentSection>
-                <EntityContentDivider />
-                <EntityContentSection title="Associated Experimental Strategies">
-                  <BaseDataTable
-                    analyticsTracking={{
-                      title: 'Associated Experimental Strategies',
-                      category: TRACKING_EVENTS.categories.entityPage.file,
-                    }}
-                    loading={file.isLoading}
-                    data={toExperimentalStrategiesData(data)}
-                    columns={experimentalStrategiesColumns}
-                    downloadName="experimental_strategies"
-                  />
-                </EntityContentSection>
-                {fileType === FILE_TYPE_CRAM || fileType === FILE_TYPE_BAM ? (
-                  <React.Fragment>
-                    <EntityContentDivider />
-                    <EntityContentSection title="Sequencing Read Properties">
-                      <InfoBoxRow data={toSequencingReadProperties(data)} />
-                    </EntityContentSection>
-                  </React.Fragment>
-                ) : null}
-              </EntityContent>
-            </Container>
-          );
         }
+
+        const data = _.get(file, 'data.hits.edges[0].node');
+        const fileType = data.file_format;
+
+        return (
+          <Container>
+            <EntityTitleBar>
+              <EntityTitle icon="file" title={fileId} tags={file.isLoading ? [] : getTags(data)} />
+            </EntityTitleBar>
+            <EntityActionBar>
+              <CavaticaAnalyse fileId={fileId} disabled={!hasFilePermission} />
+              <Download
+                onSuccess={url => {
+                  trackUserInteraction({
+                    category: TRACKING_EVENTS.categories.entityPage.file,
+                    action: 'Download File',
+                    label: url,
+                  });
+                }}
+                onError={err => {
+                  trackUserInteraction({
+                    category: TRACKING_EVENTS.categories.entityPage.file,
+                    action: 'Download File FAILED',
+                    label: JSON.stringify(err, null, 2),
+                  });
+                }}
+                kfId={data.kf_id}
+                disabled={!hasFilePermission}
+              />
+              <ShareButton link={window.location.href} />
+            </EntityActionBar>
+
+            <EntityContent>
+              <EntityContentSection title="File Properties">
+                <Row
+                  className={css`
+                    width: '100%';
+                  `}
+                >
+                  <SummaryTable rows={toFilePropertiesSummary(data)} rowMax={6} />
+                </Row>
+              </EntityContentSection>
+              <EntityContentDivider />
+              <EntityContentSection title="Associated Participants/Biospecimens">
+                <BaseDataTable
+                  analyticsTracking={{
+                    title: 'Associated Participants/Biospecimens',
+                    category: TRACKING_EVENTS.categories.entityPage.file,
+                  }}
+                  loading={file.isLoading}
+                  data={toParticpantBiospecimenData(data)}
+                  transforms={{
+                    study_name: studyShortName => (
+                      <ExternalLink
+                        href={`${kfWebRoot}/support/studies-and-access`}
+                        onClick={e => {
+                          trackUserInteraction({
+                            category: TRACKING_EVENTS.categories.entityPage.file,
+                            action:
+                              TRACKING_EVENTS.actions.click +
+                              `: Associated Participants/Biospecimens: Study Name`,
+                            label: studyShortName,
+                          });
+                        }}
+                      >
+                        {studyShortName}
+                      </ExternalLink>
+                    ),
+                  }}
+                  columns={particpantBiospecimenColumns}
+                  downloadName="participants_biospecimens"
+                />
+              </EntityContentSection>
+
+              {hasSequencingReadProperties(data) ? (
+                <React.Fragment>
+                  <EntityContentDivider />
+                  <EntityContentSection title="Associated Experimental Strategies">
+                    <BaseDataTable
+                      analyticsTracking={{
+                        title: 'Associated Experimental Strategies',
+                        category: TRACKING_EVENTS.categories.entityPage.file,
+                      }}
+                      loading={file.isLoading}
+                      data={toExperimentalStrategiesData(data)}
+                      columns={experimentalStrategiesColumns}
+                      downloadName="experimental_strategies"
+                    />
+                  </EntityContentSection>
+                </React.Fragment>
+              ) : null}
+
+              {(fileType === FILE_TYPE_CRAM || fileType === FILE_TYPE_BAM) &&
+              hasSequencingReadProperties(data) ? (
+                <React.Fragment>
+                  <EntityContentDivider />
+                  <EntityContentSection title="Sequencing Read Properties">
+                    <InfoBoxRow data={toSequencingReadProperties(data)} />
+                  </EntityContentSection>
+                </React.Fragment>
+              ) : null}
+            </EntityContent>
+          </Container>
+        );
       }}
     </ArrangerDataProvider>
   ),

--- a/src/components/EntityPage/File/participantBiospecimenTable.js
+++ b/src/components/EntityPage/File/participantBiospecimenTable.js
@@ -23,7 +23,7 @@ export const toParticpantBiospecimenData = data =>
           participant_id: pickData(p, 'kf_id'),
           external_id: pickData(p, 'external_id'),
           study_name: pickData(p, 'study.short_name'),
-          proband: pickData(p, 'is_proband', val => (typeof val === 'boolean' ? 'Yes' : 'No')),
+          proband: pickData(p, 'is_proband', val => (Boolean(val) ? 'Yes' : 'No')),
           biospecimen_id: pickData(biospecimen, 'kf_id'),
           analyte_type: pickData(biospecimen, 'analyte_type'),
           tissue_type: pickData(biospecimen, 'source_text_tissue_type'),

--- a/src/components/EntityPage/File/sequencingProperties.js
+++ b/src/components/EntityPage/File/sequencingProperties.js
@@ -1,5 +1,13 @@
+import _ from 'lodash';
+
+export const hasSequencingReadProperties = data => {
+  return _.get(data, 'sequencing_experiments.hits.edges[0].node', null) !== null;
+};
+
 export const toSequencingReadProperties = data => {
-  const experiments = data.sequencing_experiments.hits.edges[0].node;
+  const experiments = _.get(data, 'sequencing_experiments.hits.edges[0].node');
+
+  if (!experiments) return [];
 
   const {
     max_insert_size: maxInsertSize,

--- a/src/components/EntityPage/File/utils.js
+++ b/src/components/EntityPage/File/utils.js
@@ -3,7 +3,7 @@ import { differenceInYears, differenceInDays, addYears } from 'date-fns';
 
 export const pickData = (data, valuePath, transform = x => x) => {
   const selectedData = _.get(data, valuePath, null);
-  return selectedData ? transform(selectedData) : '--';
+  return selectedData === null ? '--' : transform(selectedData);
 };
 
 export const formatDate = date => {

--- a/src/components/EntityPage/File/utils.js
+++ b/src/components/EntityPage/File/utils.js
@@ -1,9 +1,12 @@
 import _ from 'lodash';
 import { differenceInYears, differenceInDays, addYears } from 'date-fns';
 
-export const pickData = (data, valuePath, transform = x => x) => {
+export const pickData = (data, valuePath, transform) => {
   const selectedData = _.get(data, valuePath, null);
-  return selectedData === null ? '--' : transform(selectedData);
+  if (transform) {
+    return transform(selectedData);
+  }
+  return selectedData === null ? '--' : selectedData;
 };
 
 export const formatDate = date => {


### PR DESCRIPTION
…Also, better check for  null value.

`pickData` does not invoke the transform when the field is absent or null (`_.get` returns null).

```
export const pickData = (data, valuePath, transform = x => x) => {
  const selectedData = _.get(data, valuePath, null);
  return selectedData === null ? '--' : transform(selectedData);
};
```

Would you prefer to invoke the transforms even with null values?

```
export const pickData = (data, valuePath, transform = x => x) => {
  const selectedData = _.get(data, valuePath, null);
  return transform(selectedData);
};
```

Pro: each field can transform a null value.
Con: more risk of inserting a regression, maybe some minor refactor on some usage of `pickData`.

Another option is to return `--` by default if no `transform` is provided:

```
export const pickData = (data, valuePath, transform) => {
  const selectedData = _.get(data, valuePath, null);
  if (transform) {
    return transform(selectedData);
  }
  return selectedData === null ? '--' : selectedData;
};
```