### PR TITLE
fixes #1107 - column selection was beneath the footer

### DIFF
--- a/src/uikit/DataTable/ToolbarButtons/styles.js
+++ b/src/uikit/DataTable/ToolbarButtons/styles.js
@@ -47,7 +47,7 @@ export const DropdownContent = styled('div')`
   position: absolute;
   background: white;
   min-width: 100%;
-  z-index: 1;
+  z-index: 200;
   border: 1px solid rgba(0, 0, 0, 0.05);
   box-sizing: border-box;
   cursor: pointer;


### PR DESCRIPTION
I used `z-index: 200` since it is used elsewhere.
Modals use `1000` and most deeper layer components are <= 100.