### PR TITLE
🐛 fixes the tooltip rendering error

### DIFF
--- a/src/chartkit/components/Pie.js
+++ b/src/chartkit/components/Pie.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import tinygradient from 'tinygradient';
 import { ResponsivePie } from '@nivo/pie';
+import Tooltip from './Tooltip';
 
 const PieWrapper = styled('div')`
   height: 100%;
@@ -18,7 +19,7 @@ const PieTitle = styled('div')`
   margin-bottom: 5px;
 `;
 
-const StyleTooltip = styled('Tooltip')`
+const StyleTooltip = styled(Tooltip)`
   text-align: left;
   justify: left;
   font-size: 12px;

--- a/src/chartkit/components/Tooltip.js
+++ b/src/chartkit/components/Tooltip.js
@@ -7,8 +7,19 @@ const TooltipContianer = styled('div')`
   font-size: 12px;
 `;
 
-const Tooltip = ({ id, value, index, color, data, children = null, formatter = v => v }) => (
-  <TooltipContianer keys={index}>{children ? children : formatter(data)}</TooltipContianer>
+const Tooltip = ({
+  className,
+  id,
+  value,
+  index,
+  color,
+  data,
+  children = null,
+  formatter = v => v,
+}) => (
+  <TooltipContianer className={className} keys={index}>
+    {children ? children : formatter(data)}
+  </TooltipContianer>
 );
 
 export default Tooltip;


### PR DESCRIPTION
React cannot find the component properly based on string name, it needs a component reference. `className` needs to be passed down to the dom node so the style applies. Was causing this originally when hovering on the pie charts:
![screen shot 2019-02-15 at 7 27 38 am](https://user-images.githubusercontent.com/11821106/52856822-720ab000-30f3-11e9-91db-0a31d89b17a6.png)

