### PR TITLE
🐛uses family_id instead of family.family_id

### DIFF
--- a/src/components/CohortBuilder/ParticipantsTableView/queries.js
+++ b/src/components/CohortBuilder/ParticipantsTableView/queries.js
@@ -28,8 +28,8 @@ export const participantsQuery = sqon => ({
               }
             }
             gender
+            family_id
             family {
-              family_id
               family_compositions {
                 hits {
                   edges {
@@ -78,7 +78,7 @@ export const participantsQuery = sqon => ({
         diagnosis,
         ageAtDiagnosis,
         gender: get(node, 'gender'),
-        familyId: get(node, 'family.family_id'),
+        familyId: get(node, 'family_id'),
         familyCompositions,
         filesCount: get(node, 'files.hits.total'),
       };


### PR DESCRIPTION
Some of the indices under `participant_centric` in Elasticsearch do not have the `family.family_id` field in their mappings, resulting in inconsistent GraphQL API generated by arranger. 

While this is a symptom of a deeper back-end issue, this UI fix ensures the table will always load as the `family_id` at the root level of participant is confirmed to be the reliable field.

@rosibaj FYI :)