### PR TITLE
♻️ removes the spread props in QueriesResolver

### DIFF
--- a/src/components/CohortBuilder/QueriesResolver.js
+++ b/src/components/CohortBuilder/QueriesResolver.js
@@ -55,7 +55,7 @@ class QueriesResolver extends Component {
   memoFetchData = memoize(this.fetchData);
 
   render() {
-    return this.props.children({ ...this.state, ...this.props });
+    return this.props.children({ ...this.state });
   }
 }
 


### PR DESCRIPTION
I don't think this is necessary, but please correct me if I'm wrong :)

Removing it now so we don't accidentally rely on it