### PR TITLE
changed page layout component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -100,7 +100,6 @@ const App = compose(
             forceSelectRole({
               isLoadingUser,
               Component: CohortBuilder,
-              WrapperPage: FixedFooterPage,
               loggedInUser,
               index: props.match.params.index,
               graphqlField: props.match.params.index,

--- a/src/components/CohortBuilder/index.js
+++ b/src/components/CohortBuilder/index.js
@@ -10,14 +10,8 @@ import SQONProvider from './SQONProvider';
 import { withRouter } from 'react-router-dom';
 
 const Container = styled('div')`
-  flex: 1;
-  flex-direction: column;
-  display: flex;
-  height: 100%;
   width: 100%;
-  align-items: center;
-  background-color: #f4f5f8;
-  min-height: 960px;
+  background-color: ${({ theme }) => theme.backgroundGrey};
 `;
 
 const Heading = styled(H1)`


### PR DESCRIPTION
Works same as `UserDashboard`
Footer at bottom pushed down by content.
Will be further improved once we have the Cards displaying without a page loader. (like the UserDashboard where Cards load without a page loader)