### PR TITLE
QueriesResolver race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,6 +3209,11 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
+    "CBuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/CBuffer/-/CBuffer-0.1.5.tgz",
+      "integrity": "sha1-3yk7wEVCHg1N60dW1+kI9dJ2jrQ="
+    },
     "JSONSelect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
@@ -3656,7 +3661,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -4985,6 +4990,14 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
+    "binaryheap-resizable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/binaryheap-resizable/-/binaryheap-resizable-1.0.0.tgz",
+      "integrity": "sha1-6XHlzwAXtN+QKeLwTsGtoDFHO5E=",
+      "requires": {
+        "peek": "~0.0.2"
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -5384,6 +5397,14 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbuffer-resizable": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/cbuffer-resizable/-/cbuffer-resizable-0.0.3.tgz",
+      "integrity": "sha1-9nbngURO0FDUXVP7F1mb8MoZCLg=",
+      "requires": {
+        "CBuffer": "~0.1.5"
+      }
     },
     "center-align": {
       "version": "0.1.3",
@@ -6362,7 +6383,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         }
       }
@@ -7214,7 +7235,7 @@
     },
     "elasticsearch": {
       "version": "14.2.2",
-      "resolved": "http://registry.npmjs.org/elasticsearch/-/elasticsearch-14.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-14.2.2.tgz",
       "integrity": "sha1-a7tjsZsX+pchGyLurLD5EZf01rY=",
       "requires": {
         "agentkeepalive": "^3.4.1",
@@ -7227,7 +7248,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -9676,7 +9697,7 @@
     },
     "graphql-config": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
       "integrity": "sha512-eb4FzlODifHE/Q+91QptAmkGw39wL5ToinJ2556UUsGt2drPc4tzifL+HSnHSaxiIbH8EUhc/Fa6+neinF04qA==",
       "requires": {
         "graphql-import": "^0.4.4",
@@ -9693,7 +9714,7 @@
     },
     "graphql-import": {
       "version": "0.4.5",
-      "resolved": "http://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
       "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
       "requires": {
         "lodash": "^4.17.4"
@@ -11939,7 +11960,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
@@ -13173,6 +13194,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "peek": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/peek/-/peek-0.0.2.tgz",
+      "integrity": "sha1-WLVmZE+M2+L7NqqmscOEEXYDpUA="
     },
     "performance-now": {
       "version": "0.2.0",
@@ -15441,7 +15467,7 @@
     },
     "react-toastify": {
       "version": "3.4.3",
-      "resolved": "http://registry.npmjs.org/react-toastify/-/react-toastify-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-3.4.3.tgz",
       "integrity": "sha512-9teTL5In66vsv7O1LnbMQVKmT3CUcTL95sdy8GW5XX5J5uRFY3xSXRqRIcJtD4HSCrjTU2e72pwOiy73VgvJ1Q==",
       "requires": {
         "glamor": "^2.20.40",
@@ -17474,6 +17500,15 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+    },
+    "task-queue": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/task-queue/-/task-queue-1.0.2.tgz",
+      "integrity": "sha1-RvPLXg6ccU+taLQZKkNEekdcZsI=",
+      "requires": {
+        "binaryheap-resizable": "~1.0.0",
+        "cbuffer-resizable": "~0.0.3"
+      }
     },
     "term-size": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "recompose": "^0.26.0",
     "scriptjs": "^2.5.8",
     "styled-system": "^2.2.5",
+    "task-queue": "1.0.2",
     "tinygradient": "^0.4.2",
     "url-join": "^2.0.2",
     "victory-pie": "^14.0.1",


### PR DESCRIPTION
2 things here:
1) implement caching with a global cache store so it persists throughout application lifecycle (a highly simplified solution)
2) QueriesResolver updates were allowed to happen in parallel so there was room for race conditions. Fixed this with a task queue.