### PR TITLE
add option to not replace text with loader, display to side instead

### DIFF
--- a/src/components/CohortBuilder/Results.js
+++ b/src/components/CohortBuilder/Results.js
@@ -207,6 +207,7 @@ const Results = ({
                     {Number(participantCount || 0).toLocaleString()} Participants with{' '}
                   </SubHeading>
                   <PurpleLinkWithLoader
+                    replaceText={false}
                     getLink={() => generateAllFilesLink(state.loggedInUser, api, data[0].files)}
                   >
                     {`${Number(data[0].filesCount || 0).toLocaleString()} Files`}

--- a/src/uikit/LinkWithLoader.js
+++ b/src/uikit/LinkWithLoader.js
@@ -8,21 +8,28 @@ import { Link } from './Core';
  * Purpose is to create a link and navigate to it when you need it async
  * eg. dynamically generating a link that takes time because of requesting data
  */
-const LinkWithLoader = ({ getLink, children, history, className }) => (
+const LinkWithLoader = ({ getLink, children, history, className, replaceText = true }) => (
   <Component initialState={{ isLoading: false }}>
     {({ state, setState }) => (
-      <Link
-        className={className}
-        to=""
-        onClick={async e => {
-          e.preventDefault();
-          setState({ isLoading: true });
-          const url = await getLink();
-          history.push(url);
-        }}
-      >
-        {state.isLoading ? <LoadingSpinner size="11px" center={false} /> : children}
-      </Link>
+      <React.Fragment>
+        <Link
+          className={className}
+          to=""
+          onClick={async e => {
+            e.preventDefault();
+            setState({ isLoading: true });
+            const url = await getLink();
+            history.push(url);
+          }}
+        >
+          {state.isLoading && replaceText ? (
+            <LoadingSpinner size="11px" center={false} />
+          ) : (
+            children
+          )}
+        </Link>
+        {state.isLoading && !replaceText ? <LoadingSpinner size="11px" center={false} /> : null}
+      </React.Fragment>
     )}
   </Component>
 );


### PR DESCRIPTION
Adds option to display loader to side of link
Looks better in Results header instead of `6,432 Participants with <Loader>`,
now it is `6,432 Participants with 2,232 Files <Loader>`