### PR TITLE
🐛 filters out riff entries that are not saved queries

### DIFF
--- a/src/components/UserDashboard/SavedQueries/index.js
+++ b/src/components/UserDashboard/SavedQueries/index.js
@@ -28,6 +28,12 @@ const FileRepositoryLink = styled(Link)`
   color: ${({ theme }) => theme.primary};
 `;
 
+/**
+ * This is a stop-gap solution until Riff supports tags to support
+ * server-side differentiation between entity types
+ */
+const isSavedQuery = q => !!q.content.Files;
+
 export const MySavedQueries = compose(
   provideSavedQueries,
   injectState,
@@ -44,7 +50,8 @@ export const MySavedQueries = compose(
     api,
     theme,
   }) => {
-    const Header = <CardHeader title="Saved Queries" badge={queries.length} />;
+    const savedQueries = queries.filter(isSavedQuery);
+    const Header = <CardHeader title="Saved Queries" badge={savedQueries.length} />;
     return (
       <DashboardCard Header={Header} scrollable>
         {loadingQueries ? (
@@ -61,22 +68,19 @@ export const MySavedQueries = compose(
                   </PromptMessageContent>
                 </PromptMessageContainer>
                 <Box mt={2} mb={2}>
-                  {exampleQueries.map(q => {
-                    q.link = `/search${q.content.longUrl.split('/search')[1]}`;
-                    return (
-                      <QueryBlock
-                        key={q.id}
-                        query={q}
-                        inactive={deletingIds.includes(q.id)}
-                        savedTime={false}
-                      />
-                    );
-                  })}
+                  {exampleQueries.filter(isSavedQuery).map(q => (
+                    <QueryBlock
+                      key={q.id}
+                      query={q}
+                      inactive={deletingIds.includes(q.id)}
+                      savedTime={false}
+                    />
+                  ))}
                 </Box>
               </Box>
             ) : (
               <Box mt={2} mb={2}>
-                {queries
+                {savedQueries
                   .filter(q => q.alias)
                   .map(q => ({
                     ...q,

--- a/src/components/UserDashboard/SavedQueries/index.js
+++ b/src/components/UserDashboard/SavedQueries/index.js
@@ -28,12 +28,6 @@ const FileRepositoryLink = styled(Link)`
   color: ${({ theme }) => theme.primary};
 `;
 
-/**
- * This is a stop-gap solution until Riff supports tags to support
- * server-side differentiation between entity types
- */
-const isSavedQuery = q => !!q.content.Files;
-
 export const MySavedQueries = compose(
   provideSavedQueries,
   injectState,
@@ -50,8 +44,7 @@ export const MySavedQueries = compose(
     api,
     theme,
   }) => {
-    const savedQueries = queries.filter(isSavedQuery);
-    const Header = <CardHeader title="Saved Queries" badge={savedQueries.length} />;
+    const Header = <CardHeader title="Saved Queries" badge={queries.length} />;
     return (
       <DashboardCard Header={Header} scrollable>
         {loadingQueries ? (
@@ -68,19 +61,22 @@ export const MySavedQueries = compose(
                   </PromptMessageContent>
                 </PromptMessageContainer>
                 <Box mt={2} mb={2}>
-                  {exampleQueries.filter(isSavedQuery).map(q => (
-                    <QueryBlock
-                      key={q.id}
-                      query={q}
-                      inactive={deletingIds.includes(q.id)}
-                      savedTime={false}
-                    />
-                  ))}
+                  {exampleQueries.map(q => {
+                    q.link = `/search${q.content.longUrl.split('/search')[1]}`;
+                    return (
+                      <QueryBlock
+                        key={q.id}
+                        query={q}
+                        inactive={deletingIds.includes(q.id)}
+                        savedTime={false}
+                      />
+                    );
+                  })}
                 </Box>
               </Box>
             ) : (
               <Box mt={2} mb={2}>
-                {savedQueries
+                {queries
                   .filter(q => q.alias)
                   .map(q => ({
                     ...q,

--- a/src/stateProviders/provideSavedQueries.js
+++ b/src/stateProviders/provideSavedQueries.js
@@ -27,7 +27,13 @@ export default provideState({
         )
         .then(value => state => {
           effects.setLoading(false);
-          const queries = (value || []).filter(q => !q.content.example);
+          const queries = (value || [])
+            .filter(q => !q.content.example)
+            /**
+             * The following filter is a stop-gap solution until Riff supports
+             * tags for server-side differentiation between entity types
+             */
+            .filter(q => !!q.content.Files);
           const exampleQueries = (value || []).filter(q => q.content.example);
           return { ...state, queries, exampleQueries };
         });


### PR DESCRIPTION
stop gap solution to allow dashboard SavedQueries card to identify saved queries from riff data.