### PR TITLE
account for not having event object and flip styles

### DIFF
--- a/src/chartkit/components/HorizontalBar.js
+++ b/src/chartkit/components/HorizontalBar.js
@@ -39,9 +39,7 @@ class HorizontalBar extends Component {
 
   onMouseEnter(data, e) {
     const { showCursor = true } = this.props;
-    if (showCursor) {
-      e.target.style.cursor = 'pointer';
-    }
+    e.target.style.cursor = showCursor ? 'pointer' : 'default';
 
     if (data) {
       const { index, indexValue } = data;
@@ -57,7 +55,10 @@ class HorizontalBar extends Component {
   }
 
   onMouseLeave(data, e) {
-    //   e.target.style.cursor = 'default';
+    const target = e ? e.target : false;
+    if (target) {
+      target.style.cursor = 'default';
+    }
     this.setState({ highlightedIndex: null, highlightedIndexValue: null });
   }
 

--- a/src/chartkit/components/VerticalBar.js
+++ b/src/chartkit/components/VerticalBar.js
@@ -38,7 +38,7 @@ class VerticalBar extends Component {
 
   onMouseEnter(data, e) {
     const { showCursor = true } = this.props;
-    e.target.style.cursor = showCursor ? 'hand' : 'pointer';
+    e.target.style.cursor = showCursor ? 'pointer' : 'default';
 
     if (data) {
       const { index, indexValue } = data;
@@ -54,8 +54,11 @@ class VerticalBar extends Component {
   }
 
   onMouseLeave(data, e) {
+    const target = e ? e.target : false;
+    if (target) {
+      target.style.cursor = 'default';
+    }
     this.setState({ highlightedIndex: null, highlightedIndexValue: null });
-    e.target.style.cursor = 'pointer';
   }
 
   onClick(data) {


### PR DESCRIPTION
There are cases where `onMouseLeave` is fired and there isn't an event object to style cursor off.
eg. moving from one chart to the next.

Adds check that we have event object

Flips styles to be correct