### PR TITLE
add Resize provider to re-render on resize

### DIFF
--- a/src/components/CohortBuilder/Summary/SurvivalChart.js
+++ b/src/components/CohortBuilder/Summary/SurvivalChart.js
@@ -9,6 +9,7 @@ import { withApi } from 'services/api';
 import { fetchSurvivalData } from 'services/arranger';
 import md5 from 'md5';
 import CardContent from 'uikit/Card/CardContent';
+import { SizeProvider } from 'components/Utils';
 
 const SurvivalChartWrapper = styled('div')`
   margin-top: 10px;
@@ -183,8 +184,6 @@ const StyledSurvivalPlot = styled(SurvivalPlot)`
   }
 `;
 
-//     transform: translatey(7px);
-
 class SurvivalChart extends React.Component {
   constructor(props) {
     super(props);
@@ -287,31 +286,38 @@ class SurvivalChart extends React.Component {
     };
 
     return (
-      <CohortCard
-        Content={SurvivalCardContent}
-        title="Overall Survival"
-        loading={this.state.isLoading}
-      >
-        <SurvivalChartWrapper>
-          <SurvivalChartHeader>
-            Applicable survival data for <a>{get(data, '[0].donors.length', 0)} Participants</a>
-          </SurvivalChartHeader>
-          <StyledSurvivalPlot
-            dataSets={data}
-            onMouseLeaveDonors={this.handleMouseLeaveDonors}
-            onMouseEnterDonors={this.handleMouseEnterDonors}
-          />
-          <div style={tooltipStyle}>
-            <strong>{donor.id}</strong>
-            <div>Survival Rate: {(donor.survivalEstimate * 100).toFixed(2)}%</div>
-            {donor.isCensored ? (
-              <div>Censored Survival Time: {donor.time} days (censored)</div>
-            ) : (
-              <div>Survival Time: {donor.time} days </div>
-            )}
-          </div>
-        </SurvivalChartWrapper>
-      </CohortCard>
+      <SizeProvider>
+        {({ size }) => (
+          <CohortCard
+            Content={SurvivalCardContent}
+            title="Overall Survival"
+            loading={this.state.isLoading}
+          >
+            <SurvivalChartWrapper>
+              <SurvivalChartHeader>
+                Applicable survival data for <a>{get(data, '[0].donors.length', 0)} Participants</a>
+              </SurvivalChartHeader>
+
+              <StyledSurvivalPlot
+                size={size}
+                dataSets={data}
+                onMouseLeaveDonors={this.handleMouseLeaveDonors}
+                onMouseEnterDonors={this.handleMouseEnterDonors}
+              />
+
+              <div style={tooltipStyle}>
+                <strong>{donor.id}</strong>
+                <div>Survival Rate: {(donor.survivalEstimate * 100).toFixed(2)}%</div>
+                {donor.isCensored ? (
+                  <div>Censored Survival Time: {donor.time} days (censored)</div>
+                ) : (
+                  <div>Survival Time: {donor.time} days </div>
+                )}
+              </div>
+            </SurvivalChartWrapper>
+          </CohortCard>
+        )}
+      </SizeProvider>
     );
   }
 }


### PR DESCRIPTION
Keeps overflow visible so that tooltip is visible if it flows over the graph to the top part of the card
Add resize provider to render (snap into place when window is resized)