### PR TITLE
📈 Cohort Builder Combined Queries tracking

### DIFF
--- a/src/components/CohortBuilder/SqonBuilder/index.js
+++ b/src/components/CohortBuilder/SqonBuilder/index.js
@@ -14,7 +14,14 @@ import {
   ModalContentSection,
   ARRANGER_API_PARTICIPANT_INDEX_NAME,
 } from '../common';
+import {SQONdiff} from '../../Utils'
 import { ModalFooter } from 'components/Modal';
+import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
+
+
+const trackSQONaction = ({category, action, label}) => {
+  trackUserInteraction({category, action, label: JSON.stringify(label)})
+}
 
 const extendedMappingToDisplayNameMap = memoize(extendedMapping =>
   extendedMapping.reduce((acc, { field, displayName }) => {
@@ -61,9 +68,21 @@ const SqonBuilder = compose(
   withApi,
   injectState,
 )(({ api, onChange, state, effects, ...rest }) => {
+  
   const handleAction = async action => {
 
-
+    // track the existing and operated on sqon actions
+    trackSQONaction({
+      category: TRACKING_EVENTS.categories.cohortBuilder.sqonBuilder,
+      action: `${action.eventKey} - ${Object.keys(action.eventDetails)[0]}`, 
+      label: {
+        [action.eventKey.toLowerCase()]: SQONdiff(rest.syntheticSqons, action.newSyntheticSqons), 
+        sqon_result: {
+          sqon: action.newSyntheticSqons, 
+          eventDetails: action.eventDetails 
+        } 
+      }})
+    
     if (action.eventKey === 'CLEAR_ALL') {
       delete rest['activeSqonIndex'];
       effects.setModal({

--- a/src/components/Utils/index.js
+++ b/src/components/Utils/index.js
@@ -1,7 +1,26 @@
 import React from 'react';
 import { SizeMe } from 'react-sizeme';
+import { isObject, transform, isEqual } from 'lodash';
 
 export const SizeProvider = props => <SizeMe refreshRate={100} {...props} />;
 export const withSize = Wrapped => props => (
   <SizeProvider>{({ size }) => <Wrapped size={size} {...props} />}</SizeProvider>
 );
+
+
+/**
+ * Deep diff between two object, using lodash
+ * @param  {Object} object Object compared
+ * @param  {Object} base   Object to compare with
+ * @return {Object}        Return a new object who represent the diff
+ */
+export const SQONdiff = (object, base) => {
+  function changes(object, base) {
+    return transform(object, function(result, value, key) {
+      if (!isEqual(value, base[key])) {
+        result[key] = (isObject(value) && isObject(base[key])) ? changes(value, base[key]) : value;
+      }
+    });
+  }
+  return changes(object, base);
+}

--- a/src/services/analyticsTracking/trackingEventConstants.js
+++ b/src/services/analyticsTracking/trackingEventConstants.js
@@ -34,6 +34,9 @@ export const TRACKING_EVENTS = {
       dataTable: 'File Repo: Data Table',
       actionsSidebar: 'File Repo: Actions Sidebar',
     },
+    cohortBuilder:{
+      'sqonBuilder':"Cohort Builder: SQON Builder"
+    },
     integration: {
       cavatica: 'Integration: Cavatica',
     },


### PR DESCRIPTION
This tracks all the multi-sqon changes (duplicate, remove, updated) that can be done to Combined Queries in the Cohort Builder. This tracking event overload the label property to track specific sqon and event details and could potentially cause the event not to be tracked for large complex queries