### PR TITLE
Bug/#1473 menu dropdown

### DIFF
--- a/src/components/CohortBuilder/Categories/Category.js
+++ b/src/components/CohortBuilder/Categories/Category.js
@@ -131,9 +131,11 @@ const noop = () => {};
 
 const Category = compose(
   withDropdownState,
-  withProps(({ fields, currentSearchField = '' }) => {
+  withProps(({ fields, currentSearchField = '', category, currentCategory }) => {
     const index = fields.indexOf(currentSearchField);
-    return index > -1 ? { showExpanded: true, activeIndex: index } : {};
+    return index > -1 && category === currentCategory
+      ? { showExpanded: true, activeIndex: index }
+      : {};
   }),
 )(
   ({
@@ -147,31 +149,32 @@ const Category = compose(
     setExpanded = noop,
     showExpanded,
     fields,
-    setSearchField,
+    setActiveCategory,
     sqon = {
       op: 'and',
       content: [],
     },
     onSqonUpdate = noop,
     onClose = noop,
+    category = '',
   }) => {
     const isFieldInSqon = fieldId =>
       sqon.content.some(({ content: { field } }) => field === fieldId);
 
-    const isOpen = isDropdownVisible || activeIndex;
+    const isOpen = isDropdownVisible || !!activeIndex;
 
     return (
       <Dropdown
         {...{
           multiLevel: true,
           onOuterClick: () => {
-            setSearchField('');
+            setActiveCategory({ category, fieldName: '' });
             setDropdownVisibility(false);
             onClose();
           },
           isOpen,
           onToggle: toggleDropdown,
-          setActiveIndex: index => setSearchField(fields[index]),
+          setActiveIndex: index => setActiveCategory({ fieldName: fields[index], category }),
           activeIndex,
           setExpanded,
           showExpanded,

--- a/src/components/CohortBuilder/Categories/Category.js
+++ b/src/components/CohortBuilder/Categories/Category.js
@@ -6,7 +6,7 @@ import { withApi } from 'services/api';
 import Column from 'uikit/Column';
 import Dropdown from 'uikit/Dropdown';
 import { compose, lifecycle, withState, withProps } from 'recompose';
-import { withDropdownMultiPane } from 'uikit/Dropdown';
+import { withDropdownState } from 'uikit/Dropdown';
 import Filter from './Filter';
 import CategoryRowDisplay from './CategoryRowDisplay';
 import { arrangerProjectId } from 'common/injectGlobals';
@@ -101,8 +101,8 @@ const CategoryButton = styled(Column)`
     background-color: ${({ theme }) => theme.backgroundGrey};
   }
 
-  ${({ isDropdownVisible, theme }) =>
-    isDropdownVisible
+  ${({ isOpen, theme }) =>
+    isOpen
       ? css`
           background-color: ${theme.backgroundGrey};
           box-shadow: 0 0 5.9px 0.1px ${theme.lighterShadow};
@@ -130,16 +130,10 @@ const CategoryRow = compose(withApi)(({ api, field, active }) => (
 const noop = () => {};
 
 const Category = compose(
-  withDropdownMultiPane,
+  withDropdownState,
   withProps(({ fields, currentSearchField = '' }) => {
     const index = fields.indexOf(currentSearchField);
-    return index > -1
-      ? {
-          showExpanded: true,
-          activeIndex: index,
-          isDropdownVisible: true,
-        }
-      : {};
+    return index > -1 ? { showExpanded: true, activeIndex: index } : {};
   }),
 )(
   ({
@@ -149,13 +143,11 @@ const Category = compose(
     toggleDropdown,
     isDropdownVisible,
     setDropdownVisibility,
-    toggleExpanded,
-    toggleExpandedDropdown,
-    setActiveIndex,
     activeIndex,
-    setExpanded,
+    setExpanded = noop,
     showExpanded,
     fields,
+    setSearchField,
     sqon = {
       op: 'and',
       content: [],
@@ -165,18 +157,21 @@ const Category = compose(
   }) => {
     const isFieldInSqon = fieldId =>
       sqon.content.some(({ content: { field } }) => field === fieldId);
+
+    const isOpen = isDropdownVisible || activeIndex;
+
     return (
       <Dropdown
         {...{
           multiLevel: true,
           onOuterClick: () => {
-            setExpanded(false);
+            setSearchField('');
             setDropdownVisibility(false);
             onClose();
           },
-          isOpen: isDropdownVisible,
+          isOpen,
           onToggle: toggleDropdown,
-          setActiveIndex,
+          setActiveIndex: index => setSearchField(fields[index]),
           activeIndex,
           setExpanded,
           showExpanded,
@@ -189,16 +184,14 @@ const Category = compose(
               initialSqon={sqon}
               onSubmit={sqon => {
                 onSqonUpdate(sqon);
-                toggleExpanded();
                 setDropdownVisibility(false);
                 onClose();
               }}
               onBack={() => {
-                toggleExpanded();
                 onClose();
               }}
               onCancel={() => {
-                toggleExpandedDropdown();
+                setDropdownVisibility(false);
                 onClose();
               }}
               field={field}
@@ -215,7 +208,7 @@ const Category = compose(
           OptionsContainerComponent: OptionsWrapper,
         }}
       >
-        <CategoryButton isDropdownVisible={isDropdownVisible}>
+        <CategoryButton isOpen={isOpen}>
           <Column alignItems="center">
             {' '}
             {children}

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -186,7 +186,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.quickSearch}
           currentSearchField={currentSearchField}
           color={theme.filterPurple}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.quickSearch}
           currentCategory={currentCategory}
@@ -201,7 +200,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.study}
           currentSearchField={currentSearchField}
           color={theme.studyRed}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.study}
           currentCategory={currentCategory}
@@ -216,7 +214,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.demographic}
           currentSearchField={currentSearchField}
           color={theme.demographicPurple}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.demographic}
           currentCategory={currentCategory}
@@ -231,7 +228,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.clinical}
           currentSearchField={currentSearchField}
           color={theme.clinicalBlue}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.clinical}
           currentCategory={currentCategory}
@@ -246,7 +242,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.biospecimen}
           currentSearchField={currentSearchField}
           color={theme.biospecimenOrange}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.biospecimen}
           currentCategory={currentCategory}
@@ -261,7 +256,6 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.availableData}
           currentSearchField={currentSearchField}
           color={theme.dataBlue}
-          setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.availableData}
           currentCategory={currentCategory}

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -105,7 +105,6 @@ const CATEGORY_FIELDS = {
     'biospecimens.source_text_tissue_type',
     'biospecimens.ncit_id_tissue_type',
     'biospecimens.source_text_tumor_descriptor',
-
   ],
   availableData: [
     'available_data_types',
@@ -156,6 +155,7 @@ class Categories extends React.Component {
           onSqonUpdate={this.handleSqonUpdate}
           fields={CATEGORY_FIELDS.quickSearch}
           color={theme.filterPurple}
+          setSearchField={this.handleSearchField}
         >
           <QuickFilterIcon fill={theme.filterPurple} />
         </Category>
@@ -167,6 +167,7 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.study}
           currentSearchField={currentSearchField}
           color={theme.studyRed}
+          setSearchField={this.handleSearchField}
         >
           <StudyIcon fill={theme.studyRed} />
         </Category>
@@ -178,6 +179,7 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.demographic}
           currentSearchField={currentSearchField}
           color={theme.demographicPurple}
+          setSearchField={this.handleSearchField}
         >
           <DemographicIcon fill={theme.demographicPurple} />
         </Category>
@@ -189,6 +191,7 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.clinical}
           currentSearchField={currentSearchField}
           color={theme.clinicalBlue}
+          setSearchField={this.handleSearchField}
         >
           <ClinicalIcon width={18} height={17} fill={theme.clinicalBlue} />
         </Category>
@@ -200,6 +203,7 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.biospecimen}
           currentSearchField={currentSearchField}
           color={theme.biospecimenOrange}
+          setSearchField={this.handleSearchField}
         >
           <BiospecimenIcon fill={theme.biospecimenOrange} />
         </Category>
@@ -211,6 +215,7 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.availableData}
           currentSearchField={currentSearchField}
           color={theme.dataBlue}
+          setSearchField={this.handleSearchField}
         >
           <FileIcon width={11} height={14} fill={theme.dataBlue} />
         </Category>

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -182,15 +182,14 @@ class Categories extends React.Component {
           title="Quick Filters"
           sqon={sqon}
           onSqonUpdate={this.handleSqonUpdate}
+          onClose={this.handleCategoryClose}
           fields={CATEGORY_FIELDS.quickSearch}
+          currentSearchField={currentSearchField}
           color={theme.filterPurple}
           setSearchField={this.handleSearchField}
           setActiveCategory={this.setActiveCategory}
           category={CATEGORY_NAMES.quickSearch}
           currentCategory={currentCategory}
-          fields={CATEGORY_FIELDS.quickSearch}
-          currentSearchField={currentSearchField}
-          onClose={this.handleCategoryClose}
         >
           <QuickFilterIcon fill={theme.filterPurple} />
         </Category>

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -155,7 +155,7 @@ class Categories extends React.Component {
   }
 
   handleCategoryClose() {
-    this.setState({ currentSearchField: '', currentCategory: null });
+    this.setActiveCategory({ fieldName: '', category: null });
   }
 
   setActiveCategory = ({ category, fieldName }) =>

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -122,6 +122,8 @@ const CATEGORY_NAMES = {
   availableData: 'availableData',
 };
 
+const excludedCategories = ['searchAll', 'quickSearch'];
+
 class Categories extends React.Component {
   constructor(props) {
     super(props);
@@ -139,18 +141,10 @@ class Categories extends React.Component {
 
   // searching should not open quick filters
   handleSearchField(fieldName) {
-    let currentCategory = null;
-    if (CATEGORY_FIELDS.clinical.includes(fieldName)) {
-      currentCategory = CATEGORY_NAMES.clinical;
-    } else if (CATEGORY_FIELDS.study.includes(fieldName)) {
-      currentCategory = CATEGORY_NAMES.study;
-    } else if (CATEGORY_FIELDS.biospecimen.includes(fieldName)) {
-      currentCategory = CATEGORY_NAMES.biospecimen;
-    } else if (CATEGORY_FIELDS.demographic.includes(fieldName)) {
-      currentCategory = CATEGORY_NAMES.demographic;
-    } else if (CATEGORY_FIELDS.availableData.includes(fieldName)) {
-      currentCategory = CATEGORY_NAMES.availableData;
-    }
+    const currentCategoryKey = Object.keys(CATEGORY_FIELDS)
+      .filter(key => !excludedCategories.includes(key))
+      .find(key => CATEGORY_FIELDS[key].includes(fieldName));
+    const currentCategory = CATEGORY_NAMES[currentCategoryKey];
     this.setState({ currentSearchField: fieldName, currentCategory });
   }
 

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -114,6 +114,7 @@ const CATEGORY_FIELDS = {
 };
 
 const CATEGORY_NAMES = {
+  quickSearch: 'quickSearch',
   study: 'study',
   clinical: 'clinical',
   biospecimen: 'biospecimen',
@@ -154,10 +155,10 @@ class Categories extends React.Component {
   }
 
   handleCategoryClose() {
-    this.setState({ currentSearchField: '' });
+    this.setState({ currentSearchField: '', currentCategory: null });
   }
 
-  setActiveCategory = (category, fieldName) =>
+  setActiveCategory = ({ category, fieldName }) =>
     this.setState({
       currentCategory: category,
       currentSearchField: fieldName,
@@ -165,7 +166,7 @@ class Categories extends React.Component {
 
   render() {
     const { theme, sqon } = this.props;
-    const { currentSearchField } = this.state;
+    const { currentSearchField, currentCategory } = this.state;
 
     return (
       <Container>
@@ -184,6 +185,12 @@ class Categories extends React.Component {
           fields={CATEGORY_FIELDS.quickSearch}
           color={theme.filterPurple}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.quickSearch}
+          currentCategory={currentCategory}
+          fields={CATEGORY_FIELDS.quickSearch}
+          currentSearchField={currentSearchField}
+          onClose={this.handleCategoryClose}
         >
           <QuickFilterIcon fill={theme.filterPurple} />
         </Category>
@@ -196,6 +203,9 @@ class Categories extends React.Component {
           currentSearchField={currentSearchField}
           color={theme.studyRed}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.study}
+          currentCategory={currentCategory}
         >
           <StudyIcon fill={theme.studyRed} />
         </Category>
@@ -208,6 +218,9 @@ class Categories extends React.Component {
           currentSearchField={currentSearchField}
           color={theme.demographicPurple}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.demographic}
+          currentCategory={currentCategory}
         >
           <DemographicIcon fill={theme.demographicPurple} />
         </Category>
@@ -220,6 +233,9 @@ class Categories extends React.Component {
           currentSearchField={currentSearchField}
           color={theme.clinicalBlue}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.clinical}
+          currentCategory={currentCategory}
         >
           <ClinicalIcon width={18} height={17} fill={theme.clinicalBlue} />
         </Category>
@@ -232,6 +248,9 @@ class Categories extends React.Component {
           currentSearchField={currentSearchField}
           color={theme.biospecimenOrange}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.biospecimen}
+          currentCategory={currentCategory}
         >
           <BiospecimenIcon fill={theme.biospecimenOrange} />
         </Category>
@@ -244,6 +263,9 @@ class Categories extends React.Component {
           currentSearchField={currentSearchField}
           color={theme.dataBlue}
           setSearchField={this.handleSearchField}
+          setActiveCategory={this.setActiveCategory}
+          category={CATEGORY_NAMES.availableData}
+          currentCategory={currentCategory}
         >
           <FileIcon width={11} height={14} fill={theme.dataBlue} />
         </Category>

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -140,15 +140,15 @@ class Categories extends React.Component {
   // searching should not open quick filters
   handleSearchField(fieldName) {
     let currentCategory = null;
-    if (CATEGORY_FIELDS.clinical.indexOf(fieldName) > -1) {
+    if (CATEGORY_FIELDS.clinical.includes(fieldName)) {
       currentCategory = CATEGORY_NAMES.clinical;
-    } else if (CATEGORY_FIELDS.study.indexOf(fieldName) > -1) {
+    } else if (CATEGORY_FIELDS.study.includes(fieldName)) {
       currentCategory = CATEGORY_NAMES.study;
-    } else if (CATEGORY_FIELDS.biospecimen.indexOf(fieldName) > -1) {
+    } else if (CATEGORY_FIELDS.biospecimen.includes(fieldName)) {
       currentCategory = CATEGORY_NAMES.biospecimen;
-    } else if (CATEGORY_FIELDS.demographic.indexOf(fieldName) > -1) {
+    } else if (CATEGORY_FIELDS.demographic.includes(fieldName)) {
       currentCategory = CATEGORY_NAMES.demographic;
-    } else if (CATEGORY_FIELDS.availableData.indexOf(fieldName) > -1) {
+    } else if (CATEGORY_FIELDS.availableData.includes(fieldName)) {
       currentCategory = CATEGORY_NAMES.availableData;
     }
     this.setState({ currentSearchField: fieldName, currentCategory });

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -113,11 +113,20 @@ const CATEGORY_FIELDS = {
   ],
 };
 
+const CATEGORY_NAMES = {
+  study: 'study',
+  clinical: 'clinical',
+  biospecimen: 'biospecimen',
+  demographic: 'demographic',
+  availableData: 'availableData',
+};
+
 class Categories extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       currentSearchField: '',
+      currentCategory: null,
     };
     autobind(this);
   }
@@ -127,13 +136,32 @@ class Categories extends React.Component {
     this.props.onSqonUpdate(...args);
   }
 
+  // searching should not open quick filters
   handleSearchField(fieldName) {
-    this.setState({ currentSearchField: fieldName });
+    let currentCategory = null;
+    if (CATEGORY_FIELDS.clinical.indexOf(fieldName) > -1) {
+      currentCategory = CATEGORY_NAMES.clinical;
+    } else if (CATEGORY_FIELDS.study.indexOf(fieldName) > -1) {
+      currentCategory = CATEGORY_NAMES.study;
+    } else if (CATEGORY_FIELDS.biospecimen.indexOf(fieldName) > -1) {
+      currentCategory = CATEGORY_NAMES.biospecimen;
+    } else if (CATEGORY_FIELDS.demographic.indexOf(fieldName) > -1) {
+      currentCategory = CATEGORY_NAMES.demographic;
+    } else if (CATEGORY_FIELDS.availableData.indexOf(fieldName) > -1) {
+      currentCategory = CATEGORY_NAMES.availableData;
+    }
+    this.setState({ currentSearchField: fieldName, currentCategory });
   }
 
   handleCategoryClose() {
     this.setState({ currentSearchField: '' });
   }
+
+  setActiveCategory = (category, fieldName) =>
+    this.setState({
+      currentCategory: category,
+      currentSearchField: fieldName,
+    });
 
   render() {
     const { theme, sqon } = this.props;

--- a/src/uikit/Dropdown/index.js
+++ b/src/uikit/Dropdown/index.js
@@ -97,20 +97,17 @@ export const withDropdownState = compose(
 );
 
 export const withDropdownMultiPane = compose(
-  withDropdownState,
-  compose(
-    withState('showExpanded', 'setExpanded', false),
-    withState('activeIndex', 'setActiveIndex', null),
-    withHandlers({
-      toggleExpanded: ({ showExpanded, setExpanded }) => e => {
-        setExpanded(!showExpanded);
-      },
-      toggleExpandedDropdown: ({ showExpanded, setExpanded, toggleDropdown }) => e => {
-        setExpanded(!showExpanded);
-        toggleDropdown();
-      },
-    }),
-  ),
+  withState('showExpanded', 'setExpanded', false),
+  withState('activeIndex', 'setActiveIndex', null),
+  withHandlers({
+    toggleExpanded: ({ showExpanded, setExpanded }) => e => {
+      setExpanded(!showExpanded);
+    },
+    toggleExpandedDropdown: ({ showExpanded, setExpanded, toggleDropdown }) => e => {
+      setExpanded(!showExpanded);
+      toggleDropdown();
+    },
+  }),
 );
 
 export default Dropdown;


### PR DESCRIPTION
Change active category dropdown to be based `currentCategory`state in addition to `currentSearchField` with dropdown `isDropdownVisible` state still present.
Fixes
- dropdown visibility indeterminate because of props and state colliding (fixes active style when not active) 
- clicking on items from `SearchAll` will open current category and not `Quick Filter` if first hit.
