### PR TITLE
fix/1572 - disable sorting on Participant Table arrays fields

### DIFF
--- a/src/components/CohortBuilder/ParticipantsTableView/ParticipantsTable.js
+++ b/src/components/CohortBuilder/ParticipantsTableView/ParticipantsTable.js
@@ -136,18 +136,21 @@ const participantsTableViewColumns = (onRowSelected, onAllRowsSelected, dirtyHac
     accessor: 'diagnosisCategories',
     Cell: props => <CollapsibleMultiLineCell {...props} />,
     field: 'diagnoses.diagnosis_category',
+    sortable: false,
   },
   {
     Header: 'Diagnosis',
     accessor: 'diagnosis',
     Cell: props => <CollapsibleMultiLineCell {...props} />,
     field: 'diagnoses.diagnosis',
+    sortable: false,
   },
   {
     Header: 'Age at Diagnosis (days)',
     accessor: 'ageAtDiagnosis',
     Cell: props => <CollapsibleMultiLineCell {...props} />,
     field: 'diagnoses.age_at_event_days',
+    sortable: false,
   },
   { Header: 'Gender', accessor: 'gender', field: 'gender' },
   { Header: 'Family ID', accessor: 'familyId', field: 'family_id' },
@@ -156,12 +159,14 @@ const participantsTableViewColumns = (onRowSelected, onAllRowsSelected, dirtyHac
     accessor: 'familyCompositions',
     Cell: props => <CollapsibleMultiLineCell {...props} />,
     field: 'family.family_compositions',
+    sortable: false,
   },
   {
     Header: 'Files',
     accessor: 'filesCount',
     Cell: props => <NbFilesCell {...props} />,
     field: 'files',
+    sortable: false,
   },
 ];
 


### PR DESCRIPTION
Make explicit which column can be sorted or not in the Participant Table.

That PR does not affect the File Repo Table.