### PR TITLE
🐛 Rebuilds arranger admin ui with missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
       "integrity": "sha512-lqK94b+caNtmKFs5oUVXlSpN3sm5IXZ+KfhMxOtr0LR2SqErzkoJilitjDvJ1WbjHlxLI7WtCjRmOLdOGJqtMQ=="
     },
     "@arranger/admin": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@arranger/admin/-/admin-1.1.5.tgz",
-      "integrity": "sha512-PRyPemwTSkz6BaQhG9RwlZ0sdz4nTaLMyGSnPnk6QmN1bJozZlevZEBFTIcgae1CEr2hibqmUnTq5u3fHl4HRw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@arranger/admin/-/admin-1.1.6.tgz",
+      "integrity": "sha512-7J0vP/DIZQJB8DfzetNAYXZlO0gZ/uokEzRyzg5NBM1xasabYNePkanu+qA/6hZyJXQXxUF9WB5T3wqZkVxp5A==",
       "requires": {
-        "@arranger/mapping-utils": "^1.1.5",
-        "@arranger/schema": "^1.1.5",
+        "@arranger/mapping-utils": "^1.1.6",
+        "@arranger/schema": "^1.1.6",
         "@types/elasticsearch": "^5.0.26",
         "apollo-link-http": "^1.5.5",
         "apollo-server": "^2.1.0",
@@ -44,11 +44,11 @@
       },
       "dependencies": {
         "@arranger/mapping-utils": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-1.1.5.tgz",
-          "integrity": "sha512-++NRGi0B/AWB4WIdgOKq9E5h92XYFfITlXd+rHCLYhHQDYD6YjnXFQPlpK1nyHPgYQaj316unI5Y+MaFejcGDg==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-1.1.6.tgz",
+          "integrity": "sha512-B8Zodt6UauBxuJytDRKAkX6AyJfZDjgtox12fzX1toOgRddjd031APWCAbXhXCPUW1/wsQo2RWDoYJrPZdvICw==",
           "requires": {
-            "@arranger/middleware": "^1.1.5",
+            "@arranger/middleware": "^1.1.6",
             "babel-polyfill": "^6.26.0",
             "elasticsearch": "^14.0.0",
             "graphql-fields": "^1.0.2",
@@ -80,9 +80,9 @@
           }
         },
         "@arranger/middleware": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-1.1.5.tgz",
-          "integrity": "sha512-9l7QausIK70PgNa8jSfYU+mE6b0giBq0cWdD7YqY9xg3J7+09fXhBEtDayBBI01LjMNOE06ZmHm7bYWZvQggPA==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-1.1.6.tgz",
+          "integrity": "sha512-nSmTveqoAQcMzymZ8I11yUHJtXj6ZJ2AjhOZ7MXRKmh2+zLgm8D1DlwWHgr9Fvlab+8OrC05zLmRPyFzPi65sg==",
           "requires": {
             "body-parser": "^1.18.2",
             "cors": "^2.8.4",
@@ -112,11 +112,11 @@
       }
     },
     "@arranger/admin-ui": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@arranger/admin-ui/-/admin-ui-1.1.5.tgz",
-      "integrity": "sha512-vyy4MMAo1U7RtiCfYJ5jrvG6qiHGgVz+8fCgkNNj3JDrkogtCTAnpeVUDuAVu91/jRLAbUxREBuVHJfUpbo9PQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@arranger/admin-ui/-/admin-ui-1.1.6.tgz",
+      "integrity": "sha512-Ji1/aMXE0SNVmLwGghgFXuMk+rY8clE69GAGhXK/eQi2HWJtf5XWn0tTp2r2NMGPpIy5+ZbUwxtJvMywnocJ0w==",
       "requires": {
-        "@arranger/admin": "^1.1.5",
+        "@arranger/admin": "^1.1.6",
         "@types/react-redux": "^6.0.9",
         "@types/react-router-dom": "^4.3.1",
         "@types/react-table": "^6.7.14",
@@ -130,7 +130,7 @@
         "convert-units": "^2.3.4",
         "emotion": "^9.2.12",
         "emotion-theming": "^9.2.9",
-        "file-saver": "^2.0.0-rc.4",
+        "file-saver": "^2.0.1",
         "graphql": "^14.0.2",
         "jszip": "^3.1.5",
         "lodash": "^4.17.11",
@@ -311,12 +311,12 @@
       }
     },
     "@arranger/schema": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-1.1.5.tgz",
-      "integrity": "sha512-PiQuRzXPFOWaNfULrc/3RvBqAfZk718mP4a1r4HsjcooYaHvSsAwHG260XuxgdYOYPErfSzyXyCcJHe2Svz5mQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-1.1.6.tgz",
+      "integrity": "sha512-fpCxUnagBOMlD20546DHXWPE8YgJWCq8qkju1U81q1YrAah9i2a2lpD0zj9V/K+qV44IdYEklN/f4EzS+UkTqA==",
       "requires": {
-        "@arranger/mapping-utils": "^1.1.5",
-        "@arranger/middleware": "^1.1.5",
+        "@arranger/mapping-utils": "^1.1.6",
+        "@arranger/middleware": "^1.1.6",
         "babel-polyfill": "^6.26.0",
         "elasticsearch": "^14.0.0",
         "graphql-middleware": "1.3.1",
@@ -329,11 +329,11 @@
       },
       "dependencies": {
         "@arranger/mapping-utils": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-1.1.5.tgz",
-          "integrity": "sha512-++NRGi0B/AWB4WIdgOKq9E5h92XYFfITlXd+rHCLYhHQDYD6YjnXFQPlpK1nyHPgYQaj316unI5Y+MaFejcGDg==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-1.1.6.tgz",
+          "integrity": "sha512-B8Zodt6UauBxuJytDRKAkX6AyJfZDjgtox12fzX1toOgRddjd031APWCAbXhXCPUW1/wsQo2RWDoYJrPZdvICw==",
           "requires": {
-            "@arranger/middleware": "^1.1.5",
+            "@arranger/middleware": "^1.1.6",
             "babel-polyfill": "^6.26.0",
             "elasticsearch": "^14.0.0",
             "graphql-fields": "^1.0.2",
@@ -343,9 +343,9 @@
           }
         },
         "@arranger/middleware": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-1.1.5.tgz",
-          "integrity": "sha512-9l7QausIK70PgNa8jSfYU+mE6b0giBq0cWdD7YqY9xg3J7+09fXhBEtDayBBI01LjMNOE06ZmHm7bYWZvQggPA==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-1.1.6.tgz",
+          "integrity": "sha512-nSmTveqoAQcMzymZ8I11yUHJtXj6ZJ2AjhOZ7MXRKmh2+zLgm8D1DlwWHgr9Fvlab+8OrC05zLmRPyFzPi65sg==",
           "requires": {
             "body-parser": "^1.18.2",
             "cors": "^2.8.4",
@@ -3429,9 +3429,9 @@
       }
     },
     "@types/react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.3.2.tgz",
+      "integrity": "sha512-biesHodFxPgDxku2m08XwPeAfUYBcxAnrQG7pwFikuA3L2e3u2OKAb+Sb16bJuU3L5CTHd+Ivap+ke4mmGsHqQ==",
       "requires": {
         "@types/history": "*",
         "@types/react": "*",
@@ -3439,9 +3439,9 @@
       }
     },
     "@types/react-table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-6.8.0.tgz",
-      "integrity": "sha512-2oIZ8kXGK5Pka2MrdNcPCED0NUVEc3tcOI2/Q4vHjeSghHr470AEEidxG19/KMZfCGl5/ISEcKtCHCiFNAFhyg==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-6.8.1.tgz",
+      "integrity": "sha512-56wi1s7+H4eGbtXsppNz/OeBeUiPQZnJYLxia0ZpwcD47VfYFE1EkbVadEoJshJIjR4nbSQSF/AgJHvC/ZwHaQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -9732,9 +9732,9 @@
       }
     },
     "file-saver": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.0.tgz",
-      "integrity": "sha512-cYM1ic5DAkg25pHKgi5f10ziAM7RJU37gaH1XQlyNDrtUnzhC/dfoV9zf2OmF0RMKi42jG5B0JWBnPQqyj/G6g=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.1.tgz",
+      "integrity": "sha512-dCB3K7/BvAcUmtmh1DzFdv0eXSVJ9IAFt1mw3XZfAexodNRoE29l3xB2EX4wH2q8m/UTzwzEPq/ArYk98kUkBQ=="
     },
     "file-system-cache": {
       "version": "1.0.5",
@@ -20075,9 +20075,9 @@
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "acorn-globals": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-          "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
+          "integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
           "requires": {
             "acorn": "^6.0.1",
             "acorn-walk": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@arranger/admin-ui": "1.1.5",
+    "@arranger/admin-ui": "1.1.6",
     "@arranger/components": "1.0.34",
     "@nivo/bar": "^0.51.0",
     "@nivo/core": "^0.51.0",
@@ -21,7 +21,7 @@
     "emotion-theming": "^9.0.0",
     "fb": "^2.0.0",
     "file-loader": "^3.0.1",
-    "file-saver": "^2.0.0",
+    "file-saver": "^2.0.1",
     "filesize": "^3.6.0",
     "formik": "^0.10.5",
     "freactal": "^1.1.1",


### PR DESCRIPTION
The last build was missing some dependencies that caused the export buttons to not work. This just updates with the latest build.