### PR TITLE
fixed the Cavatica button in File Repo uploading every files, ignoring the sqon

### DIFF
--- a/src/components/cavatica/CavaticaCopyButton.js
+++ b/src/components/cavatica/CavaticaCopyButton.js
@@ -36,8 +36,8 @@ const CavaticaButton = styled(BigWhiteButton)`
     disabled ? disabledButtonStyles : null}
 `;
 
-export default compose(withTheme)(({ disabled, theme, text, buttonStyle, fileIds, ...props }) => (
-  <CavaticaOpenModalWrapper fileIds={fileIds}>
+export default compose(withTheme)(({ disabled, theme, text, buttonStyle, fileIds, sqon }) => (
+  <CavaticaOpenModalWrapper fileIds={fileIds} sqon={sqon}>
     <CavaticaButton disabled={disabled} buttonStyle={buttonStyle}>
       <ButtonContent>
         <CavaticaLogo


### PR DESCRIPTION
All files were uploaded, unless specific files were selected in the table (checkboxes)

![image](https://user-images.githubusercontent.com/373603/57097218-2f657680-6ce5-11e9-9b24-5689f17d925c.png)

The number of files should now match the current query.