### PR TITLE
Feat/1639 seach all numerics

### DIFF
--- a/src/components/CohortBuilder/Categories/Category.js
+++ b/src/components/CohortBuilder/Categories/Category.js
@@ -171,8 +171,9 @@ const Category = compose(
   }) => {
     const isFieldInSqon = fieldId =>
       sqon.content.some(({ content: { field } }) => field === fieldId);
-    let currentSQON = sqon;
-    const isOpen = isDropdownVisible || !!activeIndex;
+
+    const currentSQON = sqon;
+    const isOpen = isDropdownVisible || activeIndex >= 0;
 
     return (
       <Dropdown
@@ -203,7 +204,7 @@ const Category = compose(
               }
             : undefined,
           showArrow: false,
-          items: (fields || []).map((field, i) => (
+          items: (fields || []).map(field => (
             <CategoryRow active={isFieldInSqon(field)} field={field} />
           )),
           expandedItems: (fields || []).map((field, i) => (

--- a/src/components/CohortBuilder/Categories/index.js
+++ b/src/components/CohortBuilder/Categories/index.js
@@ -37,12 +37,9 @@ const CATEGORY_FIELDS = {
 
     // Clinical
     'affected_status',
-    // "Cannot query field "buckets" on type "NumericAggregations"."
-    // 'diagnoses.age_at_event_days',
-    // "Cannot query field "buckets" on type "NumericAggregations"."
-    // 'outcome.age_at_event_days',
-    // "Cannot query field "buckets" on type "NumericAggregations"."
-    // 'phenotype.age_at_event_days',
+    'diagnoses.age_at_event_days',
+    'outcome.age_at_event_days',
+    'phenotype.age_at_event_days',
     'phenotype.ancestral_hpo_ids',
     'diagnoses.mondo_id_diagnosis',
     'diagnoses.ncit_id_diagnosis',
@@ -58,8 +55,7 @@ const CATEGORY_FIELDS = {
     'outcome.vital_status',
 
     // Biospecimen
-    // "Cannot query field "buckets" on type "NumericAggregations"."
-    // 'biospecimens.age_at_event_days',
+    'biospecimens.age_at_event_days',
     'biospecimens.analyte_type',
     'biospecimens.source_text_anatomical_site',
     'biospecimens.ncit_id_anatomical_site',

--- a/src/components/CohortBuilder/SearchAll/QueryResults.js
+++ b/src/components/CohortBuilder/SearchAll/QueryResults.js
@@ -85,8 +85,8 @@ QueryResults.propTypes = {
       matchByDisplayName: PropTypes.bool.isRequired,
       buckets: PropTypes.arrayOf(
         PropTypes.shape({
-          value: PropTypes.string.isRequired,
-          docCount: PropTypes.number.isRequired,
+          key: PropTypes.string.isRequired,
+          doc_count: PropTypes.number.isRequired,
         }),
       ),
     }),

--- a/src/components/CohortBuilder/SearchAll/QueryResultsBody.js
+++ b/src/components/CohortBuilder/SearchAll/QueryResultsBody.js
@@ -38,20 +38,20 @@ const QueryResultsBody = ({
           <div className="category-name" data-index={i} onClick={handleFieldNameClicked}>
             <TextHighlight content={field.displayName} highlightText={query} />
           </div>
-          {field.buckets.map(({ value, docCount }) => (
-            <div className="result-item" key={`result-item_${value}`}>
+          {field.buckets.map(({ key, doc_count }) => (
+            <div className="result-item" key={`result-item_${key}`}>
               <label>
                 <input
                   type="checkbox"
-                  checked={selections[field.name].indexOf(value) > -1}
+                  checked={selections[field.name].indexOf(key) > -1}
                   className="selection"
                   onChange={evt => {
-                    onSelectionChange(evt, field, value);
+                    onSelectionChange(evt, field, key);
                   }}
                 />
-                <TextHighlight content={value} highlightText={query} />
+                <TextHighlight content={key} highlightText={query} />
               </label>
-              <span className="doc-count">{docCount}</span>
+              <span className="doc-count">{doc_count}</span>
             </div>
           ))}
         </div>
@@ -71,8 +71,8 @@ QueryResultsBody.propTypes = {
       matchByDisplayName: PropTypes.bool.isRequired,
       buckets: PropTypes.arrayOf(
         PropTypes.shape({
-          value: PropTypes.string.isRequired,
-          docCount: PropTypes.number.isRequired,
+          key: PropTypes.string.isRequired,
+          doc_count: PropTypes.number.isRequired,
         }),
       ),
     }),

--- a/src/components/CohortBuilder/SearchAll/queries.js
+++ b/src/components/CohortBuilder/SearchAll/queries.js
@@ -1,6 +1,10 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 
+const AGGREGATABLE_FIELDS_TYPES = ['boolean', 'date', 'id', 'keyword', 'text'];
+// const NONAGGREGATABLE_FIELDS_TYPES = ['float', 'integer', 'long'];
+const UNSUPPORTED_FIELDS_TYPES = ['nested', 'object'];
+
 const toGqlFieldPath = fieldPath => fieldPath.replace(/\./g, '__');
 
 const getBuckets = searchFields =>
@@ -8,21 +12,75 @@ const getBuckets = searchFields =>
     .map(toGqlFieldPath)
     .reduce((acc, gqlFieldName) => `${acc} ${gqlFieldName} { buckets { doc_count key } }`, '');
 
-export const searchAllFieldsQuery = (sqon, searchFields) => ({
-  query: gql`
+const isTypeAggregatable = type => AGGREGATABLE_FIELDS_TYPES.includes(type);
+
+export const searchAllQueries = (sqon, fields, extendedMapping) => {
+  // keep relevant extended mappings
+  const filteredMappings = extendedMapping.filter(m => fields.includes(m.field));
+  const filteredMappingsMap = new Map(filteredMappings.map(m => [m.field, m]));
+
+  // If a field of an unsupported type is passed, ignore it, but warn.
+  const unsupportedFields = filteredMappings.filter(m => UNSUPPORTED_FIELDS_TYPES.includes(m.type));
+  if (unsupportedFields.length > 0) {
+    console.warn(
+      `[SearchAll] found unsupported fields in query, they will be ignored.`,
+      unsupportedFields,
+    );
+  }
+
+  // separate aggreagatable fields
+  const aggregatableFieldsMappings = filteredMappings.filter(m => isTypeAggregatable(m.type));
+  const aggregatableFields = fields.filter(f =>
+    aggregatableFieldsMappings.some(m => m.field === f),
+  );
+
+  if (aggregatableFields.length === 0) {
+    return [];
+  }
+
+  const query = gql`
     query($sqon: JSON) {
       participant {
         aggregations(filters: $sqon) {
-          ${getBuckets(searchFields)}
+          ${getBuckets(aggregatableFields)}
         }
       }
-    }
-  `,
-  variables: { sqon },
-  transform: data => {
-    if (data.errors) {
-      return { errors: data.errors };
-    }
-    return get(data, 'data.participant.aggregations');
-  },
-});
+    }`;
+
+  return [
+    {
+      query,
+      variables: { sqon },
+      transform: data => {
+        if (data.errors) {
+          return { errors: data.errors };
+        }
+
+        const aggregations = get(data, 'data.participant.aggregations', {});
+
+        // merge aggragatable and nonaggregatable fields together,
+        //  respecting the original fields order
+        //  and turn them into usable objects for the SearchAll
+        return fields.reduce((acc, field) => {
+          const isAggregation = aggregatableFields.includes(field);
+          const fieldPath = toGqlFieldPath(field);
+          const fieldMapping = filteredMappingsMap.get(field);
+          acc[fieldPath] = {
+            name: field,
+            isAggregation,
+            displayName: fieldMapping.displayName || '',
+            buckets: isAggregation
+              ? aggregations[fieldPath].buckets
+              : [
+                  {
+                    doc_count: 0,
+                    key: '',
+                  },
+                ],
+          };
+          return acc;
+        }, {});
+      },
+    },
+  ];
+};


### PR DESCRIPTION
Added support for nonaggretable fields to the `SearchAll`.

Also, fixed a bug where the first filter of a category in the Cohort Builder would not open from the `SearchAll`.