### PR TITLE
Fix/1820 validate virtual studies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kf-portal-ui",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6974,7 +6974,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "deep-extend": {
@@ -7051,7 +7051,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -7075,9 +7075,8 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -7094,8 +7093,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
@@ -7116,7 +7114,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7178,8 +7175,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.6"
           }
         },
         "npmlog": {
@@ -7195,8 +7192,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -19148,7 +19144,7 @@
               "resolved": false,
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.1"
               }
             },
             "deep-extend": {
@@ -19217,7 +19213,7 @@
               "resolved": false,
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
               }
             },
             "ignore-walk": {
@@ -19225,7 +19221,7 @@
               "resolved": false,
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -19252,7 +19248,7 @@
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "isarray": {
@@ -19265,7 +19261,7 @@
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               }
             },
             "minimist": {
@@ -19308,9 +19304,9 @@
               "resolved": false,
               "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
               "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
+                "debug": "4.1.1",
+                "iconv-lite": "0.4.24",
+                "sax": "1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -19335,8 +19331,8 @@
               "resolved": false,
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               }
             },
             "npm-bundled": {
@@ -19349,8 +19345,8 @@
               "resolved": false,
               "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
               "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.6"
               }
             },
             "npmlog": {
@@ -19397,8 +19393,8 @@
               "resolved": false,
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               }
             },
             "path-is-absolute": {

--- a/src/common/sqonUtils.js
+++ b/src/common/sqonUtils.js
@@ -1,6 +1,19 @@
-import { cloneDeep, merge, union } from 'lodash';
+import { cloneDeep, merge, union, isEqual } from 'lodash';
 
 import { BOOLEAN_OPS, isReference } from '@kfarranger/components/dist/AdvancedSqonBuilder/utils';
+
+/**
+ * Returns a default, empty sqon.
+ * @returns {Object[]} - A copy of an empty sqon.
+ */
+export const getDefaultSqon = () => cloneDeep([{ op: 'and', content: [] }]);
+
+/**
+ * Check wether this is a default, empty sqon.
+ * @param {Object[]} sqons - an array of sqon object.
+ * @returns {boolean} `true` if it is a default sqon; `false` otherwise.
+ */
+export const isDefaultSqon = sqons => isEqual(sqons, getDefaultSqon());
 
 /**
  * Sets the value in the given `newSqon` to the `sourceSqons` at the given `sourceIndex`.

--- a/src/common/sqonUtils.unit.js
+++ b/src/common/sqonUtils.unit.js
@@ -3,6 +3,8 @@ import { cloneDeep } from 'lodash';
 import { cyan } from 'chalk';
 
 import {
+  getDefaultSqon,
+  isDefaultSqon,
   setSqonValueAtIndex,
   MERGE_VALUES_STRATEGIES,
   MERGE_OPERATOR_STRATEGIES,
@@ -13,13 +15,40 @@ const numberOfSqonsDidntChanged = (sourceSqons, sqonIndex, newSqons) => {
 };
 
 describe(cyan.bold('sqonUtils'), () => {
+  describe('getDefaultSqon', () => {
+    it('returns an empty sqon', () => {
+      const sqon = getDefaultSqon();
+      expect(sqon.length).to.eq(1);
+      expect(sqon[0].op).to.eq('and');
+      expect(sqon[0].content).to.eql([]);
+    });
+
+    it('returns a new instance each time', () => {
+      const sqon1 = getDefaultSqon();
+      const sqon2 = getDefaultSqon();
+      expect(sqon1).not.to.be.eq(sqon2);
+      expect(sqon1).to.be.eql(sqon2);
+    });
+  });
+
+  describe('isDefaultSqon', () => {
+    it('returns `true` if a sqon is loosely equal to the default sqon', () => {
+      expect(isDefaultSqon([{ op: 'and', content: [] }])).to.be.true;
+    });
+
+    it('returns `false` if a sqon is not loosely equal to the default sqon', () => {
+      expect(isDefaultSqon([{ op: 'or', content: [] }])).to.be.false;
+      expect(isDefaultSqon([{ op: 'and', content: [0] }])).to.be.false;
+    });
+  });
+
   describe('setSqonValueAtIndex', () => {
     describe('given an empty sqon in "targetSqons" at the given "targetIndex"', () => {
       const targetIndex = 0;
       let sourceSqons;
 
       beforeEach(() => {
-        sourceSqons = [{ op: 'and', content: [] }];
+        sourceSqons = getDefaultSqon();
       });
 
       it('adds the operation of the "newSqon" in the "targetSqons"', () => {

--- a/src/components/CohortBuilder/SQONProvider.js
+++ b/src/components/CohortBuilder/SQONProvider.js
@@ -77,7 +77,7 @@ class SQONProvider extends React.Component {
   }
 
   // takes care of putting a new sqon into place while preserving references
-  // TODO - move to @kfarranger/components/dist/AdvancedSqonBuilder/utils
+  // TODO - move to `common/sqonUtils`
   mergeSqonToActiveIndex(newSqon) {
     const { sqons, activeIndex } = this.props;
     const updatedSqons = sqons.map((currentSqon, i) =>

--- a/src/components/CohortBuilder/SaveVirtualStudiesModalContent.js
+++ b/src/components/CohortBuilder/SaveVirtualStudiesModalContent.js
@@ -12,6 +12,7 @@ import { ModalFooter } from 'components/Modal/index.js';
 import { ModalContentSection } from './common';
 
 import { saveVirtualStudy } from '../../store/actionCreators/virtualStudies';
+import { createVirtualStudy } from 'services/virtualStudies';
 
 const DESCRIPTION_MAX_LENGTH = 300;
 
@@ -28,7 +29,7 @@ class SaveVirtualStudiesModalContent extends React.Component {
     autobind(this);
   }
 
-  propTypes = {
+  static propTypes = {
     saveAs: PropTypes.bool.isRequired,
   };
 
@@ -51,16 +52,15 @@ class SaveVirtualStudiesModalContent extends React.Component {
       saveAs,
     } = this.props;
 
-    return saveVirtualStudy({
-      loggedInUser,
-      sqonsState: {
-        sqons,
-        activeIndex: activeSqonIndex,
-        virtualStudyId: saveAs ? null : virtualStudyId,
-      },
+    const study = createVirtualStudy(
+      saveAs ? null : virtualStudyId,
       name,
       description,
-    });
+      sqons,
+      activeSqonIndex,
+    );
+
+    return saveVirtualStudy(loggedInUser, study);
   }
 
   submitHandler() {

--- a/src/components/CohortBuilder/VirtualStudiesMenu/index.js
+++ b/src/components/CohortBuilder/VirtualStudiesMenu/index.js
@@ -5,8 +5,6 @@ import { withRouter } from 'react-router-dom';
 import { Trans } from 'react-i18next';
 import autobind from 'auto-bind-es5';
 import urlJoin from 'url-join';
-
-// TODO - kill those once done
 import { injectState } from 'freactal';
 
 import Row from 'uikit/Row';
@@ -18,6 +16,7 @@ import {
   loadSavedVirtualStudy,
   saveVirtualStudy,
 } from '../../../store/actionCreators/virtualStudies';
+import { createVirtualStudy } from 'services/virtualStudies';
 
 import Tooltip from 'uikit/Tooltip';
 import { WhiteButton } from 'uikit/Button.js';
@@ -94,16 +93,9 @@ class VirtualStudiesMenu extends React.Component {
       return this.onSaveAsClick();
     }
 
-    return saveVirtualStudy({
-      loggedInUser,
-      sqonsState: {
-        sqons,
-        activeIndex,
-        virtualStudyId,
-      },
-      name,
-      description,
-    }).catch(err => {
+    const study = createVirtualStudy(virtualStudyId, name, description, sqons, activeIndex);
+
+    return saveVirtualStudy(loggedInUser, study).catch(err => {
       console.error('Error while saving the virtual study', err);
     });
   }
@@ -213,8 +205,8 @@ class VirtualStudiesMenu extends React.Component {
           </header>
 
           <div className="description">
-            {description.split(/\n/).map(line => (
-              <p>{line}&nbsp;</p>
+            {description.split(/\n/).map((line, i) => (
+              <p key={i}>{line}&nbsp;</p>
             ))}
           </div>
         </Row>

--- a/src/services/profiles.js
+++ b/src/services/profiles.js
@@ -1,9 +1,6 @@
 import urlJoin from 'url-join';
 import { personaApiRoot } from 'common/injectGlobals';
 
-// TODO: Issue #321
-// acceptedKfOptIn
-// acceptedNihOptIn
 const DEFAULT_FIELDS = `
   _id
   title
@@ -49,7 +46,9 @@ const DEFAULT_FIELDS = `
 const url = urlJoin(personaApiRoot, 'graphql');
 
 export const getProfile = api => async () => {
-  const { data: { self } } = await api({
+  const {
+    data: { self },
+  } = await api({
     url,
     body: {
       query: `
@@ -66,7 +65,11 @@ export const getProfile = api => async () => {
 };
 
 export const createProfile = api => async ({ egoId, lastName, firstName, email }) => {
-  const { data: { userCreate: { record } } } = await api({
+  const {
+    data: {
+      userCreate: { record },
+    },
+  } = await api({
     url,
     body: {
       variables: { egoId, lastName, firstName, email },
@@ -85,7 +88,11 @@ export const createProfile = api => async ({ egoId, lastName, firstName, email }
 };
 
 export const updateProfile = api => async ({ user }) => {
-  const { data: { userUpdate: { record } } } = await api({
+  const {
+    data: {
+      userUpdate: { record },
+    },
+  } = await api({
     url,
     body: {
       variables: { record: user },
@@ -105,7 +112,11 @@ export const updateProfile = api => async ({ user }) => {
 };
 
 export const deleteProfile = api => async ({ user }) => {
-  const { data: { userRemove: { recordId } } } = await api({
+  const {
+    data: {
+      userRemove: { recordId },
+    },
+  } = await api({
     url,
     body: {
       variables: { _id: user._id },
@@ -123,7 +134,9 @@ export const deleteProfile = api => async ({ user }) => {
 };
 
 export const getTags = api => async ({ filter, size }) => {
-  const { data: { tags } } = await api({
+  const {
+    data: { tags },
+  } = await api({
     url,
     body: {
       variables: { model: 'User', field: 'interests', filter, size },

--- a/src/store/reducers/cohortBuilder.js
+++ b/src/store/reducers/cohortBuilder.js
@@ -1,4 +1,5 @@
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep } from 'lodash';
+import { getDefaultSqon, isDefaultSqon } from 'common/sqonUtils';
 
 import {
   VIRTUAL_STUDY_LOAD_REQUESTED,
@@ -17,10 +18,8 @@ import {
   LOGOUT,
 } from '../actionTypes';
 
-const defaultSqon = [{ op: 'and', content: [] }];
-
 export const initialState = {
-  sqons: cloneDeep(defaultSqon),
+  sqons: getDefaultSqon(),
   activeIndex: 0,
   uid: null,
   virtualStudyId: null,
@@ -35,7 +34,7 @@ export const initialState = {
 const dirty = state => ({
   ...state,
   dirty: true,
-  areSqonsEmpty: isEqual(state.sqons, defaultSqon),
+  areSqonsEmpty: isDefaultSqon(state.sqons),
 });
 
 export default (state = initialState, action) => {
@@ -43,7 +42,7 @@ export default (state = initialState, action) => {
     case '@@INIT':
       return {
         ...state,
-        areSqonsEmpty: isEqual(state.sqons, defaultSqon),
+        areSqonsEmpty: isDefaultSqon(state.sqons),
       };
     case VIRTUAL_STUDY_LOAD_REQUESTED:
       return {
@@ -56,7 +55,7 @@ export default (state = initialState, action) => {
         ...action.payload,
         isLoading: false,
       };
-      newState.areSqonsEmpty = isEqual(newState.sqons, defaultSqon);
+      newState.areSqonsEmpty = isDefaultSqon(newState.sqons);
       return newState;
     case VIRTUAL_STUDY_LOAD_FAILURE:
       return {

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -50,17 +50,17 @@ const colors = {
   errorBorder: `#e45562`,
   // warning
   warningDark: '#ff9427', //yellow
-  warningLight: '#ff9427', // TODO: confirm this color
+  warningLight: '#ff9427',
   warningBackground: '#fff4e9',
   warningBorder: `#ff9427`,
   // info
   infoDark: '#22afe9', //blue
-  infoLight: '#e8f7fd', // TODO: confirm this color
+  infoLight: '#e8f7fd',
   infoBackground: '#e8f7fd',
   infoBorder: `#22afe9`,
   // success
   successDark: '#009bb8', //green
-  successLight: '#e6f3f5', // TODO: confirm this color
+  successLight: '#e6f3f5',
   successBackground: '#e6f3f5',
   successBorder: `#009bb8`,
 

--- a/src/uikit/EditableLabel.js
+++ b/src/uikit/EditableLabel.js
@@ -1,5 +1,3 @@
-// @flow
-// TODO: move this to arranger/components
 import React from 'react';
 import { compose, withState, withHandlers, defaultProps, withPropsOnChange } from 'recompose';
 import { trim } from 'lodash';
@@ -183,7 +181,9 @@ export default compose(
             `}
           >
             {trim(inputValue)
-              ? renderNonEditing ? renderNonEditing(trim(inputValue)) : trim(inputValue)
+              ? renderNonEditing
+                ? renderNonEditing(trim(inputValue))
+                : trim(inputValue)
               : placeholderComponent}
           </span>
           {!disabled && <PencilIcon style={{ paddingLeft: '10px' }} />}


### PR DESCRIPTION
Standardized the format of virtual studies around the application so they are homogeneous, even though the services require and returns different representations.

Validated the format and values of the studies when loading them from the local storage, or saving them.

This way, missing fields are always set to a default value and studies are validated before being sent to services and studies received from services (Riff) are validated, too.