### PR TITLE
feat/1688 - added number of participants to queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@kfarranger/admin-ui": "1.2.3",
-    "@kfarranger/components": "1.2.4",
+    "@kfarranger/components": "1.3.0",
     "@nivo/bar": "^0.51.0",
     "@nivo/core": "^0.51.0",
     "@nivo/pie": "^0.51.0",

--- a/src/components/CohortBuilder/SqonBuilder/index.js
+++ b/src/components/CohortBuilder/SqonBuilder/index.js
@@ -14,14 +14,13 @@ import {
   ModalContentSection,
   ARRANGER_API_PARTICIPANT_INDEX_NAME,
 } from '../common';
-import {SQONdiff} from '../../Utils'
+import { SQONdiff } from '../../Utils';
 import { ModalFooter } from 'components/Modal';
 import { trackUserInteraction, TRACKING_EVENTS } from 'services/analyticsTracking';
 
-
-const trackSQONaction = ({category, action, label}) => {
-  trackUserInteraction({category, action, label: JSON.stringify(label)})
-}
+const trackSQONaction = ({ category, action, label }) => {
+  trackUserInteraction({ category, action, label: JSON.stringify(label) });
+};
 
 const extendedMappingToDisplayNameMap = memoize(extendedMapping =>
   extendedMapping.reduce((acc, { field, displayName }) => {
@@ -68,9 +67,7 @@ const SqonBuilder = compose(
   withApi,
   injectState,
 )(({ api, onChange, state, effects, ...rest }) => {
-
   const handleAction = async action => {
-
     // track the existing and operated on sqon actions
     trackSQONaction({
       category: TRACKING_EVENTS.categories.cohortBuilder.sqonBuilder,
@@ -79,9 +76,10 @@ const SqonBuilder = compose(
         [action.eventKey.toLowerCase()]: SQONdiff(rest.syntheticSqons, action.newSyntheticSqons),
         sqon_result: {
           sqon: action.newSyntheticSqons,
-          eventDetails: action.eventDetails
-        }
-      }})
+          eventDetails: action.eventDetails,
+        },
+      },
+    });
 
     if (action.eventKey === 'CLEAR_ALL') {
       delete rest['activeSqonIndex'];
@@ -123,13 +121,11 @@ const SqonBuilder = compose(
               arrangerProjectId={arrangerProjectId}
               arrangerProjectIndex={ARRANGER_API_PARTICIPANT_INDEX_NAME}
               FieldOpModifierContainer={props => {
-                return (
-                <StyledFieldFilterContainer showHeader={false} {...props} />
-              )}}
+                return <StyledFieldFilterContainer showHeader={false} {...props} />;
+              }}
               fieldDisplayNameMap={extendedMappingToDisplayNameMap(extendedMapping)}
               onChange={handleAction}
               {...rest}
-              // activeSqonIndex={1}
             />
           )
         }

--- a/src/components/CohortBuilder/index.js
+++ b/src/components/CohortBuilder/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'react-emotion';
 import { compose } from 'recompose';
 import { injectState } from 'freactal';
+import { withTheme } from 'emotion-theming';
 
 import saveSet from '@kfarranger/components/dist/utils/saveSet';
 import graphql from 'services/arranger';
@@ -14,6 +15,7 @@ import SqonBuilder from './SqonBuilder';
 import SQONProvider from './SQONProvider';
 import VirtualStudiesMenu from './VirtualStudiesMenu';
 import PromptMessage from 'uikit/PromptMessage';
+import ParticipantIcon from 'icons/ParticipantIcon';
 
 const Container = styled('div')`
   width: 100%;
@@ -46,8 +48,9 @@ const StylePromptMessage = styled(PromptMessage)`
 
 const CohortBuilder = compose(
   withApi,
+  withTheme,
   injectState,
-)(({ api, state: { loggedInUser } }) => (
+)(({ api, state: { loggedInUser }, theme }) => (
   <SQONProvider>
     {({
       sqons: syntheticSqons,
@@ -137,6 +140,13 @@ const CohortBuilder = compose(
                 onChange={sqonBuilderSqonsChange}
                 onActiveSqonSelect={sqonBuilderActiveSqonSelect}
                 emptyEntryMessage="Use the filters above to build a query"
+                ResultCountIcon={ParticipantIcon}
+                resultCountIconProps={{
+                  height: 14,
+                  width: 14,
+                  fill: theme.greyScale11,
+                  // fill: 'currentColor',
+                }}
               />
             </SqonBuilderContainer>
           </FullWidthWhite>

--- a/src/icons/ParticipantIcon.js
+++ b/src/icons/ParticipantIcon.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default ({ width = 94, height = 94, fill = '#a9adc0', ...props }) => {
+export default ({ width = 94, height = 94, fill = '#a9adc0', className = '' }) => {
   return (
     <svg
       id="Isolation_Mode"
@@ -9,6 +9,7 @@ export default ({ width = 94, height = 94, fill = '#a9adc0', ...props }) => {
       viewBox="0 0 101.49 124.78"
       width={width}
       height={height}
+      className={className}
     >
       <defs>
         <style>{`.cls-1{fill: ${fill};fill-rule:evenodd;}`}</style>


### PR DESCRIPTION
Adds the number of participants in each query of the virtual study.

Dependent on ~~https://github.com/overture-stack/arranger/pull/519~~ https://github.com/kids-first/arranger/pull/3

Dependent on `@kfarranger/components@1.3.0`, not yet published. We must merge the above PR before, bump the version and publish to npm, then adjust it in this PR if needs be, then merge this one.