### PR TITLE
fix/1875 & fix/1876 various charts issues with Firefox

### DIFF
--- a/src/chartkit/components/HorizontalBar.js
+++ b/src/chartkit/components/HorizontalBar.js
@@ -181,7 +181,7 @@ class HorizontalBar extends Component {
       axisBottom: {
         orient: 'bottom',
         tickSize: 0,
-        tickPadding: 5,
+        tickPadding: 8,
         tickRotation: 0,
         legend: '# Participants',
         legendPosition: 'middle',
@@ -212,10 +212,11 @@ class HorizontalBar extends Component {
       tooltip: props => <Tooltip {...props} formatter={tooltipFormatter} />,
     };
 
+    // see https://github.com/plouc/nivo/issues/164#issuecomment-488939712
     return (
       <HorizontalBarWrapper>
         {!legends ? null : <Legend legends={legends} theme={defaultTheme.legend} />}
-        <TextBugWrapper baseline="text-before-edge">
+        <TextBugWrapper baseline="central">
           <ChartDisplayContainer>
             {height ? (
               <ResponsiveBar {...chartData} height={height} />

--- a/src/chartkit/components/VerticalBar.js
+++ b/src/chartkit/components/VerticalBar.js
@@ -138,11 +138,12 @@ class VerticalBar extends Component {
       indexBy = 'id',
       height,
       tooltipFormatter,
-      axisLeftLegend = '# Participants', // TODO REMOVE magic string
-      axisBottomLegend = 'Age at Diagnosis (years)', // TODO REMOVE magic string
+      axisLeftLegend = '',
+      axisBottomLegend = '',
       axisLeftFormat = v => v.toLocaleString(),
       axisBottomFormat = v => v.toLocaleString(),
       bottomLegendOffset = 35,
+      leftLegendOffset = -40,
     } = this.props;
 
     const chartData = {
@@ -185,7 +186,7 @@ class VerticalBar extends Component {
       axisBottom: {
         orient: 'bottom',
         tickSize: 0,
-        tickPadding: 5,
+        tickPadding: 8,
         tickRotation: 0,
         legend: axisBottomLegend,
         legendPosition: 'middle',
@@ -200,7 +201,7 @@ class VerticalBar extends Component {
         tickSize: 0,
         tickPadding: 5,
         tickRotation: 0,
-        legendOffset: -42,
+        legendOffset: leftLegendOffset,
         renderTick: this.renderAxisLeftTick,
         format: axisLeftFormat,
         theme: defaultTheme,
@@ -221,10 +222,11 @@ class VerticalBar extends Component {
       tooltip: props => <Tooltip {...props} formatter={tooltipFormatter} />,
     };
 
+    // see https://github.com/plouc/nivo/issues/164#issuecomment-488939712
     return (
       <VerticalBarWrapper>
         {!legends ? null : <Legend legends={legends} theme={defaultTheme.legend} />}
-        <TextBugWrapper baseline="text-before-edge">
+        <TextBugWrapper baseline="central">
           <ChartDisplayContainer>
             {height ? (
               <ResponsiveBar {...chartData} height={height} />

--- a/src/components/CohortBuilder/Summary/AgeDiagChart.js
+++ b/src/components/CohortBuilder/Summary/AgeDiagChart.js
@@ -75,6 +75,7 @@ class AgeDiagChart extends React.Component {
           data={data}
           sortBy={false}
           indexBy="label"
+          axisBottomLegend="Age at Diagnosis (years)"
           tooltipFormatter={ageAtDiagnosisTooltip}
           height={225}
           colors={[theme.chartColors.lightblue]}

--- a/src/components/CohortBuilder/Summary/DataTypeChart.js
+++ b/src/components/CohortBuilder/Summary/DataTypeChart.js
@@ -50,6 +50,7 @@ class DataTypeChart extends React.Component {
         keys={['value']}
         height={260}
         bottomLegendOffset={20}
+        leftLegendOffset={-42}
         sortByKeys={['value']}
         sortOrder={'desc'}
         data={data}


### PR DESCRIPTION
Fixes:
#1875 
#1876 
- alignment of y-axis labels in HorizontalBar charts (Studies, Most Frequent Diagnosis) on Firefox

Remaining issues:
- Small difference between he padding between x-axis labels of both Horizontal and Vertical graphs

![image](https://user-images.githubusercontent.com/373603/60743449-ac100d80-9f3f-11e9-8aa3-0cbbd274759d.png)
