### PR TITLE
feat/1858 - allow to display OrcId conditionnaly, for testing purpose

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release notes for kf-portal-ui
 
+## 2019-08-13 kf-portal-ui 2.7.2
+
+This release includes a way to deploy the OrcId login button in production, but hidden. This is only done for testing purposes.
+
+### Includes
+
+- [#2014](https://github.com/kids-first/kf-portal-ui/issues/2014) Orcid Login : hidden deploy to test in production
+
 ## 2019-08-09 kf-portal-ui 2.7.1
 
 This release concentrates on bug fixes following the release 2.7.0 and contains no new features.

--- a/src/common/injectGlobals.js
+++ b/src/common/injectGlobals.js
@@ -43,7 +43,12 @@ export const facebookAppId = getApplicationEnvVar('FACEBOOK_APP_ID');
 export const egoAppId = getApplicationEnvVar('EGO_APP_ID');
 export const googleMapsKey = getApplicationEnvVar('GOOGLE_MAPS_KEY');
 
-export const orcidAuthAppId = getApplicationEnvVar('ORCID_AUTH_APP_ID');
+const orcidOverride = typeof qs === 'object' && qs.hasOwnProperty('orcid');
+if (orcidOverride) {
+  global.log('warning: OrcId login will be displayed');
+}
+
+export const orcidAuthAppId = orcidOverride ? getApplicationEnvVar('ORCID_AUTH_APP_ID') : '';
 export const orcidAuthApiBaseUri = getApplicationEnvVar('ORCID_AUTH_API_URI');
 export const orcidAuthScope = getApplicationEnvVar('ORCID_AUTH_API_SCOPE');
 export const orcidAuthRedirectUri = getApplicationEnvVar('ORCID_AUTH_REDIRECT_URI');


### PR DESCRIPTION
:warning: This is a PR to `master`, so merging it will trigger a deployment in production.

The OrcId login button will only be displayed it we add a parameter named `orcid` in the query string, i.e. : https://portal.kidsfirstdrc.org/dashboard?orcid

This is only done to test the OrcId login in production, and might be reverted in future release of `2.7.x`, and won't be included in the release of `2.8.0`.