### PR TITLE
feat/2031 - made the new family report available in the Cohort Builder

### DIFF
--- a/src/services/reports/familyClinicalData.js
+++ b/src/services/reports/familyClinicalData.js
@@ -1,0 +1,27 @@
+import { format } from 'date-fns';
+
+import { EGO_JWT_KEY } from 'common/constants';
+import downloader from 'common/downloader';
+import { arrangerProjectId, reportsApiRoot } from 'common/injectGlobals';
+
+const url = `${reportsApiRoot}/reports/family-clinical-data`;
+
+export default sqon => {
+  const egoJwt = localStorage.getItem(EGO_JWT_KEY);
+  const filename = format(new Date(), `[participants_clinical_]YYYYMMDD[.xlsx]`);
+  return downloader({
+    url,
+    method: 'POST',
+    responseType: 'blob',
+    data: {
+      sqon,
+      projectId: arrangerProjectId,
+      filename,
+    },
+    headers: {
+      Authorization: `Bearer ${egoJwt}`,
+      Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/services/reports/index.js
+++ b/src/services/reports/index.js
@@ -1,0 +1,2 @@
+export { default as clinicalDataReport } from './clinicalData';
+export { default as familyClinicalDataReport } from './familyClinicalData';


### PR DESCRIPTION
- Made the "Family Clinical Data" report available from the "Download" button of the Cohort Builder table.
- Cleaned the page a little, it was getting out of hand
- Hidden behind the `clinicalDataReport` feature toggle (same as the Participant Clinical Data report)
- Removed the condition that disables the report : the current condition makes no sense with the format of the family compositions. There could be both false positive and false negatives.