### PR TITLE
Added UI button for the Biospecimen report in Cohort Builder

### DIFF
--- a/src/services/reports/biospecimenData.js
+++ b/src/services/reports/biospecimenData.js
@@ -1,0 +1,27 @@
+import { format } from 'date-fns';
+
+import { EGO_JWT_KEY } from 'common/constants';
+import downloader from 'common/downloader';
+import { arrangerProjectId, reportsApiRoot } from 'common/injectGlobals';
+
+const url = `${reportsApiRoot}/reports/biospecimen-data`;
+
+export default sqon => {
+  const egoJwt = localStorage.getItem(EGO_JWT_KEY);
+  const filename = format(new Date(), `[biospecimen_]YYYYMMDD[.xlsx]`);
+  return downloader({
+    url,
+    method: 'POST',
+    responseType: 'blob',
+    data: {
+      sqon,
+      projectId: arrangerProjectId,
+      filename,
+    },
+    headers: {
+      Authorization: `Bearer ${egoJwt}`,
+      Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/services/reports/index.js
+++ b/src/services/reports/index.js
@@ -1,2 +1,3 @@
 export { default as clinicalDataReport } from './clinicalData';
 export { default as familyClinicalDataReport } from './familyClinicalData';
+export { default as biospecimenDataReport } from './biospecimenData';


### PR DESCRIPTION
Added the choice in the "Download" button of the cohort builder to download the Biospecimen Data Report.

The reports are under the feature toggle `REACT_APP_FT_CLINICAL_DATA_REPORT`. If it is false, the old report will be downloaded instead.

![image](https://user-images.githubusercontent.com/373603/68900036-fdf04d80-0700-11ea-8bb6-5113b6e107d4.png)
