### PR TITLE
Display an error when downloading of a report fails

### DIFF
--- a/src/common/downloader.js
+++ b/src/common/downloader.js
@@ -60,32 +60,30 @@ export default async (opts = {}) => {
     throw new Error(`Unsupported responseType "${opts.responseType}" provided.`);
   }
 
-  return axios(opts)
-    .then(response => {
-      // Make a Blob from the response
-      const blob = getBlobFromResponse(response, opts.responseType);
+  return axios(opts).then(response => {
+    // Make a Blob from the response
+    const blob = getBlobFromResponse(response, opts.responseType);
 
-      // Try to determine the filename from the `content-disposition` header,
-      //  fallback to a UUID if it fails.
-      let filename = null;
-      const disposition = response.headers['content-disposition'];
-      if (disposition) {
-        try {
-          const filenameFromContentDisposition = disposition
-            .split(';')
-            .map(part => part.trim())
-            // Matching the modern format`filename="MyFile.txt"`,
-            //  but not the derelict syntax `filename*=utf-8''MyFile.txt`
-            .find(part => /filename=".*"/i.test(part));
-          filename = /filename="(.*)"/i.exec(filenameFromContentDisposition)[1];
-        } catch (err) {
-          filename = uuid();
-          console.warn('failed to parse filename, will fallback to an UUID', disposition);
-        }
+    // Try to determine the filename from the `content-disposition` header,
+    //  fallback to a UUID if it fails.
+    let filename = null;
+    const disposition = response.headers['content-disposition'];
+    if (disposition) {
+      try {
+        const filenameFromContentDisposition = disposition
+          .split(';')
+          .map(part => part.trim())
+          // Matching the modern format`filename="MyFile.txt"`,
+          //  but not the derelict syntax `filename*=utf-8''MyFile.txt`
+          .find(part => /filename=".*"/i.test(part));
+        filename = /filename="(.*)"/i.exec(filenameFromContentDisposition)[1];
+      } catch (err) {
+        filename = uuid();
+        console.warn('failed to parse filename, will fallback to an UUID', disposition);
       }
+    }
 
-      // Let the user download the file.
-      saveAs(blob, filename);
-    })
-    .catch(console.error);
+    // Let the user download the file.
+    saveAs(blob, filename);
+  });
 };

--- a/src/components/FileRepo/DownloadButton.js
+++ b/src/components/FileRepo/DownloadButton.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import { compose } from 'recompose';
@@ -28,6 +29,7 @@ import {
   biospecimenDataReport,
 } from 'services/reports';
 import { isFeatureEnabled } from 'common/featuresToggles';
+import { displayError } from 'store/actionCreators/errors';
 
 const StyledDropdownOptionsContainer = styled(DropdownOptionsContainer)`
   position: absolute;
@@ -217,6 +219,7 @@ class DownloadButton extends React.Component {
     try {
       await reportFn(sqon);
     } catch (err) {
+      this.props.displayError(`Error downloading the report`);
       console.error(`Error downloading the report`, err);
     } finally {
       this.setState({ isDownloadingReport: false });
@@ -227,8 +230,11 @@ class DownloadButton extends React.Component {
     return (
       <OptionRow
         onMouseDown={async () => {
-          await this.downloadReport(reportName, sqon);
-          setDropdownVisibility(false);
+          try {
+            await this.downloadReport(reportName, sqon);
+          } finally {
+            setDropdownVisibility(false);
+          }
         }}
       >
         {label}
@@ -298,6 +304,7 @@ class DownloadButton extends React.Component {
 
   fileRepoRender() {
     const {
+      displayError,
       api,
       sqon,
       projectId,
@@ -312,6 +319,7 @@ class DownloadButton extends React.Component {
       try {
         await reportFn();
       } catch (err) {
+        displayError(`Error downloading the report`);
         console.error(`Error downloading the report`, err);
       } finally {
         this.setState({ isDownloadingReport: false });
@@ -434,7 +442,15 @@ class DownloadButton extends React.Component {
   }
 }
 
+const mapDispatchToProps = {
+  displayError,
+};
+
 export default compose(
   withApi,
   injectState,
+  connect(
+    null,
+    mapDispatchToProps,
+  ),
 )(DownloadButton);

--- a/src/store/actionCreators/errors.js
+++ b/src/store/actionCreators/errors.js
@@ -1,0 +1,19 @@
+import { ERROR_DISPLAY, ERROR_DISMISSED } from '../actionTypes';
+
+/**
+ * Displays a dismissible error to the user.
+ * @param {{message:String}|String} error - An error, either in form of a `string` or an object with a `message` property, e.g. `Error`.
+ */
+export const displayError = error => ({
+  type: ERROR_DISPLAY,
+  payload: error,
+});
+
+/**
+ * Dismisses an error by it's unique identifier, or prevent it from appearing.
+ * @param {String} errorUuid - the unique identifier of an error.
+ */
+export const dismissError = errorUuid => ({
+  type: ERROR_DISMISSED,
+  payload: errorUuid,
+});

--- a/src/store/actionTypes.js
+++ b/src/store/actionTypes.js
@@ -26,3 +26,6 @@ export const LOGOUT = 'LOGOUT';
 
 export const MODAL_OPEN = 'MODAL_OPEN';
 export const MODAL_CLOSE = 'MODAL_CLOSE';
+
+export const ERROR_DISPLAY = 'ERROR_DISPLAY';
+export const ERROR_DISMISSED = 'ERROR_DISMISSED';

--- a/src/store/reducers/errors.js
+++ b/src/store/reducers/errors.js
@@ -1,0 +1,36 @@
+import { ERROR_DISPLAY, ERROR_DISMISSED } from '../actionTypes';
+import uuid from 'uuid';
+
+const initialState = {
+  errors: [
+    // {
+    //   uuid: string,
+    //   message: string,
+    // },
+  ],
+  currentError: null, // null | object
+};
+
+const toError = payload => ({
+  uuid: uuid(),
+  message: String(payload.message ? payload.message : payload),
+});
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case ERROR_DISPLAY:
+      const newError = toError(action.payload);
+      return {
+        errors: state.errors.concat(newError),
+        currentError: state.currentError === null ? newError : state.currentError,
+      };
+    case ERROR_DISMISSED:
+      const filteredErrors = state.errors.filter(err => err.uuid !== action.payload);
+      return {
+        errors: filteredErrors,
+        currentError: filteredErrors[0] || null,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -4,10 +4,12 @@ import virtualStudies from './virtualStudies';
 import currentVirtualStudy from './currentVirtualStudy';
 import user from './user';
 import ui from './ui';
+import errors from './errors';
 
 export default combineReducers({
   virtualStudies,
   currentVirtualStudy,
   user,
   ui,
+  errors,
 });


### PR DESCRIPTION
This also adds the functionality of displaying an error alert from anywhere in the app, given that the standard header is displayed.