### PR TITLE
:lipstick: Override ant design styles for titles

### DIFF
--- a/src/antdTheme.less
+++ b/src/antdTheme.less
@@ -6,3 +6,10 @@
 */
 
 @layout-sider-background: #f4f5f8;
+
+@heading-color: #2b388f;
+//info: font-size-base: 14px;
+@heading-1-size: ceil(@font-size-base * 2);
+@heading-2-size: ceil(@font-size-base * 1.285);
+@heading-3-size: ceil(@font-size-base * 1);
+@typography-title-font-weight: 500;

--- a/src/components/MemberSearchPage/FilterDrawer.js
+++ b/src/components/MemberSearchPage/FilterDrawer.js
@@ -30,14 +30,7 @@ class FilterDrawer extends Component {
         <div style={{ height: 50, display: 'flex', padding: '15px 7px 15px 12px' }}>
           <Title
             level={2}
-            className={'h2-title'}
             style={{
-              fontFamily: 'Montserrat,sans-serif',
-              color: '#2b388f',
-              fontWeight: 500,
-              margin: 0,
-              padding: 0,
-              fontSize: 18,
               display: collapsed ? 'none' : 'block',
             }}
           >

--- a/src/components/MemberSearchPage/FilterTable.js
+++ b/src/components/MemberSearchPage/FilterTable.js
@@ -30,16 +30,10 @@ const FilterTable = props => {
         key={1}
         header={
           <Title
-            level={2}
+            level={3}
+            className={'filter-title'}
             style={{
-              color: 'rgb(43, 56, 143)',
               margin: 0,
-              padding: 0,
-              fontFamily: 'Montserrat, sans-serif',
-              textDecoration: 'none',
-              fontSize: 14,
-              fontWeight: 700,
-              textAlign: 'center',
               display: 'inline-flex',
             }}
           >

--- a/src/components/MemberSearchPage/MemberSearchBorder.js
+++ b/src/components/MemberSearchPage/MemberSearchBorder.js
@@ -8,24 +8,9 @@ const MemberSearchBorder = props => {
   return (
     <div className={'grid-container'}>
       <Row>
-        <Title
-          level={1}
-          style={{
-            color: '#2b388f',
-            margin: 0,
-            padding: 0,
-            fontWeight: 500,
-            lineHeight: 0.71,
-            letterSpacing: 0.4,
-            fontFamily: 'Montserrat, sans-serif',
-            textDecoration: 'none',
-            fontSize: 28,
-          }}
-        >
-          Kids First Membership
-        </Title>
+        <Title level={1}>Kids First Membership</Title>
       </Row>
-      <Row style={{ marginTop: 20 }}>
+      <Row>
         <Col span={24}>{props.children}</Col>
       </Row>
     </div>

--- a/src/components/MemberSearchPage/MemberSearchPage.css
+++ b/src/components/MemberSearchPage/MemberSearchPage.css
@@ -14,27 +14,6 @@
   margin: 20px;
 }
 
-.h1-title {
-    color: #2b388f;
-    margin: 0;
-    padding: 0;
-    font-weight: 500;
-    line-height: 0.71;
-    letter-spacing: 0.4px;
-    font-family: Montserrat, sans-serif;
-    text-decoration: none;
-    font-size: 28px;
-}
-
-.h2-title {
-    font-family: Montserrat,sans-serif;
-    color: #2b388f;
-    font-weight: 500;
-    margin: 0;
-    padding: 0;
-    font-size: 18px;
-}
-
 .interest-container {
   display: flex;
   align-items: baseline;

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,10 @@ a.primary {
   color: #90278e;
 }
 
+h3.filter-title {
+  font-weight: 700;
+}
+
 /* Temporary fix for the aggregation cards overflow */
 .aggregation-card span.bucket-link {
   max-width: 370px;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import 'babel-polyfill';
-import 'index.css';
-// import 'antd/dist/antd.css';
 import './antd-kf-theme.css';
+import 'index.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';


### PR DESCRIPTION
- Changed import order in Index.js so that our styles overrides Ant Design (not the other way around) 
- Updates Style for titles (H1-H2-H3) for Ant Design
