### PR TITLE
Use Antd "Notification" rather than "Alert" (member page, privacy swi…

### DIFF
--- a/src/components/UserProfile/HeaderBanner.js
+++ b/src/components/UserProfile/HeaderBanner.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Alert, Avatar, Button, Icon, Popconfirm, Row, Switch, Tooltip, Typography } from 'antd';
-import { userProfileBackground, getMsgFromAccessError } from './utils';
+import { Avatar, Button, Icon, Popconfirm, Row, Switch, Tooltip, Typography } from 'antd';
+import { userProfileBackground } from './utils';
 import PropTypes from 'prop-types';
 import { computeGravatarSrcFromEmail } from 'utils';
 import ProfilePill from 'uikit/ProfilePill';
@@ -16,7 +16,6 @@ const HeaderBanner = ({
   onChangePrivacyStatusCb,
   onChangeActivityStatusCb,
   isLoading,
-  error,
   canEdit,
   features,
   isAdmin,
@@ -107,19 +106,6 @@ const HeaderBanner = ({
               />
               <Text className={'hd-text'}>Public</Text>
             </Row>
-            {Boolean(error) && Object.keys(error).length > 0 && (
-              <Row>
-                <Alert
-                  message="Error"
-                  description={getMsgFromAccessError(
-                    error,
-                    'An error occurred while updating the profile',
-                  )}
-                  type="error"
-                  closable
-                />
-              </Row>
-            )}
           </div>
         )}
     </Row>
@@ -130,7 +116,6 @@ HeaderBanner.propTypes = {
   profile: PropTypes.object.isRequired,
   onChangePrivacyStatusCb: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  error: PropTypes.object,
   canEdit: PropTypes.bool.isRequired,
 };
 

--- a/src/components/UserProfile/HeaderBannerContainer.js
+++ b/src/components/UserProfile/HeaderBannerContainer.js
@@ -1,58 +1,79 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import {
+  selectErrorIsToggleProfileStatus,
   selectIsLoadingProfileStatus,
   selectProfile,
-  selectErrorIsToggleProfileStatus,
 } from '../../store/selectors/users';
-import { toggleIsPublic, toggleIsActive } from '../../store/actionCreators/user';
+import { cleanErrors, toggleIsActive, toggleIsPublic } from '../../store/actionCreators/user';
 import HeaderBanner from 'components/UserProfile/HeaderBanner';
+import { notification } from 'antd';
+import { getMsgFromAccessError } from './utils';
 
-class HeaderBannerContainer extends React.Component {
-  static propTypes = {
-    /** we must always have a non empty profile here */
-    profile: PropTypes.object,
-    onToggleIsPublic: PropTypes.func.isRequired,
-    onToggleIsActive: PropTypes.func.isRequired,
-    isLoading: PropTypes.bool.isRequired,
-    error: PropTypes.object,
-    canEdit: PropTypes.bool.isRequired,
-    isAdmin: PropTypes.bool.isRequired,
-  };
+const HeaderBannerContainer = props => {
+  const {
+    isLoading,
+    error,
+    profile,
+    canEdit,
+    isAdmin,
+    onCleanErrors,
+    onToggleIsPublic,
+    onToggleIsActive,
+  } = props;
+  useEffect(() => {
+    if (error) {
+      /**
+       * FIXME:
+       *  This notification should not be the responsibility of this component.
+       *  When a global notification system will be implemented remove this effect from this component
+       *  and let it manage this notification.
+       * */
+      notification.error({
+        message: 'Error',
+        description: getMsgFromAccessError(error, 'An error occurred while updating the profile'),
+        duration: 10, //[sec]
+        onClose: () => onCleanErrors(),
+      });
+    }
+  }, [error]);
 
-  onChangePrivacyStatus = () => {
-    const { profile, onToggleIsPublic } = this.props;
-    onToggleIsPublic({
-      ...profile,
-      ...{ isPublic: !profile.isPublic },
-    });
-  };
+  return (
+    <HeaderBanner
+      onChangePrivacyStatusCb={() =>
+        onToggleIsPublic({
+          ...profile,
+          ...{ isPublic: !profile.isPublic },
+        })
+      }
+      onChangeActivityStatusCb={() =>
+        onToggleIsActive({
+          ...profile,
+          ...{ isActive: !profile.isActive },
+        })
+      }
+      profile={profile}
+      isLoading={isLoading}
+      error={error}
+      canEdit={canEdit}
+      isAdmin={isAdmin}
+    />
+  );
+};
 
-  onChangeActivityStatus = () => {
-    const { profile, onToggleIsActive } = this.props;
-    onToggleIsActive({
-      ...profile,
-      ...{ isActive: !profile.isActive },
-    });
-  };
-
-  render() {
-    const { isLoading, error, profile, canEdit, isAdmin } = this.props;
-    return (
-      <HeaderBanner
-        onChangePrivacyStatusCb={this.onChangePrivacyStatus}
-        onChangeActivityStatusCb={this.onChangeActivityStatus}
-        profile={profile}
-        isLoading={isLoading}
-        error={error}
-        canEdit={canEdit}
-        isAdmin={isAdmin}
-      />
-    );
-  }
-}
+HeaderBannerContainer.propTypes = {
+  /** we must always have a non empty profile here */
+  profile: PropTypes.object,
+  onToggleIsPublic: PropTypes.func.isRequired,
+  onToggleIsActive: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  error: PropTypes.object,
+  canEdit: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+  onCleanErrors: PropTypes.func.isRequired,
+};
 
 const mapStateToProps = state => ({
   profile: selectProfile(state),
@@ -64,6 +85,7 @@ const mapDispatchToProps = dispatch => {
   return {
     onToggleIsPublic: profile => dispatch(toggleIsPublic(profile)),
     onToggleIsActive: profile => dispatch(toggleIsActive(profile)),
+    onCleanErrors: () => dispatch(cleanErrors()),
   };
 };
 


### PR DESCRIPTION
…tch):

The "Alert" component was breaking the layout. Andt notification is global and does not affect the layout.
Secondly, show notification every time an error is thrown when trying to toggle (before it was only shown once)
Eventually, the notification will have to be extracted from the component and be managed globally by the app.