### PR TITLE
2995 fix card header

### DIFF
--- a/src/components/CohortBuilder/Summary/Cards/AgeDiagChart.js
+++ b/src/components/CohortBuilder/Summary/Cards/AgeDiagChart.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import Card from '@ferlab/ui/core/view/GridCard';
 import Empty, { SIZE } from 'components/UI/Empty';
 
-const CHART_HEIGHT_PX = 350;
+const CHART_HEIGHT_PX = 320;
 
 const ageAtDiagnosisTooltip = (data) =>
   `${data.value.toLocaleString()} Participant${data.value > 1 ? 's' : ''}`;

--- a/src/components/CohortBuilder/Summary/Cards/SurvivalChart.js
+++ b/src/components/CohortBuilder/Summary/Cards/SurvivalChart.js
@@ -223,7 +223,7 @@ export class SurvivalChart extends React.Component {
 
     return (
       <Card title={Header} loading={this.state.isLoading}>
-        <SurvivalCardContent>{renderGraphContent(330, 325)}</SurvivalCardContent>
+        <SurvivalCardContent>{renderGraphContent(300, 295)}</SurvivalCardContent>
       </Card>
     );
   }

--- a/src/components/CohortBuilder/Summary/Summary.css
+++ b/src/components/CohortBuilder/Summary/Summary.css
@@ -29,27 +29,6 @@
   grid-column: span 2;
 }
 
-.ant-card-head-title {
-  padding: 0;
-}
-
-.ant-card-head {
-  padding: 0;
-}
-
-.ant-card-head-title > h3 {
-  font-weight: 600;
-  font-size: 20px;
-  line-height: 28px;
-}
-
-.ant-card.core-grid-card {
-  display: flex;
-  flex-direction: column;
-  min-height: 325px;
-  height: 400px;
-}
-
 .core-grid-card .ant-card-head {
   margin: 2px 20px;
 }

--- a/src/components/CohortBuilder/Summary/index.js
+++ b/src/components/CohortBuilder/Summary/index.js
@@ -63,7 +63,7 @@ const Summary = ({
               title={<span className={'title-summary-card'}>Observed Phenotypes</span>}
               classNameCardItem={'ontology-sunburst-card'}
             >
-              <OntologySunburst sqon={sqon} />
+              <OntologySunburst sqon={sqon} height={260} width={260} />
             </Card>
             <DiagnosesChart
               api={api}

--- a/src/components/UI/Charts/Sunburst/sunburst.css
+++ b/src/components/UI/Charts/Sunburst/sunburst.css
@@ -47,7 +47,7 @@
   padding-left: 8px;
   padding-right: 8px;
   text-align: center;
-  height: 160px;
+  height: 100%;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
summary css is leaking on all the site and override what should be theme based.

Validated with design we should use ant design default card header height. Fix height specificaly where needed.

<img width="1710" alt="Screen Shot 2021-03-23 at 6 47 09 PM" src="https://user-images.githubusercontent.com/98903/112194292-fdc36480-8c08-11eb-92ef-0c82071462f6.png">
<img width="1956" alt="Screen Shot 2021-03-23 at 6 47 40 PM" src="https://user-images.githubusercontent.com/98903/112194299-ff8d2800-8c08-11eb-86fe-fc6fdb87581c.png">
