### PR TITLE
fix table header right aligment

### DIFF
--- a/src/pages/variantsSearchPage/VariantTable.module.scss
+++ b/src/pages/variantsSearchPage/VariantTable.module.scss
@@ -34,6 +34,6 @@
 }
 
 .tableCellAlignRight {
-  text-align: end;
+  text-align: end !important;
   white-space: nowrap;
 }


### PR DESCRIPTION
I know there is an `!important` But the way the ant design work, I can't see how I can do without in that context.