### PR TITLE
fix: #3089 table alignment accros tables

### DIFF
--- a/src/pages/variantEntity/TabFrequencies.tsx
+++ b/src/pages/variantEntity/TabFrequencies.tsx
@@ -91,21 +91,25 @@ const internalColumns = (
     title: 'ALT Allele',
     dataIndex: 'frequencies',
     render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.ac,
+    width: '14%',
   },
   {
     title: 'Alleles (ALT + REF)',
     dataIndex: 'frequencies',
     render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.an,
+    width: '14%',
   },
   {
     title: 'Homozygote',
     dataIndex: 'frequencies',
     render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.homozygotes,
+    width: '14%',
   },
   {
     title: 'Frequency',
     dataIndex: 'frequencies',
     render: (frequencies: FreqInternal) => toExponentialNotation(frequencies?.upper_bound_kf?.af),
+    width: '14%',
   },
 ];
 
@@ -128,18 +132,22 @@ const externalColumns = [
   {
     title: 'ALT Allele',
     dataIndex: 'alt',
+    width: '14%',
   },
   {
     title: 'Alleles (ALT + REF)',
     dataIndex: 'altRef',
+    width: '14%',
   },
   {
     title: 'Homozygote',
     dataIndex: 'homozygotes',
+    width: '14%',
   },
   {
     title: 'Frequency',
     dataIndex: 'frequency',
+    width: '14%',
   },
 ];
 

--- a/src/pages/variantEntity/TabSummary.tsx
+++ b/src/pages/variantEntity/TabSummary.tsx
@@ -98,6 +98,7 @@ const columns = [
   {
     title: 'AA',
     dataIndex: 'aa',
+    width: '10%',
   },
   {
     title: 'Consequence',
@@ -117,6 +118,7 @@ const columns = [
         />
       );
     },
+    width: '25%',
   },
   {
     title: 'Coding Dna',

--- a/src/pages/variantEntity/clinical.tsx
+++ b/src/pages/variantEntity/clinical.tsx
@@ -163,10 +163,12 @@ export const columnsClinVar = [
   {
     title: 'Condition',
     dataIndex: 'condition',
+    width: '25%',
   },
   {
     title: 'Inheritance',
     dataIndex: 'inheritance',
+    width: '25%',
   },
 ];
 
@@ -274,6 +276,7 @@ export const columnsPhenotypes = [
       const comicCondition = record.condition as CosmicCondition;
       return <ExpandableCell dataSource={comicCondition} />;
     },
+    width: '25%',
   },
   {
     title: 'Inheritance',
@@ -289,5 +292,6 @@ export const columnsPhenotypes = [
       }
       return record.inheritance;
     },
+    width: '25%',
   },
 ];


### PR DESCRIPTION
closes #3089 

![Screen Shot 2021-04-13 at 5 15 24 PM](https://user-images.githubusercontent.com/98903/114577275-296fc280-9c7c-11eb-8139-95199d60f9e6.png)
![Screen Shot 2021-04-13 at 5 15 32 PM](https://user-images.githubusercontent.com/98903/114577286-2aa0ef80-9c7c-11eb-9734-46545b23d88d.png)
![Screen Shot 2021-04-13 at 5 15 37 PM](https://user-images.githubusercontent.com/98903/114577290-2b398600-9c7c-11eb-8a18-658f9d1de50f.png)
![Screen Shot 2021-04-13 at 5 22 24 PM](https://user-images.githubusercontent.com/98903/114579038-c67f2b00-9c7d-11eb-9168-f3cedd383906.png)