### PR TITLE
fix: #3092 variant tag match default theme color

### DIFF
--- a/src/pages/variantEntity/TabSummary.tsx
+++ b/src/pages/variantEntity/TabSummary.tsx
@@ -9,11 +9,10 @@ import TabError from './TabError';
 import ExpandableCell from 'components/ExpandableCell';
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import capitalize from 'lodash/capitalize';
-import style from 'style/themes/default/_colors.scss';
 import ExpandableTable from 'components/ExpandableTable';
+import { filterThanSortConsequencesByImpact } from 'components/Variants/consequences';
 
 import styles from './tables.module.scss';
-import { filterThanSortConsequencesByImpact } from 'components/Variants/consequences';
 
 const { Text } = Typography;
 
@@ -138,7 +137,7 @@ const columns = [
     dataIndex: 'vep',
     render: (vep: Impact) => {
       const loweredCaseVep = vep.toLowerCase();
-      return <Tag color={style[`${loweredCaseVep}Impact`]}>{capitalize(loweredCaseVep)}</Tag>;
+      return <Tag className={`${loweredCaseVep}Impact`}>{capitalize(loweredCaseVep)}</Tag>;
     },
     width: 120,
   },

--- a/src/style/dist/themes/default/_colors.scss
+++ b/src/style/dist/themes/default/_colors.scss
@@ -28,7 +28,9 @@ $green-6: #52c41a;
 $green-8: #237804;
 
 // ORANGE
+$orange-2: #ffebc7;
 $orange-5: #f79122;
+$orange-9: #853700;
 
 // PURPLE
 $purple-2: #e6bddc;
@@ -37,6 +39,10 @@ $purple-6: #a6278f;
 // RED
 $red-5: #dd1f2a;
 $red-8: #910616;
+
+// MAGENTA
+$magenta-2: #ffe3ee;
+$magenta-8: #991765;
 
 $layout-bg-base: #f4f5f8;
 $layout-sider-background: $gray-3;

--- a/src/style/dist/themes/default/antd.css
+++ b/src/style/dist/themes/default/antd.css
@@ -24888,6 +24888,22 @@ div.ant-typography-edit-content.ant-typography-rtl {
   line-height: 20px;
   font-weight: 400;
 }
+.ant-tag.highImpact {
+  background-color: #ffe3ee;
+  color: #991765;
+}
+.ant-tag.lowImpact {
+  background-color: #d9f7be;
+  color: #237804;
+}
+.ant-tag.moderateImpact {
+  background-color: #ffebc7;
+  color: #853700;
+}
+.ant-tag.modifierImpact {
+  background-color: #eaeaec;
+  color: #383f72;
+}
 body {
   background-color: #f3f4f6;
 }

--- a/src/style/themes/default/_colors.scss
+++ b/src/style/themes/default/_colors.scss
@@ -16,12 +16,6 @@ $greyScale11: #a9adc0;
   //Badge
   badgeNewColor: $badge-new-color;
 
-  //Impacts (variants)
-  highImpact: $red-5;
-  lowImpact: $green-6;
-  moderateImpact: $orange-5;
-  modifierImpact: $body-3;
-
   //Icons
   iconColor: $body-1;
 }

--- a/src/style/themes/default/antd/_colors.less
+++ b/src/style/themes/default/antd/_colors.less
@@ -28,7 +28,9 @@
 @green-8: #237804;
 
 // ORANGE
+@orange-2: #ffebc7;
 @orange-5: #f79122;
+@orange-9: #853700;
 
 // PURPLE
 @purple-2: #e6bddc;
@@ -37,6 +39,10 @@
 // RED
 @red-5: #dd1f2a;
 @red-8: #910616;
+
+// MAGENTA
+@magenta-2: #ffe3ee;
+@magenta-8: #991765;
 
 @layout-bg-base: #f4f5f8;
 @layout-sider-background: @gray-3;

--- a/src/style/themes/default/antd/tag.less
+++ b/src/style/themes/default/antd/tag.less
@@ -4,4 +4,24 @@
   height: fit-content;
   line-height: 20px;
   font-weight: 400;
+
+  &.highImpact {
+    background-color: @magenta-2;
+    color: @magenta-8;
+  }
+
+  &.lowImpact {
+    background-color: @green-2;
+    color: @green-8;
+  }
+
+  &.moderateImpact {
+    background-color: @orange-2;
+    color: @orange-9;
+  }
+
+  &.modifierImpact {
+    background-color: @gray-4;
+    color: @body-1;
+  }
 }


### PR DESCRIPTION
closes #3092 

![Screen Shot 2021-04-13 at 6 29 58 PM](https://user-images.githubusercontent.com/98903/114587844-532de700-9c86-11eb-8614-37c2bef3abdf.png)


![Screen Shot 2021-04-13 at 6 33 34 PM](https://user-images.githubusercontent.com/98903/114588464-01d22780-9c87-11eb-80d7-eb9c6cb31a68.png)
![Screen Shot 2021-04-13 at 6 33 58 PM](https://user-images.githubusercontent.com/98903/114588468-026abe00-9c87-11eb-9f71-6405f84e33bf.png)
