### PR TITLE
make sure to add url when cluster is ready

### DIFF
--- a/src/pages/variantsSearchPage/WorkBench.tsx
+++ b/src/pages/variantsSearchPage/WorkBench.tsx
@@ -14,7 +14,12 @@ import {
   isClusterStatusIdling,
   isClusterStatusInProgress,
 } from 'store/WorkBenchTypes';
-import { selectIsLoading, selectError, selectStatus } from 'store/selectors/workBench';
+import {
+  selectIsLoading,
+  selectError,
+  selectStatus,
+  selectClusterUrl,
+} from 'store/selectors/workBench';
 import {
   getStatus,
   reInitializeState,
@@ -34,6 +39,7 @@ const mapState = (state: RootState) => ({
   isLoadingStatus: selectIsLoading(state),
   error: selectError(state),
   status: selectStatus(state),
+  url: selectClusterUrl(state),
 });
 
 const mapDispatch = (dispatch: DispatchWorkBench) => ({
@@ -64,6 +70,7 @@ const WorkBench = (props: Props) => {
     onStopCluster,
     onReInitializeState,
     isAllowed,
+    url,
   } = props;
 
   useInterval(
@@ -94,12 +101,11 @@ const WorkBench = (props: Props) => {
           </Paragraph>
           <div>
             {!error && showSwitch(status) && (
-              <Space>
+              <Space size={'middle'}>
                 <Switch
                   disabled={!isAllowed}
                   checked={status === ClusterApiStatus.createComplete}
                   loading={isLoadingStatus}
-                  size={'small'}
                   onChange={(switchIsOn: boolean) =>
                     switchIsOn ? onStartCluster() : onStopCluster()
                   }
@@ -108,6 +114,11 @@ const WorkBench = (props: Props) => {
                 />
                 {!isAllowed && (
                   <Text disabled>Currently available for Kids First investigators only.</Text>
+                )}
+                {url && (
+                  <Button href={url} target="_blank" rel="noopener noreferrer" type={'link'}>
+                    Access your SPARK cluster
+                  </Button>
                 )}
               </Space>
             )}

--- a/src/store/WorkBenchTypes.ts
+++ b/src/store/WorkBenchTypes.ts
@@ -30,6 +30,7 @@ export enum WorkBenchActions {
   failure = 'FailureAction',
   toggleLoading = 'ToggleLoadingAction',
   reInitialize = 'ReInitializeAction',
+  addClusterUrl = 'AddClusterUrlAction',
 }
 
 type reInitializeStateAction = {
@@ -59,10 +60,16 @@ type ToggleLoadingAction = {
   isLoading: boolean;
 };
 
+type AddClusterUrl = {
+  type: WorkBenchActions.addClusterUrl;
+  url: string;
+};
+
 export type WorkBenchState = {
   isLoading: boolean;
   error: Error | null | undefined;
   status: ClusterStatus;
+  url: string | null | undefined;
 };
 
 export type WorkBenchActionTypes =
@@ -71,6 +78,7 @@ export type WorkBenchActionTypes =
   | ToggleLoadingAction
   | StartClusterAction
   | DeleteClusterAction
+  | AddClusterUrl
   | reInitializeStateAction;
 
 export type DispatchWorkBench = ThunkDispatch<RootState, null, WorkBenchActionTypes>;

--- a/src/store/actionCreators/workBench.ts
+++ b/src/store/actionCreators/workBench.ts
@@ -1,4 +1,9 @@
-import { ClusterStatus, WorkBenchActions, WorkBenchActionTypes } from '../WorkBenchTypes';
+import {
+  ClusterApiStatus,
+  ClusterStatus,
+  WorkBenchActions,
+  WorkBenchActionTypes,
+} from '../WorkBenchTypes';
 import { ThunkAction } from 'redux-thunk';
 import { RootState } from '../rootState';
 import {
@@ -20,6 +25,11 @@ const failure = (error: Error): WorkBenchActionTypes => ({
 const addStatus = (status: ClusterStatus): WorkBenchActionTypes => ({
   type: WorkBenchActions.addClusterStatus,
   status,
+});
+
+const addClusterUrl = (url: string): WorkBenchActionTypes => ({
+  type: WorkBenchActions.addClusterUrl,
+  url,
 });
 
 const switchCluster = (
@@ -50,6 +60,10 @@ export const getStatus = (): ThunkAction<void, RootState, null, WorkBenchActionT
     const response = await getClusterStatus();
     const clusterStatus = response.status as ClusterStatus;
     dispatch(addStatus(clusterStatus));
+    const url = response.url;
+    if (clusterStatus === ClusterApiStatus.createComplete && url) {
+      dispatch(addClusterUrl(url));
+    }
   } catch (e) {
     dispatch(failure(e));
   } finally {

--- a/src/store/reducers/workbench.ts
+++ b/src/store/reducers/workbench.ts
@@ -9,6 +9,7 @@ const initialState: WorkBenchState = {
   isLoading: false,
   error: null,
   status: ClusterUnverifiedStatus.unverified,
+  url: null,
 };
 
 export default (state = initialState, action: WorkBenchActionTypes): WorkBenchState => {
@@ -24,6 +25,9 @@ export default (state = initialState, action: WorkBenchActionTypes): WorkBenchSt
     }
     case WorkBenchActions.reInitialize: {
       return { ...initialState };
+    }
+    case WorkBenchActions.addClusterUrl: {
+      return { ...state, url: action.url };
     }
     default:
       return state;

--- a/src/store/selectors/workBench.ts
+++ b/src/store/selectors/workBench.ts
@@ -3,3 +3,4 @@ import { RootState } from '../rootState';
 export const selectIsLoading = (state: RootState) => state.workBench.isLoading;
 export const selectStatus = (state: RootState) => state.workBench.status;
 export const selectError = (state: RootState) => state.workBench.error;
+export const selectClusterUrl = (state: RootState) => state.workBench.url;


### PR DESCRIPTION
Test Suites: 26 passed, 26 total
Tests:       153 passed, 153 total
Snapshots:   1 passed, 1 total
Time:        4.645s, estimated 7s
Ran all test suites.

Watch Usage: Press w to show more.

![screenshotLocalDevAccessSparkCluster](https://user-images.githubusercontent.com/54366437/114763880-4e723d00-9d31-11eb-9b17-91ec78aad9fc.png)
