### PR TITLE
feat: #2905 improve spark cluster session management

### DIFF
--- a/src/pages/variantsSearchPage/WorkBench.tsx
+++ b/src/pages/variantsSearchPage/WorkBench.tsx
@@ -8,11 +8,11 @@ import { RootState } from 'store/rootState';
 import { connect, ConnectedProps } from 'react-redux';
 import {
   ClusterStatus,
-  ClusterApiStatus,
   ClusterUnverifiedStatus,
   DispatchWorkBench,
   isClusterStatusIdling,
   isClusterStatusInProgress,
+  isClusterRunning,
 } from 'store/WorkBenchTypes';
 import {
   selectIsLoading,
@@ -78,7 +78,9 @@ const WorkBench = (props: Props) => {
       onGetStatus();
     },
     // Delay in milliseconds or null to stop it
-    isClusterStatusInProgress(status) ? POLLING_DELAY_IN_MS : STOP_POLLING,
+    isClusterStatusInProgress(status) || isClusterRunning(status)
+      ? POLLING_DELAY_IN_MS
+      : STOP_POLLING,
   );
 
   useEffect(() => {
@@ -104,7 +106,7 @@ const WorkBench = (props: Props) => {
               <Space size={'middle'}>
                 <Switch
                   disabled={!isAllowed}
-                  checked={status === ClusterApiStatus.createComplete}
+                  checked={isClusterRunning(status)}
                   loading={isLoadingStatus}
                   onChange={(switchIsOn: boolean) =>
                     switchIsOn ? onStartCluster() : onStopCluster()

--- a/src/store/WorkBenchTypes.ts
+++ b/src/store/WorkBenchTypes.ts
@@ -23,6 +23,9 @@ export const isClusterStatusIdling = (status: ClusterStatus) =>
 export const isClusterStatusInProgress = (status: ClusterStatus) =>
   status === ClusterApiStatus.deleteInProgress || status === ClusterApiStatus.createInProgress;
 
+export const isClusterRunning = (status: ClusterStatus) =>
+  status === ClusterApiStatus.createComplete;
+
 export enum WorkBenchActions {
   startCluster = 'StartClusterAction',
   addClusterStatus = 'AddClusterStatusAction',

--- a/src/store/actionCreators/workBench.ts
+++ b/src/store/actionCreators/workBench.ts
@@ -1,6 +1,6 @@
 import {
-  ClusterApiStatus,
   ClusterStatus,
+  isClusterRunning,
   WorkBenchActions,
   WorkBenchActionTypes,
 } from '../WorkBenchTypes';
@@ -61,7 +61,7 @@ export const getStatus = (): ThunkAction<void, RootState, null, WorkBenchActionT
     const clusterStatus = response.status as ClusterStatus;
     dispatch(addStatus(clusterStatus));
     const url = response.url;
-    if (clusterStatus === ClusterApiStatus.createComplete && url) {
+    if (isClusterRunning(clusterStatus) && url) {
       dispatch(addClusterUrl(url));
     }
   } catch (e) {


### PR DESCRIPTION
Modify the code to continue pinging even after the cluster is up because when it shuts down, we want to switch back the button to it's original state "Start cluster".