### PR TITLE
Fix studies freq tab

### DIFF
--- a/src/pages/variantEntity/TabFrequencies.tsx
+++ b/src/pages/variantEntity/TabFrequencies.tsx
@@ -9,7 +9,7 @@ import {
   Study,
   StudyInfo,
 } from 'store/graphql/variants/models';
-import { toExponentialNotation } from 'utils';
+import { formatQuotientOrElse, toExponentialNotation } from 'utils';
 import { createQueryInCohortBuilder, DispatchStoryPage } from 'store/actionCreators/studyPage';
 import { Sqon } from 'store/sqon';
 import { RootState } from 'store/rootState';
@@ -19,6 +19,10 @@ import { addToSqons } from 'common/sqonUtils';
 import ServerError from 'components/Variants/ServerError';
 
 import style from '../variantsSearchPage/VariantTable.module.scss';
+import TableSummaryKfStudies from './TableSummaryKfStudies';
+import { Align } from 'ui/types';
+
+const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
 
 type OwnProps = {
   variantId: string;
@@ -28,10 +32,17 @@ type FrequencyTabTableContainerState = {
   currentVirtualStudy: Sqon[];
 };
 
-const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
+type InternalRow = {
+  frequencies: FreqInternal;
+  key: string;
+  participantTotalNumber: number;
+  participant_ids: null | string[];
+  participant_number: number;
+  study_id: string;
+};
 
 const internalColumns = (
-  studiesInfo: StudyInfo[],
+  globalStudies: StudyInfo[],
   onLinkClick: (sqons: Sqon[]) => void,
   sqons: Sqon[],
 ) => [
@@ -39,31 +50,34 @@ const internalColumns = (
     title: 'Studies',
     dataIndex: 'study_id',
     // eslint-disable-next-line react/display-name
-    render: (study_id: string) => {
-      const study = studiesInfo.find((s) => s.id === study_id);
-      return study?.code || study_id;
+    render: (variantStudyId: string) => {
+      const study = globalStudies.find((s) => s.id === variantStudyId);
+      return study?.code || variantStudyId;
     },
   },
   {
     title: 'Domain',
     dataIndex: 'study_id',
     // eslint-disable-next-line react/display-name
-    render: (study_id: string) => {
-      const study = studiesInfo.find((s) => s.id === study_id);
+    render: (variantStudyId: string) => {
+      const study = globalStudies.find((s) => s.id === variantStudyId);
       return study?.domain.join(', ') || '';
     },
   },
   {
     title: '# Participants',
-    dataIndex: 'participant_number',
+    dataIndex: '',
     // eslint-disable-next-line react/display-name
-    render: (participant_number: string, row: any) =>
-      parseInt(participant_number) >= MIN_N_OF_PARTICIPANTS_FOR_LINK ? (
+    render: (row: InternalRow) => {
+      const participantsNumber = row.participant_number;
+      const participantsTotal = row.participantTotalNumber;
+
+      return participantsNumber && participantsNumber >= MIN_N_OF_PARTICIPANTS_FOR_LINK ? (
         <Link
           to={'/explore'}
           href={'#top'}
           onClick={() => {
-            const study = studiesInfo.find((s) => s.id === row.study_id);
+            const study = globalStudies.find((s) => s.id === row.study_id);
             if (study) {
               onLinkClick(
                 addToSqons({
@@ -77,35 +91,28 @@ const internalColumns = (
           }}
         >
           <Button type="link">
-            <div className={style.variantTableLink}>{participant_number}</div>
+            <div className={style.variantTableLink}>
+              {formatQuotientOrElse(participantsNumber, participantsTotal)}
+            </div>
           </Button>
         </Link>
       ) : (
-        participant_number
-      ),
+        formatQuotientOrElse(participantsNumber, participantsTotal)
+      );
+    },
   },
   {
-    title: 'ALT Allele',
+    title: 'ALT Alleles',
     dataIndex: 'frequencies',
+    align: Align.center,
     render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.ac,
     width: '14%',
   },
   {
-    title: 'Alleles (ALT + REF)',
+    title: 'Homozygotes',
     dataIndex: 'frequencies',
-    render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.an,
-    width: '14%',
-  },
-  {
-    title: 'Homozygote',
-    dataIndex: 'frequencies',
+    align: Align.center,
     render: (frequencies: FreqInternal) => frequencies?.upper_bound_kf?.homozygotes,
-    width: '14%',
-  },
-  {
-    title: 'Frequency',
-    dataIndex: 'frequencies',
-    render: (frequencies: FreqInternal) => toExponentialNotation(frequencies?.upper_bound_kf?.af),
     width: '14%',
   },
 ];
@@ -234,17 +241,16 @@ const TabFrequencies = (props: Props) => {
     return <ServerError />;
   }
 
-  const { studies, frequencies, dataStudies, locus } = data;
+  const {
+    variantStudies,
+    frequencies,
+    globalStudies,
+    locus,
+    participantTotalNumber,
+    participantNumber,
+  } = data;
 
   const internalFrequencies: FreqCombined | undefined = data?.frequencies?.internal?.upper_bound_kf;
-
-  const hasParticipantLink: boolean = studies.some(
-    (s: Study) => s.participant_number >= MIN_N_OF_PARTICIPANTS_FOR_LINK,
-  );
-
-  const allParticipants: string[] = [].concat(
-    ...studies.map((s: Study) => s.participant_ids || []),
-  );
 
   return (
     <Spin spinning={loading}>
@@ -252,49 +258,22 @@ const TabFrequencies = (props: Props) => {
         <Space direction={'vertical'} size={'large'}>
           <Card title="Kids First Studies">
             <Table
-              dataSource={makeInternalCohortsRows(studies)}
+              dataSource={makeInternalCohortsRows(variantStudies)}
               columns={internalColumns(
-                dataStudies,
+                globalStudies,
                 props.onClickStudyLink,
                 props.currentVirtualStudy,
               )}
               summary={() => (
-                <Table.Summary.Row>
-                  <Table.Summary.Cell index={0}>Total</Table.Summary.Cell>
-                  <Table.Summary.Cell index={1}>{''}</Table.Summary.Cell>
-                  <Table.Summary.Cell index={2}>
-                    {hasParticipantLink ? (
-                      <Link
-                        to={'/explore'}
-                        href={'#top'}
-                        onClick={() => {
-                          props.onClickStudyLink(
-                            addToSqons({
-                              fieldsWValues: [{ field: 'kf_id', value: allParticipants }],
-                              sqons: props.currentVirtualStudy,
-                            }),
-                          );
-                          const toTop = document.getElementById('main-page-container');
-                          toTop?.scrollTo(0, 0);
-                        }}
-                      >
-                        <Button type="link">
-                          <div className={style.variantTableLink}>{data?.participant_number}</div>
-                        </Button>
-                      </Link>
-                    ) : (
-                      data?.participant_number
-                    )}
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={3}>{internalFrequencies?.ac}</Table.Summary.Cell>
-                  <Table.Summary.Cell index={4}>{internalFrequencies?.an}</Table.Summary.Cell>
-                  <Table.Summary.Cell index={5}>
-                    {internalFrequencies?.homozygotes}
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={6}>
-                    {toExponentialNotation(internalFrequencies?.af)}
-                  </Table.Summary.Cell>
-                </Table.Summary.Row>
+                <TableSummaryKfStudies
+                  variantStudies={variantStudies}
+                  onClickStudyLink={props.onClickStudyLink}
+                  currentVirtualStudy={props.currentVirtualStudy}
+                  participantNumber={participantNumber}
+                  altAlleles={internalFrequencies?.ac}
+                  homozygotes={internalFrequencies?.homozygotes}
+                  participantTotalNumber={participantTotalNumber}
+                />
               )}
               pagination={false}
             />

--- a/src/pages/variantEntity/TableSummaryKfStudies.tsx
+++ b/src/pages/variantEntity/TableSummaryKfStudies.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Button, Table } from 'antd';
+import { Link } from 'react-router-dom';
+import { addToSqons } from '../../common/sqonUtils';
+import style from '../variantsSearchPage/VariantTable.module.scss';
+import { Study } from 'store/graphql/variants/models';
+import { Sqon } from 'store/sqon';
+import { formatQuotientOrElse } from 'utils';
+import { Align } from 'ui/types';
+
+type EnhancedVariantStudy = Study & { participantTotalNumber: number };
+
+type OwnProps = {
+  variantStudies: EnhancedVariantStudy[];
+  onClickStudyLink: (sqons: Sqon[]) => void;
+  currentVirtualStudy: Sqon[];
+  participantNumber: number;
+  altAlleles: number | undefined;
+  homozygotes: number | undefined;
+  participantTotalNumber: number | undefined;
+};
+
+const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
+
+const TableSummaryKfStudies = (props: OwnProps) => {
+  const {
+    variantStudies,
+    onClickStudyLink,
+    currentVirtualStudy,
+    participantNumber,
+    altAlleles,
+    homozygotes,
+    participantTotalNumber,
+  } = props;
+  const hasParticipantLink: boolean = variantStudies.some(
+    (s: Study) => s.participant_number >= MIN_N_OF_PARTICIPANTS_FOR_LINK,
+  );
+
+  const allParticipants: string[] = [
+    ...variantStudies.map((s: EnhancedVariantStudy) => s.participant_ids || []),
+  ].flat();
+
+  return (
+    <Table.Summary.Row>
+      <Table.Summary.Cell index={0}>Total</Table.Summary.Cell>
+      <Table.Summary.Cell index={1}>{''}</Table.Summary.Cell>
+      <Table.Summary.Cell index={2}>
+        {hasParticipantLink ? (
+          <Link
+            to={'/explore'}
+            href={'#top'}
+            onClick={() => {
+              onClickStudyLink(
+                addToSqons({
+                  fieldsWValues: [{ field: 'kf_id', value: allParticipants }],
+                  sqons: currentVirtualStudy,
+                }),
+              );
+              const toTop = document.getElementById('main-page-container');
+              toTop?.scrollTo(0, 0);
+            }}
+          >
+            <Button type="link">
+              <div className={style.variantTableLink}>
+                {formatQuotientOrElse(participantNumber, participantTotalNumber)}
+              </div>
+            </Button>
+          </Link>
+        ) : (
+          formatQuotientOrElse(participantNumber, participantTotalNumber)
+        )}
+      </Table.Summary.Cell>
+      <Table.Summary.Cell align={Align.center} index={3}>
+        {altAlleles}
+      </Table.Summary.Cell>
+      <Table.Summary.Cell align={Align.center} index={4}>
+        {homozygotes}
+      </Table.Summary.Cell>
+    </Table.Summary.Row>
+  );
+};
+
+export default TableSummaryKfStudies;

--- a/src/pages/variantsSearchPage/VariantTable.tsx
+++ b/src/pages/variantsSearchPage/VariantTable.tsx
@@ -27,6 +27,7 @@ import { formatQuotientOrElse, generatePaginationMessage } from 'utils';
 import ServerError from 'components/Variants/ServerError';
 import ROUTES from 'common/routes';
 import style from './VariantTable.module.scss';
+import { Align } from 'ui/types';
 
 const DEFAULT_PAGE_NUM = 1;
 const DEFAULT_PAGE_SIZE = 10;
@@ -35,12 +36,6 @@ const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
 type VariantTableState = {
   currentSqons: Sqon[];
 };
-
-enum Align {
-  center = 'center',
-  left = 'left',
-  right = 'right',
-}
 
 const isEven = (n: number) => n % 2 === 0;
 

--- a/src/store/graphql/variants/queries.tsx
+++ b/src/store/graphql/variants/queries.tsx
@@ -153,6 +153,10 @@ export const TAB_FREQUENCIES_QUERY = gql`
                 }
               }
             }
+            participant_number
+            participant_number_visible
+            participant_total_number
+            participant_frequency
             studies {
               hits {
                 edges {

--- a/src/store/graphql/variants/tabActions.tsx
+++ b/src/store/graphql/variants/tabActions.tsx
@@ -20,10 +20,15 @@ export const useTabFrequenciesData = (variantId: string) => {
     data: {
       frequencies: nodeVariant?.frequencies || {},
       locus: nodeVariant?.locus || '',
-      studies: nodeVariant?.studies?.hits?.edges.map((e: StudyNode) => e.node) || [],
-      participant_number: nodeVariant?.participant_number || 0,
+      variantStudies:
+        nodeVariant?.studies?.hits?.edges.map((e: StudyNode) => ({
+          ...e.node,
+          participantTotalNumber: nodeVariant?.participant_total_number || 0,
+        })) || [],
+      participantTotalNumber: nodeVariant?.participant_total_number || 0,
+      participantNumber: nodeVariant?.participant_number || 0,
       participant_ids: nodeVariant?.participant_ids || [],
-      dataStudies: nodesStudies?.map((n: { node: any }) => n.node),
+      globalStudies: nodesStudies?.map((n: StudyNode) => n.node),
     },
     error,
   };

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,0 +1,5 @@
+export enum Align {
+  center = 'center',
+  left = 'left',
+  right = 'right',
+}


### PR DESCRIPTION
`npm run test `(bypass circle-ci if needed):
```
Test Suites: 27 passed, 27 total
Tests:       155 passed, 155 total
Snapshots:   1 passed, 1 total
Time:        5.822s, estimated 8s
Ran all test suites.
```

QA: in variant search page + entity page (frequency tab; frequency in summary board)

![image](https://user-images.githubusercontent.com/54366437/116136446-5078bc00-a6a0-11eb-85e2-f99f27331ecc.png)


![image](https://user-images.githubusercontent.com/54366437/116136400-4060dc80-a6a0-11eb-8946-c4cbef8c526a.png)


