### PR TITLE
fix: #3134 Match Querybar and filter names

### DIFF
--- a/src/pages/studies/StudyPageContainer.tsx
+++ b/src/pages/studies/StudyPageContainer.tsx
@@ -17,20 +17,19 @@ import { IDictionary } from '@ferlab/ui/core/components/QueryBuilder/types';
 
 type StudyPageContainerProps = StudiesPageContainerData & PaginationType;
 
-const StudyPageContainer = ({ studiesResults, filters, pagination }: StudyPageContainerProps) => {
+const StudyPageContainer = ({
+  studiesResults,
+  studiesMappingResults,
+  filters,
+  pagination,
+}: StudyPageContainerProps) => {
   const total = studiesResults?.data?.hits?.total || 0;
-
-  const labelByFieldKeyMap: Record<string, string> = {
-    domain: 'Domain',
-    program: 'Program',
-    family_data: 'Family Data',
-    data_categories: 'Data Categories',
-    experimental_strategy: 'Experimental Strategy',
-  };
 
   const dictionary: IDictionary = {
     query: {
-      facet: (key) => labelByFieldKeyMap[key] || key,
+      facet: (key) =>
+        studiesMappingResults?.extendedMapping?.find((mapping: any) => key === mapping.field)
+          ?.displayName || key,
     },
   };
 

--- a/src/pages/studies/StudyPageContainer.tsx
+++ b/src/pages/studies/StudyPageContainer.tsx
@@ -13,11 +13,26 @@ import { StudiesPageContainerData } from '../../store/graphql/studies/actions';
 import StudyIcon from 'icons/StudyIconSvg';
 
 import styles from './StudiesPageContainer.module.scss';
+import { IDictionary } from '@ferlab/ui/core/components/QueryBuilder/types';
 
 type StudyPageContainerProps = StudiesPageContainerData & PaginationType;
 
 const StudyPageContainer = ({ studiesResults, filters, pagination }: StudyPageContainerProps) => {
   const total = studiesResults?.data?.hits?.total || 0;
+
+  const labelByFieldKeyMap: Record<string, string> = {
+    domain: 'Domain',
+    program: 'Program',
+    family_data: 'Family Data',
+    data_categories: 'Data Categories',
+    experimental_strategy: 'Experimental Strategy',
+  };
+
+  const dictionary: IDictionary = {
+    query: {
+      facet: (key) => labelByFieldKeyMap[key] || key,
+    },
+  };
 
   return (
     <StackLayout vertical>
@@ -31,6 +46,7 @@ const StudyPageContainer = ({ studiesResults, filters, pagination }: StudyPageCo
         onUpdate={(state) => setQueryBuilderCache('study-repo', state)}
         total={total}
         IconTotal={<StudyIcon className={styles.queryBuilderIcon} />}
+        dictionary={dictionary}
       />
       <StackLayout vertical className={styles.tableContainer}>
         <StudyTableContainer

--- a/src/pages/studies/studies.tsx
+++ b/src/pages/studies/studies.tsx
@@ -54,6 +54,7 @@ const Studies = () => {
         <PageContent title="Studies">
           <StudyPageContainer
             studiesResults={studiesResults}
+            studiesMappingResults={studiesMappingResults}
             filters={filters}
             pagination={{
               current: currentPage,

--- a/src/store/graphql/studies/actions.tsx
+++ b/src/store/graphql/studies/actions.tsx
@@ -67,6 +67,7 @@ export type SidebarData = {
 
 export type StudiesPageContainerData = {
   studiesResults: StudiesResults;
+  studiesMappingResults: StudiesMappingResults;
   filters: ISqonGroupFilter;
 };
 
@@ -78,7 +79,7 @@ export type QueryVariable = {
   sqon: any;
   first: number; // number of element to fetch
   offset: number; // start from offset number of elements
-}
+};
 
 export const useGetStudiesPageData = (variables: QueryVariable): StudiesResults => {
   const { loading, result } = useLazyResultQuery<any>(STUDIES_QUERY, {


### PR DESCRIPTION
Make sure that facet names are the same as the ones displayed in the query bar.
Currently, the facet Domain is in lower case in the query i.e. domain = Cancer

<img width="1878" alt="Capture d’écran, le 2021-04-26 à 16 07 33" src="https://user-images.githubusercontent.com/82821620/116144124-f41a9a00-a6a9-11eb-9d8e-fe0f73d778f6.png">
