### PR TITLE
fix(variant summary card): #3166 correct typo

### DIFF
--- a/src/pages/variantEntity/Summary.tsx
+++ b/src/pages/variantEntity/Summary.tsx
@@ -48,8 +48,8 @@ const Summary = ({ variant }: SummaryProps) => {
         <div>
           <SummaryItem field="Chr" value={variant.chromosome} />
           <SummaryItem field="Start" value={variant.start} />
-          <SummaryItem field="Allele Alt." value={`${variant.alternate}`} />
-          <SummaryItem field="Allele Ref." value={variant.reference} />
+          <SummaryItem field="Alt. Allele" value={`${variant.alternate}`} />
+          <SummaryItem field="Ref. Allele" value={variant.reference} />
         </div>
         <div>
           <StackLayout className={styles.topLeftContainer}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54366437/116422949-3b21a000-a80e-11eb-9582-005fde3d8096.png)

```
Test Suites: 27 passed, 27 total
Tests:       155 passed, 155 total
Snapshots:   1 passed, 1 total
Time:        9.053s
Ran all test suites.

Watch Usage: Press w to show more.
```
