### PR TITLE
fix: #3167 fix unselectable link, remove style overhead, put style gl…

### DIFF
--- a/src/pages/variantEntity/TabFrequencies.tsx
+++ b/src/pages/variantEntity/TabFrequencies.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Card, Space, Spin, Table } from 'antd';
+import { Card, Space, Spin, Table } from 'antd';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
 import { useTabFrequenciesData } from 'store/graphql/variants/tabActions';
 import {
@@ -22,7 +22,6 @@ import { Link } from 'react-router-dom';
 import { addToSqons } from 'common/sqonUtils';
 import ServerError from 'components/Variants/ServerError';
 
-import style from '../variantsSearchPage/VariantTable.module.scss';
 import TableSummaryKfStudies from './TableSummaryKfStudies';
 
 const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
@@ -94,9 +93,7 @@ const internalColumns = (
               toTop?.scrollTo(0, 0);
             }}
           >
-            <Button type="link">
-              <div className={style.variantTableLink}>{participantsNumber}</div>
-            </Button>
+            {participantsNumber}
           </Link>
           {participantsTotal ? ` / ${participantsTotal}` : ''}
         </>

--- a/src/pages/variantsSearchPage/VariantTable.module.scss
+++ b/src/pages/variantsSearchPage/VariantTable.module.scss
@@ -1,12 +1,8 @@
 @import 'src/style/themes/default/colors';
+
 .table {
   width: 100%;
   table-layout: auto;
-}
-
-.link {
-  text-decoration-line: underline;
-  color: $body-1;
 }
 
 .rowOdd {
@@ -16,16 +12,6 @@
 .variantTableCell {
   min-width: 160px;
   width: 14%;
-}
-
-.variantTableLink {
-  color: $primary-color;
-  text-decoration: underline;
-}
-
-.variantTableLink:hover {
-  color: $primary-color;
-  text-decoration: none;
 }
 
 .dbSnpTableCell {

--- a/src/pages/variantsSearchPage/VariantTable.tsx
+++ b/src/pages/variantsSearchPage/VariantTable.tsx
@@ -71,9 +71,7 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
         hgvsg ? (
           <Tooltip placement="topLeft" title={hgvsg} color={'#2b388f'}>
             <Link to={`/variant/${record.hash}?hgvsg=${hgvsg}`} href={'#top'}>
-              <Button type="link">
-                <div className={style.variantTableLink}>{hgvsg}</div>
-              </Button>
+              {hgvsg}
             </Link>
           </Tooltip>
         ) : (
@@ -151,7 +149,7 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
               toTop?.scrollTo(0, 0);
             }}
           >
-            <div className={style.variantTableLink}>{studies.hits.total || 0}</div>
+            {studies.hits.total || 0}
           </Link>
         ) : (
           0
@@ -181,7 +179,6 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
         return hasMinRequiredParticipants ? (
           <>
             <Button
-              className={style.variantTableLink}
               onClick={
                 participantNumber
                   ? () => {

--- a/src/pages/variantsSearchPage/VariantsSearchPage.module.scss
+++ b/src/pages/variantsSearchPage/VariantsSearchPage.module.scss
@@ -1,10 +1,3 @@
-@import 'src/style/themes/default/colors.module.scss';
-
-.statsAndZepplinContainer {
-  width: 100%;
-  margin-bottom: 24px;
-}
-
 .variantPageGrid {
   display: grid;
   grid-gap: 24px;
@@ -22,10 +15,4 @@
 
 .variantPageGridItemTable {
   grid-column: 1 / 3;
-}
-
-.variantPageIcons {
-  height: 18px;
-  vertical-align: middle;
-  fill: $body-1;
 }

--- a/src/style/dist/themes/default/antd.css
+++ b/src/style/dist/themes/default/antd.css
@@ -24833,8 +24833,12 @@ div.ant-typography-edit-content.ant-typography-rtl {
   color: #383f72;
   align-items: top;
 }
+.ant-table-cell button.ant-btn-link {
+  height: auto;
+  line-height: 1;
+  padding: 0;
+}
 .ant-table-cell > a {
-  text-decoration-line: underline;
   color: #383f72;
 }
 .ant-btn:disabled {

--- a/src/style/themes/default/antd/table.less
+++ b/src/style/themes/default/antd/table.less
@@ -47,8 +47,14 @@
   font-size: 14px;
   color: @body-1;
   align-items: top;
+
+  button.ant-btn-link {
+    height: auto;
+    line-height: 1;
+    padding: 0;
+  }
 }
+
 .ant-table-cell > a {
-  text-decoration-line: underline;
   color: @body-1;
 }


### PR DESCRIPTION
Task done in this PR:

- [x] Made table link selectable (copy/paste)
- [x] Removed style/tag redundencies
- [x] Made style in global theme

@adipaul1981 @evans-g-crsj @celinepelletier When adding styles, we should ask ourselves the question, is that a global style that apply to all the elements, or this is really specific to that components. Design has made a great effort standardizing our theme, custom styles should be the exception.

When we do have custom style, we should also first validate with @luclemo to make sure it's the intention.

<img width="1159" alt="Screen Shot 2021-04-28 at 3 49 43 PM" src="https://user-images.githubusercontent.com/98903/116464031-75ecfd80-a839-11eb-8d06-a9f64f9357b5.png">
