### PR TITLE
feat(summarytab): #3202 add canonical symbol if needed

### DIFF
--- a/src/pages/variantEntity/TabSummary.tsx
+++ b/src/pages/variantEntity/TabSummary.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
-import { Card, Space, Spin, Tag, Typography } from 'antd';
+import { Avatar, Card, Space, Spin, Tag, Typography } from 'antd';
 import capitalize from 'lodash/capitalize';
 
 import ExpandableCell from 'components/ExpandableCell';
@@ -214,16 +214,23 @@ const columns = [
   },
   {
     title: 'Transcript',
-    dataIndex: 'transcriptId',
-    render: (transcriptId: string) =>
-      transcriptId ? (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href={`https://www.ensembl.org/id/${transcriptId}`}
-        >
-          {transcriptId}
-        </a>
+    dataIndex: 'transcript',
+    render: (transcript: { id: string; isCanonical?: boolean }) =>
+      transcript.id ? (
+        <Space size={'small'}>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`https://www.ensembl.org/id/${transcript.id}`}
+          >
+            {transcript.id}
+          </a>
+          {transcript.isCanonical && (
+            <Avatar className={styles.transcriptAvatar} size={16}>
+              C
+            </Avatar>
+          )}
+        </Space>
       ) : (
         DISPLAY_WHEN_EMPTY_DATUM
       ),
@@ -264,7 +271,10 @@ const makeRows = (consequences: Consequence[]) =>
       ['Revel', null, consequence.node.predictions?.revel_rankscore],
     ].filter(([, , score]) => score),
     conservation: consequence.node.conservations?.phylo_p17way_primate_rankscore,
-    transcriptId: consequence.node.ensembl_transcript_id,
+    transcript: {
+      id: consequence.node.ensembl_transcript_id,
+      isCanonical: consequence.node.canonical,
+    },
   }));
 
 const TabSummary = ({ variantId }: OwnProps) => {

--- a/src/pages/variantEntity/tables.module.scss
+++ b/src/pages/variantEntity/tables.module.scss
@@ -1,5 +1,11 @@
+@import 'src/style/themes/default/colors';
+
 .cellList {
   :first-child {
     padding-right: 20px;
   }
+}
+
+.transcriptAvatar {
+  background-color: $body-2;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54366437/117190360-514ed380-adad-11eb-8215-f922570d922d.png)

```
Test Suites: 25 passed, 25 total
Tests:       142 passed, 142 total
Snapshots:   0 total
Time:        5.008 s, estimated 8 s
Ran all test suites.
```
**note:** eslint tests fails. It seems that it doesn't like sass variable. The team is notified, but I had to bypass the pretest

the error was

```
✖ npm run eslint:
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! kf-portal-ui@3.0.1 eslint: `eslint $(git diff-index --name-only --diff-filter=d HEAD | xargs) ..omitted...kidsFirst/kf-portal-ui/src/pages/variantEntity/TabSummary.tsx"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the kf-portal-ui@3.0.1 eslint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     ..omitted.../.npm/_logs/2021-05-05T18_17_43_101Z-debug.log
> kf-portal-ui@3.0.1 eslint ..omitted.../kidsFirst/kf-portal-ui
> eslint $(git diff-index --name-only --diff-filter=d HEAD | xargs) "..omitted.../kidsFirst/kf-portal-ui/src/pages/variantEntity/TabSummary.tsx"
..omitted.../kidsFirst/kf-portal-ui/src/pages/variantEntity/tables.module.scss
  1:1  error  Parsing error: Expression expected
```
