### PR TITLE
feat(FreqTab): #3165 add participants tooltip

### DIFF
--- a/src/pages/variantEntity/tables.module.scss
+++ b/src/pages/variantEntity/tables.module.scss
@@ -9,3 +9,7 @@
 .transcriptAvatar {
   background-color: $body-2;
 }
+
+:export {
+  participantsLinksTooltipColor: $geekblue-7;
+}

--- a/src/pages/variantsSearchPage/VariantTable.module.scss
+++ b/src/pages/variantsSearchPage/VariantTable.module.scss
@@ -18,3 +18,7 @@
   min-width: 140px;
   width: 12%;
 }
+
+:export {
+  hgvsgTooltipColor: $geekblue-7;
+}

--- a/src/pages/variantsSearchPage/VariantTable.tsx
+++ b/src/pages/variantsSearchPage/VariantTable.tsx
@@ -73,7 +73,7 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
       className: style.variantTableCell,
       render: (hgvsg: string, record: VariantEntity) =>
         hgvsg ? (
-          <Tooltip placement="topLeft" title={hgvsg} color={'#2b388f'}>
+          <Tooltip placement="topLeft" title={hgvsg} color={style.hgvsgTooltipColor}>
             <Link to={`/variant/${record.hash}?hgvsg=${hgvsg}`} href={'#top'}>
               {hgvsg}
             </Link>


### PR DESCRIPTION
#3165 
![participantsLinksWith](https://user-images.githubusercontent.com/54366437/117199411-27e77500-adb8-11eb-9a36-8fa3501c6e99.png)

![participantsLinksWithout](https://user-images.githubusercontent.com/54366437/117199429-2cac2900-adb8-11eb-8bcb-7b928f32e559.png)

```
Test Suites: 25 passed, 25 total
Tests:       142 passed, 142 total
Snapshots:   0 total
Time:        5.19 s
Ran all test suites.
```
**Note:** I had to bypass eslint again since it doesn't like variables in scss. However, I made sure to correct all that I could.
