### PR TITLE
fix(variant): remove canonical but fix sorting + empty data fillers

### DIFF
--- a/src/components/Variants/Test/consequences.test.ts
+++ b/src/components/Variants/Test/consequences.test.ts
@@ -1,11 +1,11 @@
-import { generateConsequencesDataLines, filterThanSortConsequencesByImpact } from '../consequences';
+import { filterThanSortConsequencesByImpact, generateConsequencesDataLines } from '../consequences';
 
 describe('Consequences', () => {
   describe('sortConsequences', () => {});
   it('should sort correctly (desc impact and canonical comes first)', () => {
     const generalCase = [
       {
-        node: { biotype: 'protein_coding', impact_score: 4, canonical: true },
+        node: { biotype: 'protein_coding', impact_score: 4, canonical: false },
       },
       {
         node: { biotype: 'retained_intron', impact_score: 4, canonical: false },
@@ -19,6 +19,9 @@ describe('Consequences', () => {
       {
         node: { biotype: 'protein_coding', impact_score: 1, canonical: false },
       },
+      {
+        node: { biotype: 'protein_coding', impact_score: 4, canonical: true },
+      },
     ];
     // @ts-ignore only needed data.
     expect(filterThanSortConsequencesByImpact(generalCase)).toEqual([
@@ -26,6 +29,13 @@ describe('Consequences', () => {
         node: {
           biotype: 'protein_coding',
           canonical: true,
+          impact_score: 4,
+        },
+      },
+      {
+        node: {
+          biotype: 'protein_coding',
+          canonical: false,
           impact_score: 4,
         },
       },

--- a/src/components/Variants/consequences.ts
+++ b/src/components/Variants/consequences.ts
@@ -23,15 +23,10 @@ export const filterThanSortConsequencesByImpact = (consequences: Consequence[]) 
   return consequences
     .filter((c) => c.node?.impact_score !== null)
     .map((c) => ({ ...c }))
-    .sort((a, b) => {
-      const isSameScore = a.node.impact_score! === b.node.impact_score!;
-      const canonicalIsNotFirst = !a.node.canonical && b.node.canonical;
-      const canonicalNeedsToBeSwapped = isSameScore && canonicalIsNotFirst;
-      if (canonicalNeedsToBeSwapped) {
-        return 1;
-      }
-      return b.node.impact_score! - a.node.impact_score!;
-    });
+    .sort(
+      (a, b) =>
+        b.node.impact_score! - a.node.impact_score! || +b.node.canonical! - +a.node.canonical!,
+    );
 };
 type SymbolToConsequences = { [key: string]: Consequence[] };
 

--- a/src/pages/variantEntity/TabClinical.tsx
+++ b/src/pages/variantEntity/TabClinical.tsx
@@ -28,6 +28,9 @@ const TabClinical = ({ variantId }: OwnProps) => {
   const clinVarRows = makeClinVarRows(dataClinvar);
   const clinVarHasRows = clinVarRows.length > 0;
 
+  const genesRows = makeGenesOrderedRow(dataGenes);
+  const genesHasRows = genesRows.length > 0;
+
   return (
     <Spin spinning={loading}>
       <StackLayout vertical fitContent>
@@ -52,11 +55,15 @@ const TabClinical = ({ variantId }: OwnProps) => {
           </Card>
 
           <Card title="Gene - Phenotype">
-            <Table
-              pagination={false}
-              dataSource={makeGenesOrderedRow(dataGenes)}
-              columns={columnsPhenotypes}
-            />
+            {genesHasRows ? (
+              <Table
+                pagination={false}
+                dataSource={makeGenesOrderedRow(dataGenes)}
+                columns={columnsPhenotypes}
+              />
+            ) : (
+              <EmptyMessage />
+            )}
           </Card>
         </Space>
       </StackLayout>

--- a/src/pages/variantEntity/TabFrequencies.tsx
+++ b/src/pages/variantEntity/TabFrequencies.tsx
@@ -87,7 +87,7 @@ const internalColumns = (
     dataIndex: 'study_id',
     render: (variantStudyId: string) => {
       const study = globalStudies.find((s) => s.id === variantStudyId);
-      return study?.domain.join(', ') || '';
+      return study?.domain.join(', ') || DISPLAY_WHEN_EMPTY_DATUM;
     },
   },
   {

--- a/src/pages/variantEntity/tables.module.scss
+++ b/src/pages/variantEntity/tables.module.scss
@@ -5,7 +5,3 @@
     padding-right: 20px;
   }
 }
-
-.transcriptAvatar {
-  background-color: $body-2;
-}

--- a/src/pages/variantsSearchPage/SuggestionOptions.tsx
+++ b/src/pages/variantsSearchPage/SuggestionOptions.tsx
@@ -1,18 +1,28 @@
-import SuggestionOption from './SuggestionOption';
 import React from 'react';
+
 import { GenomicFeatureType, Suggestion } from 'store/graphql/variants/models';
+
+import SuggestionOption from './SuggestionOption';
 
 const generateDisplayName = (suggestion: Suggestion): string | undefined => {
   const type = suggestion.type;
   return type === GenomicFeatureType.GENE ? suggestion.geneSymbol : suggestion.locus;
 };
 
+const removeSuggestionsDuplicates = (arr: Suggestion[]) =>
+  arr.reduce((acc: Suggestion[], curr: Suggestion) => {
+    const alreadyHasId = acc.some((sugg) => sugg.suggestion_id === curr.suggestion_id);
+    return alreadyHasId ? acc : [...acc, { ...curr }];
+  }, []);
+
 const generateSuggestionOptions = (searchText: string | undefined, suggestions: Suggestion[]) => {
   if (!suggestions || suggestions.length === 0) {
     return [];
   }
 
-  return suggestions.map((suggestion: Suggestion): any => {
+  const suggestionsWithoutDuplicatedIds = removeSuggestionsDuplicates(suggestions);
+
+  return suggestionsWithoutDuplicatedIds.map((suggestion: Suggestion): any => {
     const displayName = generateDisplayName(suggestion);
     return {
       label: (

--- a/src/pages/variantsSearchPage/VariantTable.tsx
+++ b/src/pages/variantsSearchPage/VariantTable.tsx
@@ -1,16 +1,13 @@
 /* eslint-disable react/display-name */
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import { Button, Table, Tooltip } from 'antd';
-// @ts-ignore
-import { compose } from 'recompose';
+import { Link } from 'react-router-dom';
+import { Table, Tooltip } from 'antd';
 
 import ROUTES from 'common/routes';
 import { addToSqons } from 'common/sqonUtils';
 import { DISPLAY_WHEN_EMPTY_DATUM } from 'components/Variants/Empty';
 import ServerError from 'components/Variants/ServerError';
-import { withHistory } from 'services/history';
 import { createQueryInCohortBuilder } from 'store/actionCreators/studyPage';
 import {
   ClinVar,
@@ -61,7 +58,6 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type Props = {
   selectedSuggestion: SelectedSuggestion;
-  history: RouteComponentProps['history'];
 } & PropsFromRedux;
 
 const generateColumns = (props: Props, studyList: StudyInfo[]) =>
@@ -140,7 +136,7 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
 
         return studies?.hits?.total ? (
           <Link
-            to={'/explore'}
+            to={ROUTES.cohortBuilder}
             href={'#top'}
             onClick={() => {
               props.onClickParticipantLink(
@@ -182,7 +178,8 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
 
         return hasMinRequiredParticipants ? (
           <>
-            <Button
+            <Link
+              to={ROUTES.cohortBuilder}
               onClick={
                 participantNumber
                   ? () => {
@@ -197,14 +194,12 @@ const generateColumns = (props: Props, studyList: StudyInfo[]) =>
                           sqons: props.currentSqons,
                         }),
                       );
-                      props.history.push(ROUTES.cohortBuilder);
                     }
                   : undefined
               }
-              type="link"
             >
               {participantNumber}
-            </Button>
+            </Link>
             {participantTotalNumber ? ` / ${participantTotalNumber}` : ''}
           </>
         ) : (
@@ -287,4 +282,4 @@ const VariantTable: FunctionComponent<Props> = (props) => {
   );
 };
 
-export default compose(withHistory, connector)(VariantTable);
+export default connector(VariantTable);


### PR DESCRIPTION
fixes following qa
- remove 'c' avatar in the summary tab
- make sure that there is consistency when empty tables (maybe not all cases are covered yet)
- put '--' when empty data (variant entity and variant search page only) 
- remove react duplicate keys in the variant suggestions (bug discovered after qa)
-  use <Link/> vs Button in the variant search results table

**Note:** eslint does not pass (scss file)

```
...omitted.../kidsFirst/kf-portal-ui/src/pages/variantEntity/tables.module.scss
  1:1  error  Parsing error: Expression expected

✖ 1 problem (1 error, 0 warnings)
```
**circle-ci bypass:**

```
Test Suites: 25 passed, 25 total
Tests:       142 passed, 142 total
Snapshots:   0 total
Time:        7.741 s
Ran all test suites.
```
