### PR TITLE
build: #3225 remove unneeded debug

### DIFF
--- a/src/common/injectGlobals.ts
+++ b/src/common/injectGlobals.ts
@@ -3,10 +3,6 @@ import queryString from 'querystring';
 
 export const getApplicationEnvVar = (envVarName) => process.env[`REACT_APP_${envVarName}`];
 
-localStorage.setItem('debug', getApplicationEnvVar('DEBUG') || ''); // manually set because CRA doesn't allow arbitrary env variable names.
-const debug = require('debug');
-global.log = debug('app');
-
 const qs = queryString.parse(global.location.search.replace(/^\?/, ''));
 
 const egoApiOverride = qs.EGO_API;


### PR DESCRIPTION
https://create-react-app.dev/docs/adding-custom-environment-variables/

`There is also a built-in environment variable called NODE_ENV. You can read it from process.env.NODE_ENV. When you run npm start, it is always equal to 'development', when you run npm test it is always equal to 'test', and when you run npm run build to make a production bundle, it is always equal to 'production'. You cannot override NODE_ENV manually. This prevents developers from accidentally deploying a slow development build to production.`