### PR TITLE
Fix/3271: Force use of react-router and react-router-dom 5.2 and upgrade some dependancies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "3.0.3",
       "dependencies": {
         "@ant-design/icons": "^4.6.2",
-        "@apollo/client": "^3.3.11",
+        "@apollo/client": "^3.3.18",
         "@ferlab/style": "^1.5.0",
         "@ferlab/ui": "^1.4.8",
         "@kfarranger/components": "1.25.0",
@@ -154,23 +154,36 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.11.tgz",
-      "integrity": "sha512-54+D5FB6RJlQ+g37f432gaexnyvDsG5X6L9VO5kqN54HJlbF8hCf/8CXtAQEHCWodAwZhy6kOLp2RM96829q3A==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.18.tgz",
+      "integrity": "sha512-SaJSda4V36/pnv7jkCBROBPwd3w/3TnG/Bd8oLESuNqm6ruXDHt067ow00Y2zz1AOL8SuOI9LXjmkr+FcTqnIQ==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.3.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.12.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.14.0",
+        "optimism": "^0.16.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.6.0",
+        "ts-invariant": "^0.7.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@apollo/client/node_modules/graphql-tag": {
@@ -6252,11 +6265,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/@types/ungap__global-this": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
-      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
-    },
     "node_modules/@types/webpack": {
       "version": "4.41.27",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
@@ -6457,11 +6465,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@ungap/global-this": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
-      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -6638,52 +6641,52 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.4.tgz",
-      "integrity": "sha512-/pktJKHUXDr4D6TJqWgudOPJW2Z+Nb+bqk40jufA3uTkLbnCRKdJPiYDIa/c7mfcPH8Hr6O8zjCERpg5Sq04Zg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "dependencies": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@wry/context/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@wry/equality": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.3.tgz",
-      "integrity": "sha512-pMrKHIgDAWxLDTGsbaVag+USmwZ2+gGrSBrtyGUxp2pxRg1Cad70lI/hd0NTPtJ4zJxN16EQ679U1Rts83AF5g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
+      "integrity": "sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==",
       "dependencies": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@wry/equality/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@wry/trie": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.2.tgz",
-      "integrity": "sha512-OxqBB39x6MfHaa2HpMiRMfhuUnQTddD32Ko020eBeJXq87ivX6xnSSnzKHVbA21p7iqBASz8n/07b6W5wW1BVQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
       "dependencies": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@wry/trie/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -24909,12 +24912,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
-      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "dependencies": {
-        "@wry/context": "^0.5.2",
-        "@wry/trie": "^0.2.1"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
@@ -33397,17 +33400,20 @@
       "dev": true
     },
     "node_modules/ts-invariant": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.1.tgz",
-      "integrity": "sha512-QQgN33g8E8yrdDuH29HASveLtbzMnRRgWh0i/JNTW4+zcLsdIOnfsgEDi/NKx4UckQyuMFt9Ujm6TWLWQ58Kvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+      "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
       "dependencies": {
-        "@types/ungap__global-this": "^0.3.1",
-        "@ungap/global-this": "^0.4.2",
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ts-invariant/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
@@ -36366,21 +36372,21 @@
       }
     },
     "@apollo/client": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.11.tgz",
-      "integrity": "sha512-54+D5FB6RJlQ+g37f432gaexnyvDsG5X6L9VO5kqN54HJlbF8hCf/8CXtAQEHCWodAwZhy6kOLp2RM96829q3A==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.18.tgz",
+      "integrity": "sha512-SaJSda4V36/pnv7jkCBROBPwd3w/3TnG/Bd8oLESuNqm6ruXDHt067ow00Y2zz1AOL8SuOI9LXjmkr+FcTqnIQ==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.3.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.12.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.14.0",
+        "optimism": "^0.16.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.6.0",
+        "ts-invariant": "^0.7.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
       },
@@ -42062,11 +42068,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "@types/ungap__global-this": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
-      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
-    },
     "@types/webpack": {
       "version": "4.41.27",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
@@ -42238,11 +42239,6 @@
           "dev": true
         }
       }
-    },
-    "@ungap/global-this": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
-      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -42420,47 +42416,47 @@
       }
     },
     "@wry/context": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.4.tgz",
-      "integrity": "sha512-/pktJKHUXDr4D6TJqWgudOPJW2Z+Nb+bqk40jufA3uTkLbnCRKdJPiYDIa/c7mfcPH8Hr6O8zjCERpg5Sq04Zg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "requires": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
     "@wry/equality": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.3.tgz",
-      "integrity": "sha512-pMrKHIgDAWxLDTGsbaVag+USmwZ2+gGrSBrtyGUxp2pxRg1Cad70lI/hd0NTPtJ4zJxN16EQ679U1Rts83AF5g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
+      "integrity": "sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==",
       "requires": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
     "@wry/trie": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.2.tgz",
-      "integrity": "sha512-OxqBB39x6MfHaa2HpMiRMfhuUnQTddD32Ko020eBeJXq87ivX6xnSSnzKHVbA21p7iqBASz8n/07b6W5wW1BVQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
       "requires": {
-        "tslib": "^1.14.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
@@ -57596,12 +57592,12 @@
       }
     },
     "optimism": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
-      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
       "requires": {
-        "@wry/context": "^0.5.2",
-        "@wry/trie": "^0.2.1"
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -64785,13 +64781,18 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.1.tgz",
-      "integrity": "sha512-QQgN33g8E8yrdDuH29HASveLtbzMnRRgWh0i/JNTW4+zcLsdIOnfsgEDi/NKx4UckQyuMFt9Ujm6TWLWQ58Kvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+      "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
       "requires": {
-        "@types/ungap__global-this": "^0.3.1",
-        "@ungap/global-this": "^0.4.2",
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "ts-pnp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@ant-design/icons": "^4.6.2",
         "@apollo/client": "^3.3.11",
-        "@babel/runtime": "^7.12.1",
         "@ferlab/style": "^1.5.0",
         "@ferlab/ui": "^1.4.8",
         "@kfarranger/components": "1.25.0",
@@ -45,7 +44,7 @@
         "react-router-dom": "^5.2.0",
         "react-share": "^3.0.1",
         "react-slick": "^0.23.2",
-        "react-social-icons": "^4.1.0",
+        "react-social-icons": "^5.3.0",
         "redux": "^4.0.5",
         "redux-devtools-extension": "^2.13.8",
         "redux-thunk": "^2.3.0",
@@ -29265,11 +29264,14 @@
       }
     },
     "node_modules/react-social-icons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-4.1.0.tgz",
-      "integrity": "sha512-wbwSbyS4QWjpL6U+GFZDBrE5Ao8px0QkRgo0XkxDHF2LNRsFNErSDnIPKiowhQ7t7IyrSA2HYrEw7ETgpVTg+Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-5.3.0.tgz",
+      "integrity": "sha512-L0ghMfES//4L/gNCtRCWeXSwQ9tx0ajnQLw14ImToOP6c0hf6LVN3QHa4vwBCD9YcOkSec96hzeyFz8JihCAQQ==",
       "dependencies": {
-        "prop-types": "^15.6.2"
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "15.x.x || 16.x.x || 17.x.x"
       }
     },
     "node_modules/react-spinkit": {
@@ -61293,11 +61295,11 @@
       }
     },
     "react-social-icons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-4.1.0.tgz",
-      "integrity": "sha512-wbwSbyS4QWjpL6U+GFZDBrE5Ao8px0QkRgo0XkxDHF2LNRsFNErSDnIPKiowhQ7t7IyrSA2HYrEw7ETgpVTg+Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-5.3.0.tgz",
+      "integrity": "sha512-L0ghMfES//4L/gNCtRCWeXSwQ9tx0ajnQLw14ImToOP6c0hf6LVN3QHa4vwBCD9YcOkSec96hzeyFz8JihCAQQ==",
       "requires": {
-        "prop-types": "^15.6.2"
+        "prop-types": "^15.7.2"
       }
     },
     "react-spinkit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4594,44 +4594,40 @@
       }
     },
     "node_modules/@kfarranger/components/node_modules/react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "dependencies": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "peerDependencies": {
         "react": ">=15"
       }
     },
     "node_modules/@kfarranger/components/node_modules/react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "dependencies": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "peerDependencies": {
         "react": ">=15"
-      }
-    },
-    "node_modules/@kfarranger/components/node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/@kfarranger/mapping-utils": {
@@ -18160,14 +18156,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "node_modules/ip": {
       "version": "1.1.5",
@@ -40541,38 +40529,33 @@
           }
         },
         "react-router": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+          "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
           "requires": {
-            "history": "^4.7.2",
-            "hoist-non-react-statics": "^2.5.0",
-            "invariant": "^2.2.4",
+            "@babel/runtime": "^7.1.2",
+            "history": "^4.9.0",
+            "hoist-non-react-statics": "^3.1.0",
             "loose-envify": "^1.3.1",
+            "mini-create-react-context": "^0.4.0",
             "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.1",
-            "warning": "^4.0.1"
+            "prop-types": "^15.6.2",
+            "react-is": "^16.6.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0"
           }
         },
         "react-router-dom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-          "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+          "version": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+          "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
           "requires": {
-            "history": "^4.7.2",
-            "invariant": "^2.2.4",
+            "@babel/runtime": "^7.1.2",
+            "history": "^4.9.0",
             "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.1",
-            "react-router": "^4.3.1",
-            "warning": "^4.0.1"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
+            "prop-types": "^15.6.2",
+            "react-router": "5.2.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0"
           }
         }
       }
@@ -52074,14 +52057,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "ip": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
-    "@apollo/client": "^3.3.11",
+    "@apollo/client": "^3.3.18",
     "@ferlab/style": "^1.5.0",
     "@ferlab/ui": "^1.4.8",
     "@kfarranger/components": "1.25.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@apollo/client": "^3.3.11",
-    "@babel/runtime": "^7.12.1",
     "@ferlab/style": "^1.5.0",
     "@ferlab/ui": "^1.4.8",
     "@kfarranger/components": "1.25.0",
@@ -45,7 +44,7 @@
     "react-router-dom": "^5.2.0",
     "react-share": "^3.0.1",
     "react-slick": "^0.23.2",
-    "react-social-icons": "^4.1.0",
+    "react-social-icons": "^5.3.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",


### PR DESCRIPTION
- Force use react-router and reace-router-dom 5.2 even for kf-arranger
- Upgrade graphql-client
- Upgrade react-social-icons
- Remove unnecessary dependancy 