### PR TITLE
fix: #3255 remove underline in charts tooltip

### DIFF
--- a/src/components/Charts/Charts.module.css
+++ b/src/components/Charts/Charts.module.css
@@ -43,7 +43,3 @@
 .tooltip-dx-chart-container {
   min-width: 50px;
 }
-
-.tooltip-dx-chart-label, .tooltip-studies-chart-label {
-  text-decoration: underline;
-}

--- a/src/components/Charts/index.js
+++ b/src/components/Charts/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import 'ui/Tooltips/tooltips.scss';
 
 export { default as MostFrequentDiagnosesChart } from './MostFrequentDiagnosesChart';
@@ -15,7 +16,7 @@ export const mostFrequentDiagnosisTooltip = (data) => {
   const participants = familyMembers + probands;
   return (
     <div className={'tp-diagnosis-container'}>
-      <div className={'tp-label'}>{removeMondo(label)}</div>
+      <div>{removeMondo(label)}</div>
       <div>{`${participants.toLocaleString()} Participant${participants !== 1 ? 's' : ''}`}</div>
     </div>
   );
@@ -26,7 +27,7 @@ export const studiesToolTip = (data) => {
   const participants = familyMembers + probands;
   return (
     <div className={'tp-studies-container'}>
-      <div className={'tp-label'}>{label}</div>
+      <div>{label}</div>
       <div>{`${probands.toLocaleString()} Proband${probands !== 1 ? 's' : ''}`}</div>
       <div>{`${familyMembers.toLocaleString()} Other Participant${
         familyMembers > 1 ? 's' : ''

--- a/src/ui/Tooltips/tooltips.scss
+++ b/src/ui/Tooltips/tooltips.scss
@@ -6,10 +6,6 @@
   min-width: 50px;
 }
 
-.tp-label {
-  text-decoration: underline;
-}
-
 .tp-content {
   font-size: 12px;
 }


### PR DESCRIPTION
Explore Data - Studies
Before
<img width="454" alt="Capture d’écran, le 2021-05-20 à 15 36 22" src="https://user-images.githubusercontent.com/82821620/119038830-982df300-b981-11eb-90fb-f93516ba6939.png">
After
<img width="453" alt="Capture d’écran, le 2021-05-20 à 15 35 21" src="https://user-images.githubusercontent.com/82821620/119038848-9f550100-b981-11eb-840c-7b28eb573ffe.png">

Explore Data - Most Frequent Diagnoses (Mondo)
Before
<img width="455" alt="Capture d’écran, le 2021-05-20 à 15 36 30" src="https://user-images.githubusercontent.com/82821620/119038922-b4ca2b00-b981-11eb-997e-325b8cef1b91.png">
After
<img width="450" alt="Capture d’écran, le 2021-05-20 à 15 35 31" src="https://user-images.githubusercontent.com/82821620/119038967-beec2980-b981-11eb-9782-4198c5857d0e.png">

Dashboard - Studies Participants
Before
<img width="463" alt="Capture d’écran, le 2021-05-20 à 15 36 43" src="https://user-images.githubusercontent.com/82821620/119039106-e2af6f80-b981-11eb-9654-7b69a3d6196d.png">
After
<img width="454" alt="Capture d’écran, le 2021-05-20 à 15 34 53" src="https://user-images.githubusercontent.com/82821620/119039142-ea6f1400-b981-11eb-87bb-81c2bdacb35f.png">

Dashboard - Most Frequent Diagnoses
Before
<img width="464" alt="Capture d’écran, le 2021-05-20 à 15 36 53" src="https://user-images.githubusercontent.com/82821620/119039213-fb1f8a00-b981-11eb-8ee9-5619d381605a.png">
After
<img width="468" alt="Capture d’écran, le 2021-05-20 à 15 35 06" src="https://user-images.githubusercontent.com/82821620/119039229-01156b00-b982-11eb-8488-d007aba8ddf8.png">
 
