### PR TITLE
fix: #SKFP-8 cavatica connection status is not fetch

### DIFF
--- a/src/store/actionCreators/cavatica.ts
+++ b/src/store/actionCreators/cavatica.ts
@@ -42,7 +42,7 @@ export const checkIfUserIsConnected = (): ThunkAction<
 };
 
 const shouldFetch = (state: RootState) =>
-  selectConnectionStatus(state) !== ConnectionStatus.disconnected;
+  selectConnectionStatus(state) !== ConnectionStatus.connected;
 
 export const checkIfUserIsConnectedIfNeeded = (): ThunkAction<
   void,
@@ -51,7 +51,7 @@ export const checkIfUserIsConnectedIfNeeded = (): ThunkAction<
   CavaticaActionTypes
 > => async (dispatch, getState) => {
   if (shouldFetch(getState())) {
-    dispatch(checkIfUserIsConnected);
+    dispatch(checkIfUserIsConnected());
   }
 };
 


### PR DESCRIPTION
#[BUG] Cavatica status is not fetch

## Description
Cavatica connection status was clear each time we refresh

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [x] QA Done
- [ ] Design/UI Approved from design


## QA
Connect to cavatica then refresh page, should still be connected
...

## Mention

@ QA, Design ...
