### PR TITLE
fix: #SKFP-140 hotfix login with orcid always redirect to login page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
 ### Technical / Other changes
 -->
 
+## 2021-09-16 kf-portal-ui 3.3.3
+
+### Technical / Other changes
+
+- [SKFP-140](https://d3b.atlassian.net/browse/SKFP-140) Fix (Login): Fix ORCID login. Always redirects to Login page
+
 ## 2021-09-15 kf-portal-ui 3.3.2
 
 ### Technical / Other changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "kf-portal-ui",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.3.2",
+      "version": "3.3.3",
       "dependencies": {
         "@ant-design/icons": "^4.6.2",
         "@apollo/client": "^3.3.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kf-portal-ui",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "engines": {
     "node": ">=15.14.0",

--- a/src/App.js
+++ b/src/App.js
@@ -159,7 +159,7 @@ const App = () => (
               )}
             />
 
-            <ProtectedRoute
+            <Route
               path={ROUTES.orcid}
               exact
               render={(props) => (


### PR DESCRIPTION
#SKFP-140: Hotfix ORCID login always redirect to login page

- closes #SKFP-140

## Description

Login with ORCID redirect to login page instead of Dashboard even if login process worked with success

Acceptance Criterias

It should redirect to Dashboard or Orcid error page instead of Login page

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [x] QA Done
- [ ] Design/UI Approved from design

## Screenshot (Before and After)


## QA

Login with ORCID provider
...

## Mention
Hotfix
