### PR TITLE
fix: #SKFP-127 fix switch tab in cavatica card in dashboard

### DIFF
--- a/src/components/UserDashboard/CavaticaProjects/index.js
+++ b/src/components/UserDashboard/CavaticaProjects/index.js
@@ -41,13 +41,13 @@ const generateTabsContent = ({
   activeTab,
 }) => {
   const NotConnectedComp = () => <NotConnected />;
-  const ConnectedComp = (cardProps) => (
-    <Connected tabToCreate={tabToCreate(cardProps)} projects={projects} loading={loading} />
+  const ConnectedComp = () => (
+    <Connected tabToCreate={tabToCreate()} projects={projects} loading={loading} />
   );
-  const CreateComp = (cardProps) => (
+  const CreateComp = () => (
     <Create
-      onProjectCreated={onProjectCreated({ cardProps, refresh })}
-      onProjectCreationCancelled={onProjectCreationCanceled(cardProps)}
+      onProjectCreated={onProjectCreated({ refresh })}
+      onProjectCreationCancelled={onProjectCreationCanceled()}
     />
   );
 
@@ -84,8 +84,8 @@ const CavaticaProjects = () => {
 
   const [activeTab, setActiveTab] = useState('Projects');
 
-  const onProjectCreated = ({ cardProps, refresh }) => (data) => {
-    cardProps.setIndex(0);
+  const onProjectCreated = ({ refresh }) => (data) => {
+    setActiveTab('Projects');
     // added project data into the data param,
     // not sure of future plans for the data param
     trackUserInteraction({
@@ -102,8 +102,8 @@ const CavaticaProjects = () => {
     setActiveTab(key);
   };
 
-  const onProjectCreationCanceled = (cardProps) => (data) => {
-    cardProps.setIndex(0);
+  const onProjectCreationCanceled = () => (data) => {
+    setActiveTab('Projects');
     // added project data into the data param,
     // not sure of future plans for the data param
     trackUserInteraction({
@@ -113,8 +113,8 @@ const CavaticaProjects = () => {
     });
   };
 
-  const tabToCreate = (cardProps) => () => {
-    cardProps.setIndex(1);
+  const tabToCreate = () => () => {
+    setActiveTab('Create');
   };
 
   return isCheckingIfConnected ? (
@@ -145,6 +145,7 @@ const CavaticaProjects = () => {
             onTabChange={(key) => {
               onTabChange(key);
             }}
+            activeTabKey={activeTab}
           >
             {
               generateTabsContent({


### PR DESCRIPTION
SKFP-127: Error when creating a new Cavatica project from Dashboard

- closes [SKFP-127](https://d3b.atlassian.net/browse/SKFP-127)

## Description

In dashboard, when creating a new project in cavatica, an error occurs even if the project has been created with success

Acceptance Criterias

No more error and user should be on Projects tab after creation success

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [x] QA Done
- [ ] Design/UI Approved from design

## Screenshot (Before and After)
Before
<img width="612" alt="Capture d’écran, le 2021-09-10 à 11 39 21" src="https://user-images.githubusercontent.com/82821620/133823140-eed2ffeb-165c-4e63-8c0c-697478bb23e7.png">

After
<img width="606" alt="Capture d’écran, le 2021-09-10 à 11 39 47" src="https://user-images.githubusercontent.com/82821620/133823194-b27645fc-76ad-453e-8551-20eec1ae44bd.png">


## QA

Connect to cavatica and create a project from dashboard page, no error should occur and after creation user is on Projects tab. If user cancel creation, then it returns on Projects tab too (without any error)

## Mention
