### PR TITLE
fix: #skfp-278 entity page long ellipsis values

### DIFF
--- a/src/pages/variantEntity/Summary.module.scss
+++ b/src/pages/variantEntity/Summary.module.scss
@@ -62,10 +62,16 @@
   .label {
     color: $body-2;
     font-size: 12px;
+    width: 25%;
   }
 
   .value {
     color: $body-1;
     font-weight: 500;
+    width: 75%;
+  }
+  .valueLong {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/src/pages/variantEntity/Summary.tsx
+++ b/src/pages/variantEntity/Summary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RiseOutlined } from '@ant-design/icons';
 import MultiLabel from '@ferlab/ui/core/components/labels/MultiLabel';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
-import { Card } from 'antd';
+import { Card, Tooltip } from 'antd';
 
 import ParticipantIcon from 'icons/ParticipantIcon';
 import StudyIcon from 'icons/StudyIconSvg';
@@ -16,12 +16,13 @@ import styles from './Summary.module.scss';
 type SummaryItemProps = {
   field: string;
   value: string;
+  isLongValue?: boolean;
 };
 
-const SummaryItem = ({ field, value }: SummaryItemProps) => (
+const SummaryItem = ({ field, value, isLongValue }: SummaryItemProps) => (
   <StackLayout className={styles.summaryItem}>
     <Label>{field}</Label>
-    <Value>{value}</Value>
+    <Value isLongValue={isLongValue}>{value}</Value>
   </StackLayout>
 );
 
@@ -29,9 +30,14 @@ const Label = ({ children }: { children: React.ReactNode }) => (
   <div className={styles.label}>{children}</div>
 );
 
-const Value = ({ children }: { children: React.ReactNode }) => (
-  <div className={styles.value}>{children}</div>
-);
+const Value = ({ children, isLongValue }: { children: React.ReactNode; isLongValue?: boolean }) =>
+  isLongValue ? (
+    <Tooltip placement="topLeft" title={children}>
+      <div className={`${styles.valueLong} ${styles.value}`}>{children}</div>
+    </Tooltip>
+  ) : (
+    <div className={styles.value}>{children}</div>
+  );
 
 type SummaryProps = {
   variant: VariantEntity | undefined;
@@ -48,7 +54,7 @@ const Summary = ({ variant }: SummaryProps) => {
         <div>
           <SummaryItem field="Chr" value={variant.chromosome} />
           <SummaryItem field="Start" value={variant.start} />
-          <SummaryItem field="Alt. Allele" value={`${variant.alternate}`} />
+          <SummaryItem field="Alt. Allele" value={`${variant.alternate}`} isLongValue={true} />
           <SummaryItem field="Ref. Allele" value={variant.reference} />
         </div>
         <div>

--- a/src/pages/variantEntity/TabSummary.tsx
+++ b/src/pages/variantEntity/TabSummary.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
-import { Card, Space, Spin, Tag, Typography } from 'antd';
+import { Card, Space, Spin, Tag, Tooltip, Typography } from 'antd';
 import capitalize from 'lodash/capitalize';
 
 import ExpandableCell from 'components/ExpandableCell';
@@ -120,7 +120,12 @@ const columns = [
   {
     title: 'AA',
     dataIndex: 'aa',
-    render: (aa: string) => aa || DISPLAY_WHEN_EMPTY_DATUM,
+    render: (aa: string) => (
+      <Tooltip placement="topLeft" title={aa || DISPLAY_WHEN_EMPTY_DATUM}>
+        <div className={styles.longValue}>{aa || DISPLAY_WHEN_EMPTY_DATUM}</div>
+      </Tooltip>
+    ),
+    className: `${styles.longValue}`,
     width: '10%',
   },
   {
@@ -146,7 +151,11 @@ const columns = [
   {
     title: 'Coding Dna',
     dataIndex: 'codingDna',
-    render: (codingDna: string) => codingDna || DISPLAY_WHEN_EMPTY_DATUM,
+    render: (codingDna: string) => (
+      <Tooltip placement="topLeft" title={codingDna || DISPLAY_WHEN_EMPTY_DATUM}>
+        <div className={styles.longValue}>{codingDna || DISPLAY_WHEN_EMPTY_DATUM}</div>
+      </Tooltip>
+    ),
   },
   {
     title: 'Strand',

--- a/src/pages/variantEntity/tables.module.scss
+++ b/src/pages/variantEntity/tables.module.scss
@@ -5,3 +5,10 @@
     padding-right: 20px;
   }
 }
+
+.longValue{
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: initial;
+}


### PR DESCRIPTION
#BUG  [Variant Entity page: Alt. Allele Ellipsis]

- [SKFP-278](https://d3b.atlassian.net/browse/SKFP-278)

## Description

Incorporate an ellipsis for the Alt. allele and add a tooltip similar to the one in the Variant table results (see screenshot) when the text goes over the space limit. The tooltip would show the result for the Alt. Allele.

Ellipsis and tooltip can be added to the AA and the Coding DNA columns in the table below. Similarly, the ellipsis can be applied when the maximum column width is attained. 

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot (Before and After)

![image](https://user-images.githubusercontent.com/29788342/139738522-c1264d52-6113-4c11-90c3-d579e2adb342.png)
![image](https://user-images.githubusercontent.com/29788342/139738559-de8d1222-7cc1-4e26-90f5-6e5745c125dd.png)

