### PR TITLE
fix: #SKFP-290 fix back to login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "kf-portal-ui",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.4.0",
+      "name": "kf-portal-ui",
+      "version": "3.4.1",
       "dependencies": {
         "@ant-design/icons": "^4.6.2",
         "@apollo/client": "^3.3.11",
@@ -8947,10 +8948,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001219",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
-      "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
-      "dev": true
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -43232,9 +43237,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001219",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz",
-      "integrity": "sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "dev": true
     },
     "capture-exit": {

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -17,12 +17,13 @@ const Login = (): React.ReactElement => {
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <Button
         type={'primary'}
-        onClick={async () =>
-          await keycloak.login({
+        onClick={async () => {
+          const url = keycloak.createLoginUrl({
             // eslint-disable-next-line max-len
             redirectUri: `${window.location.origin}/${ROUTES.dashboard}`,
-          })
-        }
+          });
+          location.assign(url);
+        }}
       >
         {'Login'}
       </Button>


### PR DESCRIPTION
#SKFP-290 BUG Clicking back on the login services menu

Also update caniuse browsert

- closes #SKFP-290

## Description

Clicking on the back arrow from the Keycloak/login services menu (RAS, Google, ORCID) does not bring you back to the portal “Login” page. 

## Acceptance Criterias

Clicking back on the Keycloak service should bring you back to the login page on the portal. 

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [x] QA Done
- [ ] Design/UI Approved from design


## QA

Click on button then click on back button, should be redirect to the previous page
...

## Mention

@ QA, Design ...
