### PR TITLE
Feat/skfp 338 variant entity page routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -103,7 +103,7 @@ const App = () => {
                   render={() => <FixedFooterPage Component={VariantSearchPage} />}
                 />
                 <ProtectedRoute
-                  path={`${ROUTES.variant}/:hash`}
+                  path={`${ROUTES.variant}/:identifier`}
                   exact
                   render={() => <Page Component={VariantEntityPage} />}
                 />

--- a/src/pages/variantEntity/TabClinical.tsx
+++ b/src/pages/variantEntity/TabClinical.tsx
@@ -11,11 +11,13 @@ import { makeClinVarRows, makeGenesOrderedRow } from './clinicalRowsGenerators';
 import ClinVarExternalLink from './ClinVarExternalLink';
 
 type OwnProps = {
-  variantId: string;
+  field: string;
+  value: string;
 };
 
-const TabClinical = ({ variantId }: OwnProps) => {
-  const { loading, data, error } = useTabClinicalData(variantId);
+const TabClinical = (props: OwnProps) => {
+  const { field, value } = props;
+  const { loading, data, error } = useTabClinicalData(field, value);
 
   if (error) {
     return <ServerError />;

--- a/src/pages/variantEntity/TabFrequencies.tsx
+++ b/src/pages/variantEntity/TabFrequencies.tsx
@@ -33,7 +33,8 @@ import TableSummaryKfStudies from './TableSummaryKfStudies';
 const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
 
 type OwnProps = {
-  variantId: string;
+  field: string;
+  value: string;
 };
 
 type FrequencyTabTableContainerState = {
@@ -294,7 +295,8 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 type Props = OwnProps & PropsFromRedux;
 
 const TabFrequencies = (props: Props) => {
-  const { loading, data, error } = useTabFrequenciesData(props.variantId);
+  const { field, value } = props;
+  const { loading, data, error } = useTabFrequenciesData(field, value);
 
   if (error) {
     return <ServerError />;

--- a/src/pages/variantEntity/TabSummary.tsx
+++ b/src/pages/variantEntity/TabSummary.tsx
@@ -20,7 +20,8 @@ import styles from './tables.module.scss';
 const { Text } = Typography;
 
 type OwnProps = {
-  variantId: string;
+  field: string;
+  value: string;
 };
 
 type TableGroup = {
@@ -280,8 +281,8 @@ const makeRows = (consequences: Consequence[]) =>
     },
   }));
 
-const TabSummary = ({ variantId }: OwnProps) => {
-  const { loading, data: rawData, error } = useTabSummaryData(variantId);
+const TabSummary = ({ field, value }: OwnProps) => {
+  const { loading, data: rawData, error } = useTabSummaryData(field, value);
 
   if (error) {
     return <ServerError />;

--- a/src/pages/variantEntity/index.tsx
+++ b/src/pages/variantEntity/index.tsx
@@ -25,13 +25,13 @@ const mTabKeys = {
 
 const tabKeyValues = Object.keys(mTabKeys);
 
-const hgvsgRegex = /^(hgvsg|locus)=([A-Za-z0-9:.>-]+)#?.*$/;
+const regExp = /^(hgvsg|locus)=([A-Za-z0-9:.>-]+)#?.*$/;
 
-const extractHgvsg = (raw: string) => hgvsgRegex.exec(raw);
+const extractIdentifier = (raw: string) => regExp.exec(raw);
 
 const VariantEntity = () => {
-  const { hash } = useParams();
-  const match = extractHgvsg(hash);
+  const { identifier } = useParams();
+  const match = extractIdentifier(identifier);
   const field = match ? match[1] : '';
   const value = match ? match[2] : '';
 

--- a/src/pages/variantEntity/index.tsx
+++ b/src/pages/variantEntity/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { FileTextOutlined, MedicineBoxOutlined, RiseOutlined } from '@ant-design/icons';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
 import { Tabs, Tag, Typography } from 'antd';
@@ -12,6 +12,7 @@ import TabFrequencies from './TabFrequencies';
 import TabSummary from './TabSummary';
 
 import styles from './VariantEntity.module.scss';
+
 const { TabPane } = Tabs;
 
 const { Title } = Typography;
@@ -24,10 +25,15 @@ const mTabKeys = {
 
 const tabKeyValues = Object.keys(mTabKeys);
 
+const hgvsgRegex = /^(hgvsg|locus)=([A-Za-z0-9:.>-]+)#?.*$/;
+
+const extractHgvsg = (raw: string) => hgvsgRegex.exec(raw);
+
 const VariantEntity = () => {
   const { hash } = useParams();
-  const location = useLocation();
-  const hgvsg = new URLSearchParams(location.search).get('hgvsg');
+  const match = extractHgvsg(hash);
+  const field = match ? match[1] : '';
+  const value = match ? match[2] : '';
 
   const [tabKey, setTabKey] = useTab(tabKeyValues, mTabKeys.summary);
 
@@ -36,7 +42,7 @@ const VariantEntity = () => {
       className={styles.pageContent}
       title={
         <StackLayout horizontal>
-          <Title level={3}>{hgvsg}</Title>
+          <Title level={3}>{value}</Title>
           <Tag className={styles.variantTag}>Germline</Tag>
         </StackLayout>
       }
@@ -51,7 +57,7 @@ const VariantEntity = () => {
           }
           key={mTabKeys.summary}
         >
-          <TabSummary variantId={hash} />
+          <TabSummary field={field} value={value} />
         </TabPane>
         <TabPane
           tab={
@@ -62,7 +68,7 @@ const VariantEntity = () => {
           }
           key={mTabKeys.frequencies}
         >
-          <TabFrequencies variantId={hash} />
+          <TabFrequencies field={field} value={value} />
         </TabPane>
         <TabPane
           tab={
@@ -73,7 +79,7 @@ const VariantEntity = () => {
           }
           key={mTabKeys.clinical}
         >
-          <TabClinical variantId={hash} />
+          <TabClinical field={field} value={value} />
         </TabPane>
       </Tabs>
     </PageContent>

--- a/src/pages/variantsSearchPage/VariantTableContainer.tsx
+++ b/src/pages/variantsSearchPage/VariantTableContainer.tsx
@@ -62,12 +62,12 @@ const generateColumns = (props: Props, studyList: StudiesResult[]) =>
   [
     {
       title: 'Variant',
-      dataIndex: 'hgvsg',
+      dataIndex: 'locus',
       className: `${style.variantTableCell} ${style.variantTableCellElipsis}`,
       render: (hgvsg: string, record: VariantEntity) =>
         hgvsg ? (
           <Tooltip placement="topLeft" title={hgvsg}>
-            <Link to={`/variant/${record.hash}?hgvsg=${hgvsg}`} href={'#top'}>
+            <Link to={`/variant/locus=${record.locus}`} href={'#top'}>
               {hgvsg}
             </Link>
           </Tooltip>

--- a/src/store/graphql/utils/query.ts
+++ b/src/store/graphql/utils/query.ts
@@ -29,14 +29,14 @@ export const useLazyResultQuery = <TData = any, TVariables = OperationVariables>
   return { error, loading, result };
 };
 
-export const buildVariantIdSqon = (id: string) => ({
+export const buildVariantSqon = (field: string, value: string) => ({
   op: 'and',
   content: [
     {
       op: 'in',
       content: {
-        field: 'hash',
-        value: id,
+        field,
+        value,
       },
     },
   ],

--- a/src/store/graphql/variants/tabActions.tsx
+++ b/src/store/graphql/variants/tabActions.tsx
@@ -1,14 +1,14 @@
-import { buildVariantIdSqon, useLazyResultQuery } from '../utils/query';
+import { buildVariantSqon, useLazyResultQuery } from '../utils/query';
 
 import { StudyNode } from './models';
 import { TAB_CLINICAL_QUERY, TAB_FREQUENCIES_QUERY, TAB_SUMMARY_QUERY } from './queries';
 
 const MAX_NUMBER_STUDIES = 2000;
 
-export const useTabFrequenciesData = (variantId: string) => {
+export const useTabFrequenciesData = (field: string, value: string) => {
   const { loading, result, error } = useLazyResultQuery<any>(TAB_FREQUENCIES_QUERY, {
     variables: {
-      sqon: buildVariantIdSqon(variantId),
+      sqon: buildVariantSqon(field, value),
       studiesSize: MAX_NUMBER_STUDIES,
     },
   });
@@ -35,19 +35,19 @@ export const useTabFrequenciesData = (variantId: string) => {
   };
 };
 
-export const useTabSummaryData = (variantId: string) => {
+export const useTabSummaryData = (field: string, value: string) => {
   const { loading, result, error } = useLazyResultQuery<any>(TAB_SUMMARY_QUERY, {
     variables: {
-      sqon: buildVariantIdSqon(variantId),
+      sqon: buildVariantSqon(field, value),
     },
   });
   return { loading, data: result?.variants?.hits?.edges[0]?.node, error };
 };
 
-export const useTabClinicalData = (variantId: string) => {
+export const useTabClinicalData = (field: string, value: string) => {
   const { loading, result, error } = useLazyResultQuery<any>(TAB_CLINICAL_QUERY, {
     variables: {
-      sqon: buildVariantIdSqon(variantId),
+      sqon: buildVariantSqon(field, value),
     },
   });
   return { loading, data: result?.variants?.hits?.edges[0]?.node || {}, error };


### PR DESCRIPTION
#[Variant Entity Page Routing]

- closes [#SKFP-338](https://d3b.atlassian.net/browse/SKFP-338)

## Description
Routing to entity variant page to be done by locus code

## Screenshot (Before and After)
![image](https://user-images.githubusercontent.com/29788342/166257422-1697543b-5cb9-41bb-b83d-bdb012f5272e.png)

![image](https://user-images.githubusercontent.com/29788342/166257498-4ef01b36-8008-4b60-8642-bb2e99820a40.png)

## Mention

@oliviercperrier 
