### PR TITLE
fix: #SKFP-347 display child nodes from search match

### DIFF
--- a/src/components/OntologyBrowser/SelectionTree.tsx
+++ b/src/components/OntologyBrowser/SelectionTree.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Component, Fragment } from 'react';
-import { Button, Col, Input, Row, Tree } from 'antd';
-import { TreeNode } from './Model';
 import { BranchesOutlined, UserOutlined } from '@ant-design/icons';
+import { Button, Col, Input, Row, Tree } from 'antd';
+
+import { TreeNode } from './Model';
+import TermCounts from './TermCounts';
 
 import './SelectionTree.css';
-import TermCounts from './TermCounts';
 
 type SelectionTreeProps = {
   dataSource: TreeNode[];
@@ -102,8 +103,10 @@ export class SelectionTree extends Component<SelectionTreeProps, SelectionTreeSt
     const cleanSearchText = searchText.replace(/[-/\\^$*+?.()|[\]{}]/g, '');
     const regex = new RegExp('\\b(\\w*' + cleanSearchText + '\\w*)\\b', 'gi');
     const text = treeNode.text;
+    const key = treeNode.key;
     const result = text.search(regex) >= 0;
-    let match = cleanSearchText === '' || result;
+    const resultKey = key.search(regex) >= 0;
+    let match = cleanSearchText === '' || result || resultKey;
 
     if (treeNode.children.length > 0) {
       let matchChild = cleanSearchText === '' || false;
@@ -118,7 +121,7 @@ export class SelectionTree extends Component<SelectionTreeProps, SelectionTreeSt
 
     if (!treeNode.hidden) {
       hitTreeNodes.push(treeNode.key);
-      if (result) {
+      if (result || resultKey) {
         const [before, hit, after] = treeNode.text.split(regex);
         treeNode.title = (
           <span>

--- a/src/components/OntologyBrowser/SelectionTree.tsx
+++ b/src/components/OntologyBrowser/SelectionTree.tsx
@@ -123,15 +123,17 @@ export class SelectionTree extends Component<SelectionTreeProps, SelectionTreeSt
       hitTreeNodes.push(treeNode.key);
       if (result || resultKey) {
         const [before, hit, after] = treeNode.text.split(regex);
-        treeNode.title = (
-          <span>
-            {before}
-            <div className={'highlight'} style={{ display: 'inherit' }}>
-              {hit}
-            </div>
-            {after}
-          </span>
-        );
+        if (hit) {
+          treeNode.title = (
+            <span>
+              {before}
+              <div className={'highlight'} style={{ display: 'inherit' }}>
+                {hit}
+              </div>
+              {after}
+            </span>
+          );
+        }
       }
     }
     return match;

--- a/src/components/OntologyBrowser/Test/SelectionTree.test.tsx
+++ b/src/components/OntologyBrowser/Test/SelectionTree.test.tsx
@@ -138,7 +138,7 @@ describe('In SelectionTree', () => {
                   'Abnormality of the integument (HP:0001574)-' +
                   'Abnormality of skin adnexa morphology (HP:0011138)-' +
                   'Skin appendage neoplasm (HP:0012842)',
-                hidden: true,
+                hidden: false,
                 results: 2,
                 exactTagCount: 2,
                 valueText: 12,
@@ -152,7 +152,7 @@ describe('In SelectionTree', () => {
                   'Abnormality of the integument (HP:0001574)-' +
                   'Abnormality of skin adnexa morphology (HP:0011138)-' +
                   'Abnormal hair morphology (HP:0001595)',
-                hidden: true,
+                hidden: false,
                 results: 2,
                 exactTagCount: 2,
                 valueText: 24,
@@ -165,7 +165,7 @@ describe('In SelectionTree', () => {
                 key:
                   'Abnormality of the integument (HP:0001574)-' +
                   'Abnormality of skin adnexa morphology (HP:0011138)-Custom term xyz',
-                hidden: true,
+                hidden: false,
                 results: 1,
                 exactTagCount: 1,
                 valueText: 112,
@@ -179,7 +179,7 @@ describe('In SelectionTree', () => {
     ];
 
     const event = {
-      target: { value: 'adne' },
+      target: { value: 'adnexa' },
     } as React.ChangeEvent<HTMLInputElement>;
 
     wrapper.find('Input').simulate('change', event);


### PR DESCRIPTION
# FEATURE  display child nodes from search match

- closes [SKFP-347](https://d3b.atlassian.net/browse/SKFP-347)

## Description

Display all child node matched by the query

## Screenshot (Before and After)
![image](https://user-images.githubusercontent.com/29788342/172658914-d7be8558-cd2b-402e-88c2-4d752c465e83.png)


## Mention

@ QA, Design ...
