### PR TITLE
feat(theme): SKFP-381 add kids-first colorscheme to the dashboard page

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -1,7 +1,7 @@
 NODE_ENV=development
 PORT=3000
 HTTPS=false
-REACT_APP_TITLE=INCLUDE-UI-DEVEL
+REACT_APP_TITLE=KIDS-FIRST-UI-DEVEL
 REACT_APP_RELEASE_ID=$npm_package_version
 REACT_APP_RELEASE_NAME=$npm_package_versionName
 REACT_APP_NOSCRIPT_CONTENT=JavaScript is required.
@@ -40,7 +40,7 @@ REACT_APP_FT_DASHBOARD_BANNER_TYPE=info
 REACT_APP_FT_DASHBOARD_BANNER_MSG="A wonderful notification"
 
 # Style
-SASS_PATH=./src/style/themes/include
+SASS_PATH=./src/style/themes/kids-first
 
 #CI
 # Put to false for warnings to fail build

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -21,5 +21,5 @@ export const FILTER_ID_QUERY_PARAM_KEY = 'filterId';
 export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
 
 export const DEFAULT_GRAVATAR_PLACEHOLDER = `${EnvironmentVariables.configFor(
-  'INCLUDE_WEB_ROOT',
+  'WEB_ROOT',
 )}/avatar-placeholder.png`;

--- a/src/components/Layout/SideImage/index.tsx
+++ b/src/components/Layout/SideImage/index.tsx
@@ -23,7 +23,7 @@ const SideImageLayout = ({
 }: OwnProps) => (
   <div className={style.sideImagePageContainer}>
     {logoSrc && (
-      <a href={EnvVariables.configFor('INCLUDE_WEB_ROOT')}>
+      <a href={EnvVariables.configFor('WEB_ROOT')}>
         <img className={style.logoImage} src={logoSrc} alt="Include Logo Logo" />
       </a>
     )}

--- a/src/helpers/EnvVariables.ts
+++ b/src/helpers/EnvVariables.ts
@@ -2,7 +2,7 @@ export default class EnvironmentVariables {
   static vars: Record<string, string | undefined> = {
     // GENERAL
     ENV: process.env.NODE_ENV,
-    INCLUDE_WEB_ROOT: process.env.REACT_APP_INCLUDE_WEB_ROOT,
+    WEB_ROOT: process.env.REACT_APP_WEB_ROOT,
     // APIS
     ARRANGER_API: process.env.REACT_APP_ARRANGER_API_URL,
     ARRANGER_PROJECT_ID: process.env.REACT_APP_ARRANGER_PROJECT_ID,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -360,9 +360,9 @@ const en = {
         authorizedStudies: {
           title: 'Authorized Studies {count, plural, =0 {} other {(#)}}',
           connectedNotice:
-            'You have access to the following INCLUDE controlled data through your NIH credentials.',
+            'You have access to the following KIDS FIRST controlled data through your NIH credentials.',
           disconnectedNotice:
-            'Access INCLUDE controlled-access data by connecting your account using your NIH Credentials',
+            'Access controlled-access data by connecting your account using your NIH Credentials',
           disconnect: 'Disconnect',
           noAvailableStudies: 'No available studies',
           authorization: 'Authorization',
@@ -389,7 +389,7 @@ const en = {
         cavatica: {
           title: 'Cavatica Projects',
           connectedNotice: 'You are connected to the Cavatica cloud environment.',
-          disconnectedNotice: 'To analyze INCLUDE data on the cloud, connect to Cavatica.',
+          disconnectedNotice: 'To analyze KIDS FIRST data on the cloud, connect to Cavatica.',
           disconnect: 'Disconnect',
           noProjects: 'You do not have any Cavatica projects.',
           createNewProject: 'Create your first project',
@@ -547,36 +547,36 @@ const en = {
       back: 'Back',
       submit: 'Submit',
       disclaimers: {
-        title: 'INCLUDE Portal Registration Process',
+        title: 'KIDS FIRST Portal Registration Process',
         description:
-          'The INCLUDE Portal is the primary entry point to the INCLUDE Data Hub. The INCLUDE Portal enables searching, visualizing, and accessing INCLUDE-relevant data. Some datasets may require additional approvals (e.g., dbGaP) and terms and conditions of access and use.',
+          'The KIDS FIRST Portal is the primary entry point to the KIDS FIRST Data Hub. The KIDS FIRST Portal enables searching, visualizing, and accessing KIDS FIRST-relevant data. Some datasets may require additional approvals (e.g., dbGaP) and terms and conditions of access and use.',
         terms: {
-          title: 'INCLUDE Portal Terms & Conditions',
+          title: 'KIDS FIRST Portal Terms & Conditions',
           lastUpdate: 'Last Update: {date}',
           bullets: {
-            1: 'My purpose for the use of INCLUDE Portal data is free from discrimination on the grounds of race, ethnicity, nationality, gender, age, physical and/or mental ability, sexual orientation, gender identity or expression, religion, or any other grounds that would impinge on an individual’s rights.',
-            2: 'I will acknowledge specific dataset(s) and/or applicable accession number(s) as well as the INCLUDE Data Hub in my dissemination of research findings, as applicable to the medium or type of dissemination.',
-            3: 'I will only share or distribute INCLUDE Portal data under terms consistent with this agreement, and the data or derivatives of the data may not be sold, in whole or in part, to any individual at any point in time for any purpose.',
+            1: 'My purpose for the use of KIDS FIRST Portal data is free from discrimination on the grounds of race, ethnicity, nationality, gender, age, physical and/or mental ability, sexual orientation, gender identity or expression, religion, or any other grounds that would impinge on an individual’s rights.',
+            2: 'I will acknowledge specific dataset(s) and/or applicable accession number(s) as well as the KIDS FIRST Data Hub in my dissemination of research findings, as applicable to the medium or type of dissemination.',
+            3: 'I will only share or distribute KIDS FIRST Portal data under terms consistent with this agreement, and the data or derivatives of the data may not be sold, in whole or in part, to any individual at any point in time for any purpose.',
             4: 'I will respect the privacy of research participants, and I will make no attempt to identify or contact individual participants or groups from whom data were collected or to generate information that could allow participants’ identities to be readily ascertained.',
-            5: 'I agree to provide a brief statement regarding my intended use of the data on the INCLUDE Portal with my name and affiliation which will be publicly displayed for the purpose of transparency and collaboration.',
-            6: 'I understand that participation in the INCLUDE community is voluntary and may be terminated by the INCLUDE Portal Administrator. I will report any actual or suspected violation of this agreement, even if unintentional, to the INCLUDE Portal Administrator. I understand that the INCLUDE Portal Administrator may take action to remedy any actual or suspected violation and/or report such behavior to the appropriate authorities.  I also understand that the INCLUDE Portal Administrator may immediately suspend or terminate my access to the INCLUDE Portal if there is an actual or suspected violation of this agreement.',
+            5: 'I agree to provide a brief statement regarding my intended use of the data on the KIDS FIRST Portal with my name and affiliation which will be publicly displayed for the purpose of transparency and collaboration.',
+            6: 'I understand that participation in the KIDS FIRST community is voluntary and may be terminated by the KIDS FIRST Portal Administrator. I will report any actual or suspected violation of this agreement, even if unintentional, to the KIDS FIRST Portal Administrator. I understand that the KIDS FIRST Portal Administrator may take action to remedy any actual or suspected violation and/or report such behavior to the appropriate authorities.  I also understand that the KIDS FIRST Portal Administrator may immediately suspend or terminate my access to the KIDS FIRST Portal if there is an actual or suspected violation of this agreement.',
           },
-          checkbox: 'I have read and agree to the INCLUDE Portal Terms and Conditions',
+          checkbox: 'I have read and agree to the KIDS FIRST Portal Terms and Conditions',
         },
         disclaimer: {
-          title: 'INCLUDE Portal Disclaimers',
+          title: 'KIDS FIRST Portal Disclaimers',
           bullets: {
-            1: 'Data available in the INCLUDE Portal is provided on an AS-IS basis and may change over time.',
-            2: 'The INCLUDE DCC does not warrant or assume any legal liability or responsibility for information, apparatus, product, or process contained in the INCLUDE Portal.',
-            3: 'Content provided on the INCLUDE Portal is for informational purposes only and is not intended to be a substitute for independent professional medical judgment, advice, diagnosis, or treatment.',
+            1: 'Data available in the KIDS FIRST Portal is provided on an AS-IS basis and may change over time.',
+            2: 'The KIDS FIRST DCC does not warrant or assume any legal liability or responsibility for information, apparatus, product, or process contained in the KIDS FIRST Portal.',
+            3: 'Content provided on the KIDS FIRST Portal is for informational purposes only and is not intended to be a substitute for independent professional medical judgment, advice, diagnosis, or treatment.',
           },
-          checkbox: 'I have read and understand the INCLUDE Portal Disclaimers',
+          checkbox: 'I have read and understand the KIDS FIRST Portal Disclaimers',
         },
         errors: 'Please accept the terms & conditions and portal disclaimers.',
       },
       registration: {
         notice:
-          'Information provided here will be shared with the INCLUDE community on the INCLUDE Portal. All fields are required unless specified as optional.',
+          'Information provided here will be shared with the KIDS FIRST community on the KIDS FIRST Portal. All fields are required unless specified as optional.',
         sections: {
           identification: 'Identification',
           roleAndAffiliation: 'Role & Affiliation',
@@ -594,7 +594,7 @@ const en = {
           iAmA: 'I am a:',
           pleaseDescribe: 'Please describe',
           iAmAffiliatedWith: 'I am affiliated with:',
-          intendToUser: 'I intend to use the INCLUDE Portal data for:',
+          intendToUser: 'I intend to use the KIDS FIRST Portal data for:',
           dataUseStatement: 'Data use statement',
           researchAreaDescribe: 'My research area or area of interest may best be described as:',
         },

--- a/src/style/themes/kids-first/antd-kids-first-theme.less
+++ b/src/style/themes/kids-first/antd-kids-first-theme.less
@@ -34,7 +34,7 @@
 // TEXT COLORS
 @text-color: @gray-8;
 @text-color-secondary: @gray-7;
-@heading-color: @gray-9;
+@heading-color: @geekblue-7;
 
 // CASCADER
 @cascader-item-selected-bg: @gray-3;

--- a/src/style/themes/kids-first/colors.less
+++ b/src/style/themes/kids-first/colors.less
@@ -104,10 +104,11 @@
 @cyan-1: #ddf4f8;
 @cyan-2: #c1e6ec;
 @cyan-4: #86d6df;
-@cyan-5: #20b1c7;
+@cyan-5: #33b8cc;
 @cyan-6: #009bba;
 @cyan-7: #007694;
 @cyan-8: #00546e;
+@cyan-9: #003447;
 
 @geekblue-1: #f0f5ff;
 @geekblue-2: #d6e4ff;
@@ -115,7 +116,7 @@
 @geekblue-4: #85a5ff;
 @geekblue-5: #597ef7;
 @geekblue-6: #2f54eb;
-@geekblue-7: #1d39c4;
+@geekblue-7: #2b388f;
 @geekblue-8: #10239e;
 @geekblue-9: #061178;
 @geekblue-10: #030852;

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
@@ -5,11 +5,11 @@
   background-color: transparent;
   width: 100%;
   border-radius: 2px;
-  border: 1px solid $gray-7;
+  border: 1px solid $cyan-7;
 
   &:hover {
-    background-color: $gray-9;
-    border-color: $gray-9;
+    background-color: $cyan-9;
+    border-color: $cyan-9;
 
     .linkArrow {
       opacity: 1;
@@ -24,12 +24,12 @@
     margin-left: -8px;
     margin-top: 5px;
     font-size: 20px;
-    color: $blue-7;
+    color: $cyan-5;
   }
 
   .linkTitle {
     font-weight: 500;
-    color: $gray-8;
+    color: $gray-1;
     font-size: 16px;
   }
 }

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.module.scss
@@ -2,7 +2,7 @@
 
 .dataExplorationLinksWrapper {
   .dataExplorationLinksCard {
-    background-color: $gray-8 !important;
+    background-color: $cyan-8 !important;
     border: none;
     padding-bottom: 16px !important;
 
@@ -47,7 +47,7 @@
 
     .dataReleaseIcon {
       margin-top: -1px;
-      color: $blue-7;
+      color: $cyan-5;
       font-size: 20px;
     }
 


### PR DESCRIPTION
# FEATURE 

- closes #381

## Description
Goal:  Refactor the Authorized Studies widget seen in INCLUDE. The KF Authorized Studies widget will have two connections (fences). This will allow users with the appropriate Fence credentials to access their controlled data files. 

Upon clicking on the Connect button, it will open the Connections modal seen in the Design. Once a user clicks either connection, it will redirect to their respective Gen3 login process (See KF settings page for more information on redirect).

With a successful login, the toggle with be “Activated”, and the Authorized Studies widget will be populated with the Studies with controlled data that the user has access to


## Screenshot 
![image](https://user-images.githubusercontent.com/65532894/186500642-2eaa8fcb-a8d8-451c-a0c0-99caf6ce7bd2.png)

