### PR TITLE
:lipstick: feat(dashboard): SKFP-377 add variants tab in saved filters

### DIFF
--- a/src/services/api/savedFilter/models.ts
+++ b/src/services/api/savedFilter/models.ts
@@ -7,6 +7,11 @@ export type TUserSavedFilter = ISavedFilter & {
   updated_date: string;
 };
 
+export enum SavedFilterTag {
+  PARTICIPANT = 'participant',
+  VARIANT = 'variants-exploration',
+}
+
 export type TUserSavedFilterInsert = Omit<
   TUserSavedFilter,
   'keycloak_id' | 'updated_date' | 'creation_date'

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -1,13 +1,33 @@
 .savedFiltersList {
+  height: 100%;
+  overflow: auto;
+  min-height: 200px;
+
+  div[class$='-item-meta'] {
+    margin-bottom: 0;
+  }
+
+  *[class$='-item-meta-description'] {
+    font-size: 12px;
+  }
+}
+
+.setTabs {
+  height: 100%;
+
+  :global(.ant-tabs-content) {
     height: 100%;
-    overflow: auto;
-    min-height: 200px;
+  }
 
-    div[class$="-item-meta"] {
-        margin-bottom: 0;
-    }
+  :global(.ant-tabs-tab) {
+    padding-top: 0 !important;
+  }
 
-    *[class$="-item-meta-description"] {
-        font-size: 12px;
+  &:global(.ant-tabs-top) {
+    :global(.ant-tabs-nav) {
+      &::before {
+        border: none;
+      }
     }
+  }
 }

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -21,15 +21,22 @@ import { SUPPORT_EMAIL } from 'store/report/thunks';
 const { Text } = Typography;
 const { TabPane } = Tabs;
 
-const getItemList = (
-  tag: SavedFilterTag,
-  savedFilters: TUserSavedFilter[],
-  fetchingError: boolean,
-  isLoading: boolean,
-) => (
+type SavedFilterListWrapperOwnprops = {
+  tag: SavedFilterTag;
+  savedFilters: TUserSavedFilter[];
+  fetchingError: boolean;
+  isLoading: boolean;
+};
+
+const SavedFilterListWrapper = ({
+  tag,
+  savedFilters,
+  fetchingError,
+  isLoading,
+}: SavedFilterListWrapperOwnprops) => (
   <List<TUserSavedFilter>
     className={styles.savedFiltersList}
-    key="2"
+    key={tag}
     bordered
     locale={{
       emptyText: fetchingError ? (
@@ -37,7 +44,7 @@ const getItemList = (
           title="Failed to Fetch Saved Filters"
           subTitle={
             <Text>
-              Please refresh and try again or{' '}
+              Please refresh and try again or
               <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
                 <Text>contact our support</Text>
               </ExternalLink>
@@ -103,7 +110,12 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
               </div>
             }
           >
-            {getItemList(SavedFilterTag.PARTICIPANT, savedFilters, fetchingError, isLoading)}
+            <SavedFilterListWrapper
+              tag={SavedFilterTag.PARTICIPANT}
+              savedFilters={savedFilters}
+              fetchingError={fetchingError}
+              isLoading={isLoading}
+            />
           </TabPane>
 
           <TabPane
@@ -115,7 +127,12 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
               </div>
             }
           >
-            {getItemList(SavedFilterTag.VARIANT, savedFilters, fetchingError, isLoading)}
+            <SavedFilterListWrapper
+              tag={SavedFilterTag.VARIANT}
+              savedFilters={savedFilters}
+              fetchingError={fetchingError}
+              isLoading={isLoading}
+            />
           </TabPane>
         </Tabs>
       }

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -1,21 +1,62 @@
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import { List, Typography } from 'antd';
+import cx from 'classnames';
+import { Tabs, List, Typography } from 'antd';
 import intl from 'react-intl-universal';
 import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
 import CardHeader from 'views/Dashboard/components/CardHeader';
 import Empty from '@ferlab/ui/core/components/Empty';
 import SavedFiltersListItem from './ListItem';
 import { useSavedFilter } from 'store/savedFilter';
-import { TUserSavedFilter } from 'services/api/savedFilter/models';
+import { SavedFilterTag, TUserSavedFilter } from 'services/api/savedFilter/models';
 import CardErrorPlaceholder from 'views/Dashboard/components/CardErrorPlaceHolder';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { STATIC_ROUTES } from 'utils/routes';
 import PopoverContentLink from 'components/uiKit/PopoverContentLink';
+import { UserOutlined } from '@ant-design/icons';
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 
 import styles from './index.module.scss';
-import {SUPPORT_EMAIL} from "store/report/thunks";
+import { SUPPORT_EMAIL } from 'store/report/thunks';
 
 const { Text } = Typography;
+const { TabPane } = Tabs;
+
+const getItemList = (
+  tag: SavedFilterTag,
+  savedFilters: TUserSavedFilter[],
+  fetchingError: boolean,
+  isLoading: boolean,
+) => (
+  <List<TUserSavedFilter>
+    className={styles.savedFiltersList}
+    key="2"
+    bordered
+    locale={{
+      emptyText: fetchingError ? (
+        <CardErrorPlaceholder
+          title="Failed to Fetch Saved Filters"
+          subTitle={
+            <Text>
+              Please refresh and try again or{' '}
+              <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
+                <Text>contact our support</Text>
+              </ExternalLink>
+              .
+            </Text>
+          }
+        />
+      ) : (
+        <Empty
+          imageType="grid"
+          description={intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
+        />
+      ),
+    }}
+    dataSource={fetchingError ? [] : savedFilters.filter((s) => s.tag === tag)}
+    loading={isLoading}
+    renderItem={(item) => <SavedFiltersListItem id={item.id} data={item} />}
+  />
+);
 
 const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
   const { savedFilters, isLoading, fetchingError } = useSavedFilter();
@@ -48,35 +89,35 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
         />
       }
       content={
-        <List<TUserSavedFilter>
-          className={styles.savedFiltersList}
-          key="2"
-          bordered
-          locale={{
-            emptyText: fetchingError ? (
-              <CardErrorPlaceholder
-                title="Failed to Fetch Saved Filters"
-                subTitle={
-                  <Text>
-                    Please refresh and try again or{' '}
-                    <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                      <Text>contact our support</Text>
-                    </ExternalLink>
-                    .
-                  </Text>
-                }
-              />
-            ) : (
-              <Empty
-                imageType="grid"
-                description={intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
-              />
-            ),
-          }}
-          dataSource={fetchingError ? [] : savedFilters}
-          loading={isLoading}
-          renderItem={(item) => <SavedFiltersListItem id={item.id} data={item} />}
-        />
+        <Tabs
+          className={cx(styles.setTabs, 'navNoMarginBtm')}
+          defaultActiveKey={SavedFilterTag.PARTICIPANT}
+        >
+          <TabPane
+            key={SavedFilterTag.PARTICIPANT}
+            tab={
+              <div>
+                <UserOutlined />
+                Participants (
+                {savedFilters.filter((s) => s.tag === SavedFilterTag.PARTICIPANT).length})
+              </div>
+            }
+          >
+            {getItemList(SavedFilterTag.PARTICIPANT, savedFilters, fetchingError, isLoading)}
+          </TabPane>
+
+          <TabPane
+            key={SavedFilterTag.VARIANT}
+            tab={
+              <div>
+                <LineStyleIcon height={14} width={14} />
+                Variants ({savedFilters.filter((s) => s.tag === SavedFilterTag.VARIANT).length})
+              </div>
+            }
+          >
+            {getItemList(SavedFilterTag.VARIANT, savedFilters, fetchingError, isLoading)}
+          </TabPane>
+        </Tabs>
       }
     />
   );


### PR DESCRIPTION
# FEATURE 

- closes [#448](https://d3b.atlassian.net/browse/SKFP-448)

## Description
Set up the Saved Filter widget as it is in INCLUDE. One difference, however, is that the users will be able to save filters from the Data Exploration page but also from the Variant Search page. Therefore, we will need to migrate the API to function with the Variant Search query management bar.


## Video

https://user-images.githubusercontent.com/65532894/190187902-d8c043f3-ef5f-4e7e-804f-805ab64b8253.mp4



