### PR TITLE
:bandaid: fix(registration): SKFP-462 SKFP-463 SKFP-464 visuals fix

### DIFF
--- a/src/views/Persona/components/RegistrationForm/index.tsx
+++ b/src/views/Persona/components/RegistrationForm/index.tsx
@@ -69,7 +69,11 @@ const Registration = ({ handleBack, hidden = true, kcToken, onFinishCallback }: 
           <Title level={3} className={styles.title}>
             Role & Affiliation
           </Title>
-          <Form.Item name="roles" label="I am a:">
+          <Form.Item
+            name="roles"
+            label="I am a:"
+            rules={[{ required: true, message: 'This field is required' }]}
+          >
             <Checkbox.Group>
               <Space direction="vertical" size={8}>
                 <div>Check all that apply</div>
@@ -100,16 +104,14 @@ const Registration = ({ handleBack, hidden = true, kcToken, onFinishCallback }: 
           </Form.Item>
 
           <Row justify="space-between">
-            <Button onClick={handleBack} size={'large'}>
+            <Button onClick={handleBack}>
               <ArrowLeftOutlined />
               Back
             </Button>
             <Space size={16}>
-              <Button onClick={handleCancel} size={'large'}>
-                Cancel
-              </Button>
-              <Button type={'primary'} onClick={handleSubmit} size={'large'}>
-                Accept
+              <Button onClick={handleCancel}>Cancel</Button>
+              <Button type={'primary'} onClick={handleSubmit}>
+                Submit
               </Button>
             </Space>
           </Row>

--- a/src/views/Persona/components/TermsConditions/index.tsx
+++ b/src/views/Persona/components/TermsConditions/index.tsx
@@ -125,13 +125,13 @@ const TermsConditions = ({ isMultiStep = false, hidden = false, onFinish }: OwnP
       style={inlineStyle}
     >
       <Space direction="vertical" size={24} className={styles.termsAndConditionsWrapper}>
-        <Title level={3}>KIDS FIRST Portal Registration Process</Title>
+        <Title level={3}>Kids First Portal Registration Process</Title>
         <GridCard
           wrapperClassName={styles.cardWrapper}
           className={styles.card}
           title={
             <div className={styles.termsCardHeader}>
-              <Title level={5}>KIDS FIRST Portal Terms & Conditions</Title>
+              <Title level={5}>Kids First Portal Terms & Conditions</Title>
               <span className={styles.lastUpdateDate}>Last Update: 11/22/2021</span>
             </div>
           }
@@ -148,17 +148,15 @@ const TermsConditions = ({ isMultiStep = false, hidden = false, onFinish }: OwnP
         >
           <Checkbox.Group>
             <Checkbox value="acceptedTerms">
-              I have read and agree to the KF Portal Terms and Conditions
+              I have read and agree to the Kids First Portal Terms and Conditions
             </Checkbox>
           </Checkbox.Group>
         </Form.Item>
 
         <Row justify="end">
           <Space size={16}>
-            <Button onClick={handleCancel} size={'large'}>
-              Cancel
-            </Button>
-            <Button type={'primary'} size={'large'} onClick={handleSubmit}>
+            <Button onClick={handleCancel}>Cancel</Button>
+            <Button type={'primary'} onClick={handleSubmit}>
               {isMultiStep ? 'Next' : 'Accept'}
             </Button>
           </Space>


### PR DESCRIPTION
# BUG

- closes [#462](https://d3b.atlassian.net/browse/SKFP-462) [#463](https://d3b.atlassian.net/browse/SKFP-463) [#464](https://d3b.atlassian.net/browse/SKFP-464)

## Description

Goal: Adjust KIDS FIRST to Kids First for the red boxes. Also, in the green box, instead of writing KF, write Kids First. 
The font size for the buttons at the bottom of the registration page should be 14px
The “Accept” button should be “Submit” instead 
The "I am a" field should be required. If a user selects a checkmark and deselects, the error message saying that this field is required should appear. Similarly, if the user does not check one of the boxes and clicks “Submit”, the error message should appear under the specific field. 

## Screenshot (Before and After)
![Screenshot_20220923_114608](https://user-images.githubusercontent.com/65532894/192001868-d8471b7f-c0c6-4435-aa07-b3cb45a540b0.png)
![Screenshot_20220923_115005](https://user-images.githubusercontent.com/65532894/192001872-d39b9e13-2a4d-48a0-b29b-3a824ea00099.png)

