### PR TITLE
:bug: fix(studies): SKFP-465 remove external id face and add it t…

### DIFF
--- a/src/graphql/studies/queries.ts
+++ b/src/graphql/studies/queries.ts
@@ -34,6 +34,7 @@ export const SEARCH_STUDIES_BY_ID_AND_NAME_QUERY = gql`
           node {
             study_id
             study_name
+            external_id
           }
         }
       }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -38,6 +38,7 @@ const en = {
         emptyText: 'No study found',
         placeholder: 'e.g. KF-DSD, Neuroblastoma…',
         title: 'Search studies',
+        tooltip: 'Search by Study Code, Study name, dbGaP Accession number',
       },
     },
     filters: {

--- a/src/views/Studies/components/StudySearch/index.tsx
+++ b/src/views/Studies/components/StudySearch/index.tsx
@@ -17,7 +17,8 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
     <GlobalSearch<IStudiesEntity>
       queryBuilderId={queryBuilderId}
       field="study_id"
-      searchFields={['study_id', 'study_name']}
+      searchFields={['study_id', 'study_name', 'external_id']}
+      tooltipText={intl.get('global.search.study.tooltip')}
       index={INDEXES.STUDIES}
       placeholder={intl.get(`global.search.study.placeholder`)}
       emptyDescription={intl.get(`global.search.study.emptyText`)}

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -32,22 +32,10 @@ const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
 
 const filterInfo: FilterInfo = {
   customSearches: [<StudySearch queryBuilderId={STUDIES_REPO_QB_ID} />],
-  defaultOpenFacets: [
-    'external_id',
-    'program',
-    'data_category',
-    'experimental_strategy',
-    'family_data',
-  ],
+  defaultOpenFacets: ['program', 'data_category', 'experimental_strategy', 'family_data'],
   groups: [
     {
-      facets: [
-        'external_id',
-        'program',
-        'data_category',
-        'experimental_strategy',
-        'family_data',
-      ],
+      facets: ['program', 'data_category', 'experimental_strategy', 'family_data'],
     },
   ],
 };
@@ -70,18 +58,6 @@ const columns: ProColumnType<any>[] = [
     key: 'program',
     title: 'Program',
     dataIndex: 'program',
-  },
-  {
-    key: 'external_id',
-    title: 'dbGaP',
-    dataIndex: 'external_id',
-    render: (external_id: string) => (
-      <ExternalLink
-        href={`https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=${external_id}`}
-      >
-        {external_id}
-      </ExternalLink>
-    ),
   },
   {
     key: 'participant_count',
@@ -169,13 +145,15 @@ const columns: ProColumnType<any>[] = [
     key: 'proteomic',
     title: 'Proteomics',
     align: 'center',
-    render: (record: IStudiesEntity) => hasDataCategory(record.data_category, DataCategory.PROTEOMIC),
+    render: (record: IStudiesEntity) =>
+      hasDataCategory(record.data_category, DataCategory.PROTEOMIC),
   },
   {
     key: 'clinical',
     title: 'Clinicals',
     align: 'center',
-    render: (record: IStudiesEntity) => hasDataCategory(record.data_category, DataCategory.PROTEOMIC),
+    render: (record: IStudiesEntity) =>
+      hasDataCategory(record.data_category, DataCategory.PROTEOMIC),
   },
 ];
 


### PR DESCRIPTION
…o search

# BUG

- closes [#465](https://d3b.atlassian.net/browse/SKFP-465)

## Description

Remove the External ID from the Study page facets. We will allow users to search using the dbGaP accession numbers (e.g., Phs001178) using the “Search Studies” auto-suggestion search bar. A user will type in Phs001____ and it will filter the studies with a matching dbGaP accession number.

![Screenshot_20220926_110253](https://user-images.githubusercontent.com/65532894/192312608-7dd72e0a-48ca-4592-8c69-5cf0c9de8843.png)
![Screenshot_20220926_110426](https://user-images.githubusercontent.com/65532894/192312612-f2e89545-7acd-4e63-981f-11156fe6c6c1.png)


