### PR TITLE
💄feat(community): SFFP-407 add community page

### DIFF
--- a/src/helpers/EnvVariables.ts
+++ b/src/helpers/EnvVariables.ts
@@ -5,6 +5,7 @@ export default class EnvironmentVariables {
     WEB_ROOT: process.env.REACT_APP_WEB_ROOT,
     // APIS
     PERSONA_API: process.env.REACT_APP_PERSONA_API,
+    LEGACY_MEMBERS_API: process.env.REACT_APP_LEGACY_MEMBERS_API,
     ARRANGER_API: process.env.REACT_APP_ARRANGER_API_URL,
     VARIANT_CLUSTER_API: process.env.REACT_APP_VARIANT_CLUSTER_API,
     ARRANGER_PROJECT_ID: process.env.REACT_APP_ARRANGER_PROJECT_ID,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -461,6 +461,24 @@ const en = {
         },
       },
     },
+    community: {
+      title: 'Kids First Community',
+      resultsMember: 'Members',
+      noResults: 'No members',
+      search: {
+        filters: 'Filters',
+        selectPlaceholder: 'Select',
+        role: 'Member Categories',
+        interest: 'Research Interests',
+        clearFilters: 'Clear filters',
+        barPlaceholder: 'Search by member name or affiliation',
+        sorter: {
+          newest: 'Newest first',
+          oldest: 'Oldest first',
+          lastnameAlpha: 'Alphabetical (last name)',
+        },
+      },
+    },
     variants: {
       sidemenu: {
         participant: 'Participant',

--- a/src/services/api/index.tsx
+++ b/src/services/api/index.tsx
@@ -43,4 +43,23 @@ export const sendRequest = async <T,>(config: AxiosRequestConfig) => {
     );
 };
 
+export const sendRequestMock = async <T,>(config: AxiosRequestConfig, mockResponsed: any) => {
+  return apiInstance
+    .request<T>(config)
+    .then(
+      (response): ApiResponse<T> => ({
+        response: response,
+        data: mockResponsed,
+        error: undefined,
+      }),
+    )
+    .catch((err): ApiResponse<T> => {
+      return {
+        response: err.response,
+        data: mockResponsed,
+        error: undefined,
+      };
+    });
+};
+
 export default apiInstance;

--- a/src/services/api/persona/models.ts
+++ b/src/services/api/persona/models.ts
@@ -4,7 +4,7 @@ export type TPersonaUser = {
   firstName: string;
   lastName: string;
   egoId?: string;
-  roles: string;
+  roles?: string[];
   acceptedTerms: boolean;
   email: string;
   institutionalEmail?: string;
@@ -28,7 +28,7 @@ export type TPersonaUser = {
   github?: string;
   linkedin?: string;
   orchid?: string;
-  interests?: string;
+  interests?: string[];
   acceptedKfOptIn?: boolean;
   acceptedNihOptIn?: boolean;
   acceptedDatasetSubscriptionKfOptIn?: boolean;
@@ -45,12 +45,17 @@ export type TPersonaUserCreate = {
   };
 };
 
-export type TPersonaUserFetch = {
+export type TPersonaSelfFetch = {
   data: {
     self: TPersonaUser;
   };
 };
 
+export type TPersonaProfileFetch = {
+  data: {
+    user: TPersonaUser;
+  };
+};
 export type TUserPersonaInsert = Omit<
   TPersonaUser,
   'id' | 'keycloak_id' | 'creation_date' | 'update_date'

--- a/src/store/persona/slice.ts
+++ b/src/store/persona/slice.ts
@@ -1,10 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { initialState } from 'store/persona/types';
-import { createPersonaUser, fetchPersonaUser } from 'store/persona/thunks';
+import { createPersonaUser, fetchPersonaUser, fetchPersonaUserProfile } from 'store/persona/thunks';
 
 // Since api can return null for personaUserInfo, undefined must be set by default
 export const PersonaState: initialState = {
   personaUserInfo: undefined,
+  profile: undefined,
   isLoading: true,
   isUpdating: false,
   isDeleting: false,
@@ -19,6 +20,9 @@ const personaSlice = createSlice({
       ...state,
       isLoading: action.payload,
     }),
+    clearProfile: (state) => {
+      state.profile = undefined;
+    },
   },
   extraReducers: (builder) => {
     // Create Persona User
@@ -50,6 +54,23 @@ const personaSlice = createSlice({
     builder.addCase(fetchPersonaUser.rejected, (state, action) => ({
       ...state,
       error: action.payload,
+      isLoading: false,
+    }));
+    // Fetch Profile
+    builder.addCase(fetchPersonaUserProfile.pending, (state) => {
+      state.isLoading = true;
+      state.profile = undefined;
+      state.error = undefined;
+    });
+    builder.addCase(fetchPersonaUserProfile.fulfilled, (state, action) => ({
+      ...state,
+      isLoading: false,
+      profile: action.payload,
+    }));
+    builder.addCase(fetchPersonaUserProfile.rejected, (state, action) => ({
+      ...state,
+      error: action.payload,
+      profile: undefined,
       isLoading: false,
     }));
   },

--- a/src/store/persona/thunks.ts
+++ b/src/store/persona/thunks.ts
@@ -26,7 +26,7 @@ const createPersonaUser = createAsyncThunk<
   {
     condition: (_, { getState }) => {
       const { persona } = getState();
-      if (persona.personaUserInfo) {
+      if (persona.profile) {
         return false;
       }
     },
@@ -58,6 +58,24 @@ const fetchPersonaUser = createAsyncThunk<
   },
 );
 
+const fetchPersonaUserProfile = createAsyncThunk<
+  TPersonaUser,
+  {
+    id: string;
+  },
+  { rejectValue: string; state: RootState }
+>('persona/fetch/profile', async (args, thunkAPI) => {
+  console.log('args', args); //TODO: to remove
+  const { data, error } = await PersonaApi.fetchProfile(args.id);
+  console.log('data', data); //TODO: to remove
+
+  if (!error) {
+    return data?.data?.user!;
+  }
+
+  return thunkAPI.rejectWithValue(error?.message);
+});
+
 const updatePersonaUser = createAsyncThunk<
   TPersonaUser,
   {
@@ -86,4 +104,4 @@ const updatePersonaUser = createAsyncThunk<
   },
 );
 
-export { createPersonaUser, fetchPersonaUser, updatePersonaUser };
+export { createPersonaUser, fetchPersonaUser, fetchPersonaUserProfile, updatePersonaUser };

--- a/src/store/persona/types.ts
+++ b/src/store/persona/types.ts
@@ -1,7 +1,8 @@
 import { TPersonaUser } from 'services/api/persona/models';
 
 export type initialState = {
-  personaUserInfo: TPersonaUser | undefined | null;
+  personaUserInfo?: TPersonaUser;
+  profile?: TPersonaUser;
   isLoading: boolean;
   isUpdating: boolean;
   isDeleting: boolean;

--- a/src/views/Community/Member/components/AvatarHeader.tsx
+++ b/src/views/Community/Member/components/AvatarHeader.tsx
@@ -1,13 +1,13 @@
 import Gravatar from '@ferlab/ui/core/components/Gravatar';
 import { Skeleton, Space, Typography } from 'antd';
 import { DEFAULT_GRAVATAR_PLACEHOLDER } from 'common/constants';
-import { TUser } from 'services/api/user/models';
+import { TPersonaUser } from 'services/api/persona/models';
 import { formatName } from '../../utils';
 
 import styles from '../index.module.scss';
 
 interface OwnProps {
-  user?: TUser;
+  user?: TPersonaUser;
   isLoading?: boolean;
 }
 
@@ -21,7 +21,7 @@ const AvatarHeader = ({ user, isLoading = false }: OwnProps) => (
           circle
           className={styles.gravatar}
           placeholder={DEFAULT_GRAVATAR_PLACEHOLDER}
-          email={user?.public_email! || ''}
+          email={user?.email! || ''}
         />
       </div>
     )}
@@ -36,9 +36,9 @@ const AvatarHeader = ({ user, isLoading = false }: OwnProps) => (
           <Typography.Title level={3} className={styles.memberName}>
             {formatName(user!)}
           </Typography.Title>
-          {user?.affiliation && (
+          {/* {user?.affiliation && (
             <Typography.Text type="secondary">{user?.affiliation}</Typography.Text>
-          )}
+          )} */}
         </>
       )}
     </Space>

--- a/src/views/Community/Member/index.tsx
+++ b/src/views/Community/Member/index.tsx
@@ -1,32 +1,36 @@
+import { useEffect } from 'react';
 import { LinkedinFilled, MailFilled } from '@ant-design/icons';
 import cx from 'classnames';
 import Empty from '@ferlab/ui/core/components/Empty';
 import { Col, Divider, List, Result, Row, Skeleton, Space, Typography } from 'antd';
-import useApi from 'hooks/useApi';
 import { useParams } from 'react-router-dom';
-import { headers, USER_API_URL } from 'services/api/user';
-import { TUser } from 'services/api/user/models';
 import Banner from './components/Banner';
 import intl from 'react-intl-universal';
 import AvatarHeader from './components/AvatarHeader';
-import { useUser } from 'store/user';
 
 import styles from './index.module.scss';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { usePersona } from 'store/persona';
+import { fetchPersonaUserProfile } from 'store/persona/thunks';
+import { useDispatch } from 'react-redux';
+import { personaActions } from 'store/persona/slice';
 
 const CommunityMember = () => {
+  const dispatch = useDispatch();
   const { id } = useParams<{ id: string }>();
-  const { userInfo } = useUser();
+  const { personaUserInfo, isLoading, profile } = usePersona();
 
-  const { loading, result } = useApi<TUser>({
-    config: {
-      url: `${USER_API_URL}/${id}`,
-      method: 'GET',
-      headers: headers(),
-    },
-  });
+  useEffect(() => {
+    if (profile === undefined) {
+      dispatch(fetchPersonaUserProfile({ id }));
+    }
 
-  if (!loading && !result) {
+    return () => {
+      dispatch(personaActions.clearProfile());
+    };
+  }, [id, profile, dispatch]);
+
+  if (!isLoading && !profile) {
     return (
       <Result
         className={styles.notFoundMember}
@@ -40,11 +44,11 @@ const CommunityMember = () => {
   return (
     <div className={styles.communityMemberWrapper}>
       <div className={styles.communityMember}>
-        <Banner isOwnUser={userInfo?.keycloak_id === result?.keycloak_id} />
+        <Banner isOwnUser={personaUserInfo?._id === profile?._id} />
         <div className={styles.contentWrapper}>
-          <AvatarHeader user={result} isLoading={loading} />
+          <AvatarHeader user={profile} isLoading={isLoading} />
           <Divider className={styles.divider} />
-          {loading ? (
+          {isLoading ? (
             <Skeleton
               paragraph={{
                 rows: 5,
@@ -59,9 +63,9 @@ const CommunityMember = () => {
                       {intl.get('screen.memberProfile.rolesTitle')}
                     </Typography.Title>
                     <List
-                      className={cx(styles.infoList, !result?.roles?.length && styles.empty)}
+                      className={cx(styles.infoList, !profile?.roles?.length && styles.empty)}
                       itemLayout="horizontal"
-                      dataSource={result?.roles ?? []}
+                      dataSource={profile?.roles ?? []}
                       renderItem={(role, index) => <li key={index}>{role}</li>}
                       locale={{
                         emptyText: (
@@ -79,7 +83,7 @@ const CommunityMember = () => {
                     <Typography.Title level={5}>
                       {intl.get('screen.memberProfile.usageTitle')}
                     </Typography.Title>
-                    <List
+                    {/* <List
                       className={cx(
                         styles.infoList,
                         !result?.portal_usages?.length && styles.empty,
@@ -97,24 +101,24 @@ const CommunityMember = () => {
                           />
                         ),
                       }}
-                    />
+                    /> */}
                   </Col>
                 </Row>
               </Col>
               <Col md={8}>
                 <Space direction="vertical">
-                  {result?.linkedin && (
-                    <ExternalLink style={{ color: 'unset' }} href={result.linkedin}>
+                  {profile?.linkedin && (
+                    <ExternalLink style={{ color: 'unset' }} href={profile.linkedin}>
                       <Space align="center">
                         <LinkedinFilled />
                         <Typography.Text>Linkedin</Typography.Text>
                       </Space>
                     </ExternalLink>
                   )}
-                  {result?.public_email && (
+                  {profile?.email && (
                     <Space align="center">
                       <MailFilled />
-                      <Typography.Text>{result?.public_email}</Typography.Text>
+                      <Typography.Text>{profile?.email}</Typography.Text>
                     </Space>
                   )}
                 </Space>

--- a/src/views/Community/components/Filters/Box/index.tsx
+++ b/src/views/Community/components/Filters/Box/index.tsx
@@ -6,12 +6,12 @@ import intl from 'react-intl-universal';
 
 import styles from './index.module.scss';
 import Sorter from '../Sorter';
-import { roleOptions, usageOptions } from 'views/Community/contants';
+import { roleOptions, interestsOptions } from 'views/Community/contants';
 
 interface OwnProps {
   onMatchFilterChange: (value: string) => void;
   onRoleFilterChange: (value: string) => void;
-  onUsageFilterChange: (value: string) => void;
+  onInterestFilterChange: (value: string) => void;
   onSortChange: (value: string) => void;
   hasFilters: boolean;
 }
@@ -19,17 +19,17 @@ interface OwnProps {
 const FiltersBox = ({
   onMatchFilterChange,
   onRoleFilterChange,
-  onUsageFilterChange,
+  onInterestFilterChange,
   onSortChange,
   hasFilters = false,
 }: OwnProps) => {
   const [filtersVisible, setFiltersVisible] = useState(false);
   const [roleFilter, setRoleFilter] = useState<string[]>([]);
-  const [usageFilter, setUsageFilter] = useState<string[]>([]);
+  const [interestFilter, setInterestFilter] = useState<string[]>([]);
 
   useEffect(() => onRoleFilterChange(roleFilter.join(',')), [roleFilter]);
 
-  useEffect(() => onUsageFilterChange(usageFilter.join(',')), [usageFilter]);
+  useEffect(() => onInterestFilterChange(interestFilter.join(',')), [interestFilter]);
 
   return (
     <Space direction="vertical" size={16} className={styles.filtersContainer}>
@@ -38,13 +38,13 @@ const FiltersBox = ({
         <div className={styles.filterContentWrapper}>
           <Input
             onChange={(e) => onMatchFilterChange(e.currentTarget.value)}
-            placeholder="Ex: Watson, Linda Crnic Institute"
+            placeholder="e.g. Watson, Children's Hospital of Philadelphia"
           />
           <Button onClick={() => setFiltersVisible(!filtersVisible)}>
             {intl.get('screen.community.search.filters')}{' '}
             {filtersVisible ? <CaretUpFilled /> : <CaretDownFilled />}
           </Button>
-          <Sorter onSortChange={onSortChange} />
+          {/* <Sorter onSortChange={onSortChange} /> */}
         </div>
       </Space>
       {filtersVisible && (
@@ -79,19 +79,19 @@ const FiltersBox = ({
             />
           </Space>
           <Space direction="vertical">
-            <ProLabel title={intl.get('screen.community.search.dataUse')} />
+            <ProLabel title={intl.get('screen.community.search.interest')} />
             <Select
               className={styles.filterMultiSelect}
               mode="multiple"
               allowClear
               placeholder={intl.get('screen.community.search.selectPlaceholder')}
               maxTagCount={1}
-              value={usageFilter}
-              onSelect={(value: string) => setUsageFilter([...usageFilter, value])}
+              value={interestFilter}
+              onSelect={(value: string) => setInterestFilter([...interestFilter, value])}
               onDeselect={(value: string) =>
-                setUsageFilter(usageFilter.filter((val) => val !== value))
+                setInterestFilter(interestFilter.filter((val) => val !== value))
               }
-              options={usageOptions.map((option) => ({
+              options={interestsOptions.map((option) => ({
                 label: option.value,
                 value: option.value,
               }))}
@@ -111,7 +111,7 @@ const FiltersBox = ({
             disabled={!hasFilters}
             onClick={() => {
               setRoleFilter([]);
-              setUsageFilter([]);
+              setInterestFilter([]);
             }}
           >
             {intl.get('screen.community.search.clearFilters')}

--- a/src/views/Community/components/MemberCard/index.tsx
+++ b/src/views/Community/components/MemberCard/index.tsx
@@ -2,39 +2,39 @@ import Gravatar from '@ferlab/ui/core/components/Gravatar';
 import { Card, Space, Typography } from 'antd';
 import { DEFAULT_GRAVATAR_PLACEHOLDER } from 'common/constants';
 import Highlighter from 'react-highlight-words';
-import { Link } from 'react-router-dom';
-import { TUser } from 'services/api/user/models';
+// import { Link } from 'react-router-dom';
+import { TPersonaUser } from 'services/api/persona/models';
 import { formatName } from 'views/Community/utils';
 
 import styles from './index.module.scss';
 
 interface OwnProps {
-  user: TUser;
+  user: TPersonaUser;
   match: string;
 }
 
 const MemberCard = ({ user, match }: OwnProps) => {
   return (
-    <Link key={user.id} className={styles.memberLink} to={`/member/${user.keycloak_id}`}>
-      <Card className={styles.memberCard}>
-        <Space direction="vertical" align="center">
-          <Gravatar
-            className={styles.userGravatar}
-            circle
-            placeholder={DEFAULT_GRAVATAR_PLACEHOLDER}
-            email={user.email || ''}
-          />
-          <Typography.Title className={styles.memberCardName} level={5}>
-            <Highlighter textToHighlight={formatName(user) ?? ''} searchWords={[match]} />
-          </Typography.Title>
-          {user.affiliation && (
-            <Typography.Text type="secondary" className={styles.memberAffiliation}>
-              <Highlighter textToHighlight={user.affiliation} searchWords={[match]} />
-            </Typography.Text>
-          )}
-        </Space>
-      </Card>
-    </Link>
+    // <Link key={user._id} className={styles.memberLink} to={`/member/${user._id}`}>
+    <Card className={styles.memberCard}>
+      <Space direction="vertical" align="center">
+        <Gravatar
+          className={styles.userGravatar}
+          circle
+          placeholder={DEFAULT_GRAVATAR_PLACEHOLDER}
+          email={user.email || ''}
+        />
+        <Typography.Title className={styles.memberCardName} level={5}>
+          <Highlighter textToHighlight={formatName(user) ?? ''} searchWords={[match]} />
+        </Typography.Title>
+        {user.institution && (
+          <Typography.Text type="secondary" className={styles.memberAffiliation}>
+            <Highlighter textToHighlight={user.institution} searchWords={[match]} />
+          </Typography.Text>
+        )}
+      </Space>
+    </Card>
+    // </Link>
   );
 };
 

--- a/src/views/Community/contants.ts
+++ b/src/views/Community/contants.ts
@@ -7,22 +7,25 @@ export const roleOptions = [
   'Federal Employee',
 ];
 
-export const usageOptions = [
+export const interestsOptions = [
   {
-    key: 'learn',
-    value:
-      'Learning more about Down syndrome and its health outcomes, management, and/or treatment',
+    key: 'childhood-cancer',
+    value: 'Childhood cancer',
   },
   {
-    key: 'help',
-    value: 'Helping me design a new research study',
+    key: 'pediatric-brain-tumors',
+    value: 'Pediatric brain tumors',
   },
   {
-    key: 'analyse',
-    value: 'Identifying datasets that I want to analyze',
+    key: 'pediatric-brain-tumors-cbttc',
+    value: 'Pediatric brain tumors: cbttc',
   },
   {
-    key: 'commercial',
-    value: 'Commercial purposes',
+    key: 'cancer',
+    value: 'Cancer',
+  },
+  {
+    key: 'bioinformatics',
+    value: 'Bioinformatics',
   },
 ];

--- a/src/views/Community/index.tsx
+++ b/src/views/Community/index.tsx
@@ -1,9 +1,8 @@
 import TableHeader from '@ferlab/ui/core/components/ProTable/Header';
+import intl from 'react-intl-universal';
 import { Space, Typography, List } from 'antd';
 import { MAIN_SCROLL_WRAPPER_ID } from 'common/constants';
 import { useEffect, useState } from 'react';
-import { UserApi } from 'services/api/user';
-import { TUser } from 'services/api/user/models';
 import useDebounce from '@ferlab/ui/core/hooks/useDebounce';
 import { scrollToTop } from 'utils/helper';
 import FiltersBox from './components/Filters/Box';
@@ -11,48 +10,50 @@ import { SortItems } from './components/Filters/Sorter';
 
 import styles from './index.module.scss';
 import MemberCard from './components/MemberCard';
+import { PersonaApi } from 'services/api/persona';
+import { TPersonaUser } from 'services/api/persona/models';
 
 const { Title } = Typography;
 const DEFAULT_PAGE_SIZE = 25;
 
 const CommunityPage = () => {
-  const [users, setUsers] = useState<TUser[]>([]);
+  const [users, setUsers] = useState<TPersonaUser[]>([]);
   const [count, setCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [match, setMatch] = useState('');
   const [roleFilter, setRoleFilter] = useState('');
-  const [usageFilter, setUsageFilter] = useState('');
+  const [interestFilter, setInterestFilter] = useState('');
   const [sort, setSort] = useState(SortItems[0].sort);
   const debouncedMatchValue = useDebounce(match, 300);
 
   useEffect(() => {
     setIsLoading(true);
-    UserApi.search({
+    PersonaApi.search({
       pageIndex: currentPage,
       pageSize: DEFAULT_PAGE_SIZE,
       match,
-      sort,
       roles: roleFilter,
-      dataUses: usageFilter,
+      interests: interestFilter,
     }).then(({ data }) => {
-      setUsers(data?.users || []);
-      setCount(data?.total || 0);
+      console.log('data', data); //TODO: to remove
+      setUsers(data?.publicMembers || []);
+      setCount(data?.count?.public || 0);
       setIsLoading(false);
     });
-  }, [currentPage, sort, debouncedMatchValue, roleFilter, usageFilter]);
+  }, [currentPage, sort, debouncedMatchValue, roleFilter, interestFilter]);
 
   return (
     <Space direction="vertical" size={24} className={styles.communityWrapper}>
       <Title className={styles.title} level={4}>
-        INCLUDE Community
+        {intl.get('screen.community.title')}
       </Title>
       <FiltersBox
         onMatchFilterChange={setMatch}
         onRoleFilterChange={setRoleFilter}
-        onUsageFilterChange={setUsageFilter}
+        onInterestFilterChange={setInterestFilter}
         onSortChange={setSort}
-        hasFilters={!!(roleFilter || usageFilter)}
+        hasFilters={!!(roleFilter || interestFilter)}
       />
       <Space className={styles.usersListWrapper} size={24} direction="vertical">
         <TableHeader

--- a/src/views/Community/utils.ts
+++ b/src/views/Community/utils.ts
@@ -1,4 +1,4 @@
-import { TUser } from 'services/api/user/models';
+import { TPersonaUser } from 'services/api/persona/models';
 
-export const formatName = (user: TUser) =>
-  user.first_name && user.last_name ? `${user.first_name} ${user.last_name}` : user.email;
+export const formatName = (user: TPersonaUser) =>
+  user.firstName && user.lastName ? `${user.firstName} ${user.lastName}` : user.email;

--- a/src/views/ProfileSettings/cards/ResearchAndUsage/index.tsx
+++ b/src/views/ProfileSettings/cards/ResearchAndUsage/index.tsx
@@ -2,7 +2,7 @@ import { Checkbox, Form, Input, Space } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { useEffect, useRef, useState } from 'react';
 import { useUser } from 'store/user';
-import { usageOptions } from 'views/Community/contants';
+import { interestsOptions } from 'views/Community/contants';
 import cx from 'classnames';
 import { useDispatch } from 'react-redux';
 import { updateUser } from 'store/user/thunks';
@@ -24,7 +24,9 @@ const initialChangedValues = {
 };
 
 const hasOtherUsage = (userUsages: string[]) =>
-  userUsages.find((usage) => !usageOptions.find((defaultUsage) => defaultUsage.value === usage));
+  userUsages.find(
+    (usage) => !interestsOptions.find((defaultUsage) => defaultUsage.value === usage),
+  );
 
 const ResearchAndUsagesCard = () => {
   const [form] = useForm();
@@ -88,7 +90,7 @@ const ResearchAndUsagesCard = () => {
           <Checkbox.Group className={formStyles.checkBoxGroup}>
             <span className={formStyles.help}>Check all that apply</span>
             <Space direction="vertical">
-              {usageOptions.map((option) => (
+              {interestsOptions.map((option) => (
                 <Checkbox key={option.key} value={option.value}>
                   {option.value}
                 </Checkbox>
@@ -101,7 +103,7 @@ const ResearchAndUsagesCard = () => {
               >
                 {({ getFieldValue }) =>
                   getFieldValue(FORM_FIELDS.DATA_USAGE)?.includes(
-                    usageOptions.find((option) => option.key === 'commercial')?.value,
+                    interestsOptions.find((option) => option.key === 'commercial')?.value,
                   ) ? (
                     <Form.Item
                       className={cx(formStyles.dynamicField, formStyles.inner)}


### PR DESCRIPTION
# FEAT

- closes [#407](https://d3b.atlassian.net/browse/SKFP-407)

## Description
Placeholder: “e.g. Watson, Children's Hospital of Philadelphia” 

- As a user inputs a string, it will match and filter the member results 
- Add a “Filters” button on right of the search bar
- The dropdown will be composed of two other dropdowns for “Member Categories" & "Research Interest". The filter options for both the “Member Categories" & "Research Interest" should be available in Persona API. 
- In the API this Members categories = role & Research Interest = interest
- Add a Clear Filter button that once clicked, will remove the filters used for the search. 

## Screenshot (Before and After)
![Screenshot_20220928_115628](https://user-images.githubusercontent.com/65532894/192828574-a84ff90b-b3f4-468c-9133-d29fa523b601.png)
![Screenshot_20220928_115739](https://user-images.githubusercontent.com/65532894/192828579-91e68919-32a4-45f1-85c7-9939c917233a.png)

## BONUS
Add basic member page implement BUT it will block since we don't have any design at the time