### PR TITLE
🩹fix(profile) SKFP-406 update and fix profile edit page

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -519,9 +519,9 @@ const en = {
           title: 'Identification',
           alert:
             'You are authenticated with <strong>{provider}</strong> using <strong>{email}</strong>. This email is never shown to the public and cannot be changed.',
-          firstName: 'First Name',
+          firstName: 'First name',
           yourFirstName: 'Your First Name',
-          lastName: 'Last Name',
+          lastName: 'Last name',
           yourLastName: 'Your Last Name',
           website: 'Website',
           editPhotoModalTitle: 'Edit photo',
@@ -535,7 +535,7 @@ const en = {
         },
         roleAffiliation: {
           title: 'Role & Affiliation',
-          iama: 'I am a:',
+          iama: 'I am a',
           checkAllThatApply: 'Check all that apply',
           institution: 'Institution or organization',
           institutionalEmail: 'Institutional email address',
@@ -552,7 +552,7 @@ const en = {
           zip: 'Zip',
         },
         researchInterests: {
-          title: 'Research Interests',
+          title: 'Research Interest',
           diseases: 'Disease areas of interest',
           studies: 'Studies of interest',
         },
@@ -818,7 +818,7 @@ const en = {
     phenotype: {
       hpo_phenotype_observed: 'Observed Phenotype (HPO)',
       hpo_phenotype_not_observed: 'Not Observed Phenotype (HPO)',
-      age_at_event_days: 'Age at Observed Phenotype'
+      age_at_event_days: 'Age at Observed Phenotype',
     },
     age_at_data_collection: 'Age at data collection',
     family_type: 'Family Unit',

--- a/src/views/Community/contants.ts
+++ b/src/views/Community/contants.ts
@@ -5,15 +5,15 @@ export const memberRolesOptions = [
   },
   {
     key: 'health',
-    value: 'Healthcare professional',
+    value: 'Healthcare Professional',
   },
   {
     key: 'patient',
-    value: 'Patient/Family member',
+    value: 'Patient/Family Member',
   },
   {
     key: 'community',
-    value: 'Community member',
+    value: 'Community Member',
   },
 ];
 
@@ -24,7 +24,7 @@ export const diseasesInterestOptions = [
   },
   {
     key: 'childhood-cancer',
-    value: 'Childhood cancer',
+    value: 'Childhood Cancer',
   },
   {
     key: 'cancer',

--- a/src/views/Persona/components/RegistrationForm/index.tsx
+++ b/src/views/Persona/components/RegistrationForm/index.tsx
@@ -6,6 +6,8 @@ import { createPersonaUser } from 'store/persona/thunks';
 import { KidsFirstKeycloakTokenParsed } from 'common/tokenTypes';
 import { STATIC_ROUTES } from 'utils/routes';
 
+import intl from 'react-intl-universal';
+
 import styles from './index.module.scss';
 import { memberRolesOptions } from 'views/Community/contants';
 
@@ -53,14 +55,14 @@ const Registration = ({ handleBack, hidden = true, kcToken, onFinishCallback }: 
           <Title level={3}>Identification</Title>
           <Text>All fields are required unless specified as optional.</Text>
           <Form.Item
-            label="First name:"
+            label={intl.get('screen.profileSettings.cards.identification.firstName')}
             name="firstName"
             rules={[{ required: true, message: 'First name is required' }]}
           >
             <Input />
           </Form.Item>
           <Form.Item
-            label="Last name:"
+            label={intl.get('screen.profileSettings.cards.identification.lastName')}
             name="lastName"
             rules={[{ required: true, message: 'Last name is required' }]}
           >
@@ -72,7 +74,7 @@ const Registration = ({ handleBack, hidden = true, kcToken, onFinishCallback }: 
           </Title>
           <Form.Item
             name="roles"
-            label="I am a:"
+            label={intl.get('screen.profileSettings.cards.roleAffiliation.iama')}
             rules={[{ required: true, message: 'This field is required' }]}
           >
             <Checkbox.Group>

--- a/src/views/ProfileSettings/cards/Identification/ToggleProfileVisibility/index.module.scss
+++ b/src/views/ProfileSettings/cards/Identification/ToggleProfileVisibility/index.module.scss
@@ -1,0 +1,17 @@
+@import 'src/style/themes/kids-first/colors';
+
+.container {
+  display: flex;
+  align-items: center;
+
+  .title {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .icon {
+    margin: 0 12px 0 4px;
+    color: $gray-7;
+    font-size: 12px;
+  }
+}

--- a/src/views/ProfileSettings/cards/Identification/ToggleProfileVisibility/index.tsx
+++ b/src/views/ProfileSettings/cards/Identification/ToggleProfileVisibility/index.tsx
@@ -6,18 +6,20 @@ import { useDispatch } from 'react-redux';
 import { usePersona } from 'store/persona';
 import { updatePersonaUser } from 'store/persona/thunks';
 
+import styles from './index.module.scss';
+
 const ToggleProfileVisibility = () => {
   const dispatch = useDispatch();
   const { personaUserInfo } = usePersona();
   const [isLoading, setIsLoading] = useState(false);
 
   return (
-    <Space align="baseline">
-      <Typography.Title level={5}>
+    <div className={styles.container}>
+      <Typography.Text className={styles.title} strong>
         {intl.get('screen.profileSettings.toggleProfileVisibility.title')}
-      </Typography.Title>
+      </Typography.Text>
       <Tooltip title={intl.get('screen.profileSettings.toggleProfileVisibility.tooltip')}>
-        <InfoCircleOutlined />
+        <InfoCircleOutlined className={styles.icon} />
       </Tooltip>
       <Switch
         loading={isLoading}
@@ -37,7 +39,7 @@ const ToggleProfileVisibility = () => {
           );
         }}
       />
-    </Space>
+    </div>
   );
 };
 

--- a/src/views/ProfileSettings/cards/Identification/index.module.scss
+++ b/src/views/ProfileSettings/cards/Identification/index.module.scss
@@ -17,3 +17,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.title {
+  margin: 0;
+}

--- a/src/views/ProfileSettings/cards/Identification/index.tsx
+++ b/src/views/ProfileSettings/cards/Identification/index.tsx
@@ -62,7 +62,7 @@ const IdentificationCard = () => {
       form={form}
       customHeader={
         <div className={styles.customHeader}>
-          <Typography.Title level={4}>
+          <Typography.Title className={styles.title} level={4}>
             {intl.get('screen.profileSettings.cards.identification.title')}
           </Typography.Title>
           <ToggleProfileVisibility />
@@ -137,7 +137,7 @@ const IdentificationCard = () => {
               </Form.Item>
               <Form.Item
                 name={FORM_FIELDS.LINKEDIN}
-                label={<ProLabel title="Linkedin" />}
+                label={<ProLabel title="LinkedIn" />}
                 rules={[{ type: 'url', validateTrigger: 'onSubmit' }]}
                 required={false}
               >

--- a/src/views/ProfileSettings/cards/Location/index.tsx
+++ b/src/views/ProfileSettings/cards/Location/index.tsx
@@ -73,19 +73,15 @@ const LocationCard = () => {
         }
       >
         <Form.Item
-          name={FORM_FIELDS.STATE}
-          label={<ProLabel title={intl.get('screen.profileSettings.cards.location.state')} />}
-          rules={[{ required: true, type: 'string', validateTrigger: 'onSubmit' }]}
-          required={false}
+          name={FORM_FIELDS.COUNTRY}
+          label={<ProLabel title={intl.get('screen.profileSettings.cards.location.country')} />}
         >
           <Input />
         </Form.Item>
 
         <Form.Item
-          name={FORM_FIELDS.COUNTRY}
-          label={<ProLabel title={intl.get('screen.profileSettings.cards.location.country')} />}
-          rules={[{ required: true, type: 'string', validateTrigger: 'onSubmit' }]}
-          required={false}
+          name={FORM_FIELDS.STATE}
+          label={<ProLabel title={intl.get('screen.profileSettings.cards.location.state')} />}
         >
           <Input />
         </Form.Item>

--- a/src/views/ProfileSettings/cards/RoleAndAffiliation/index.tsx
+++ b/src/views/ProfileSettings/cards/RoleAndAffiliation/index.tsx
@@ -79,8 +79,6 @@ const RoleAndAffiliationCard = () => {
               title={intl.get('screen.profileSettings.cards.roleAffiliation.institution')}
             />
           }
-          rules={[{ required: true, type: 'string', validateTrigger: 'onSubmit' }]}
-          required={false}
         >
           <Input />
         </Form.Item>
@@ -88,7 +86,6 @@ const RoleAndAffiliationCard = () => {
           className={formStyles.withCustomHelp}
           name={FORM_FIELDS.ROLES}
           label={intl.get('screen.profileSettings.cards.roleAffiliation.iama')}
-          required={false}
           rules={[{ required: true }]}
         >
           <Checkbox.Group className={formStyles.checkBoxGroup}>


### PR DESCRIPTION
# FIX

- closes [#406](https://d3b.atlassian.net/browse/SKFP-406)

## Description

1. Typos: “First name”, “Last name” et “LinkedIn”
2. Pour la section “Role & Affiliation”
2.1. Le champ “Institution or organization” ne devrait pas être requis
2.2. Typos
Retirer les deux points après “I am a”
Mettre les choix en Title Case (ex. Healthcare Professional”

3. Mettre les champs dans l’ordre et nommé tel que mentionné dans l’analyse Notion
4. Les champs ne devraient pas être requis
5. Typo: “Research Interest”
6. Typo: “Chidhood Cancer”
7. Il manque la section “Delete Account”

Bouton toggle
1. Card header alignment is off
2. Color of switch label is still wrong (should be body text colour)
3. Size of switch label font + tooltip still wrong

## Screenshot
![localhost_3000_profile_settings](https://user-images.githubusercontent.com/65532894/194391454-802e24c6-be14-48de-8941-7b885b096ade.png)
nshot (Before and After)

