### PR TITLE
🩹fix(data): fix colors, adjust icons, remove storage

### DIFF
--- a/src/components/uiKit/DataRelease/index.tsx
+++ b/src/components/uiKit/DataRelease/index.tsx
@@ -13,16 +13,11 @@ import { useDispatch } from 'react-redux';
 import { fetchStats } from 'store/global/thunks';
 
 import styles from 'components/uiKit/DataRelease/index.module.scss';
+import BiospecimenIcon from 'components/Icons/BiospecimenIcon';
 
 interface OwnProps {
   className?: string;
 }
-
-const formatStorage = (storage: string) => {
-  if (!storage) return;
-  const parts = storage.split(/\.| /);
-  return `${parts[0]}${parts[2]}`;
-};
 
 const DataRelease = ({ className = '' }: OwnProps) => {
   const dispatch = useDispatch();
@@ -67,7 +62,7 @@ const DataRelease = ({ className = '' }: OwnProps) => {
           <MultiLabel
             iconPosition={MultiLabelIconPositionEnum.Top}
             label={numberFormat(stats?.samples!)}
-            Icon={<FileTextOutlined className={styles.dataReleaseIcon} />}
+            Icon={<BiospecimenIcon className={styles.dataReleaseIcon} />}
             className={styles.dataReleaseStatsLabel}
             subLabel={intl.get('components.dataRelease.biospecimens')}
           />
@@ -79,15 +74,6 @@ const DataRelease = ({ className = '' }: OwnProps) => {
             Icon={<FileTextOutlined className={styles.dataReleaseIcon} />}
             className={styles.dataReleaseStatsLabel}
             subLabel={intl.get('components.dataRelease.files')}
-          />
-        </Col>
-        <Col xs={12} md={4}>
-          <MultiLabel
-            iconPosition={MultiLabelIconPositionEnum.Top}
-            label={formatStorage(stats?.fileSize!) || '0TB'}
-            Icon={<DatabaseOutlined className={styles.dataReleaseIcon} />}
-            className={styles.dataReleaseStatsLabel}
-            subLabel={intl.get('components.dataRelease.storage')}
           />
         </Col>
       </Row>

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
@@ -24,7 +24,7 @@
     margin-left: -8px;
     margin-top: 5px;
     font-size: 20px;
-    color: $cyan-5;
+    color: $cyan-4;
   }
 
   .linkTitle {

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.module.scss
@@ -17,6 +17,7 @@
 
     .customCol {
       display: flex;
+      min-width: 150px;
 
       @media screen and (max-width: 1150px) {
         flex: unset !important;
@@ -47,7 +48,7 @@
 
     .dataReleaseIcon {
       margin-top: -1px;
-      color: $cyan-5;
+      color: $cyan-4;
       font-size: 20px;
     }
 

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
@@ -17,12 +17,6 @@ import styles from './index.module.scss';
 import BiospecimenIcon from 'components/Icons/BiospecimenIcon';
 import TeamIcon from 'components/Icons/TeamIcon';
 
-const formatStorage = (storage: string) => {
-  if (!storage) return;
-  const parts = storage.split(/\.| /);
-  return `${parts[0]}${parts[2]}`;
-};
-
 const DataExplorationLinks = () => {
   const dispatch = useDispatch();
   const { stats } = useGlobals();
@@ -91,20 +85,11 @@ const DataExplorationLinks = () => {
 
           <Col flex="auto" className={styles.customCol}>
             <LinkBox
-              href={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
+              href={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
               multiLabelClassName={styles.dataReleaseStatsLabel}
               label={numberFormat(stats?.files!)}
               subLabel={intl.get('components.dataRelease.files')}
               icon={<FileTextOutlined className={styles.dataReleaseIcon} />}
-            />
-          </Col>
-          <Col flex="auto" className={styles.customCol}>
-            <LinkBox
-              href={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
-              multiLabelClassName={styles.dataReleaseStatsLabel}
-              label={formatStorage(stats?.fileSize!) || '0TB'}
-              subLabel={intl.get('components.dataRelease.storage')}
-              icon={<DatabaseOutlined className={styles.dataReleaseIcon} />}
             />
           </Col>
         </Row>


### PR DESCRIPTION
# BUG 

- closes [#376](https://d3b.atlassian.net/browse/SKFP-376)

## Description

> La couleur des icônes devrait être cyan-4 et non cyan-5, à vérifier. S’assurer aussi que la flèche est cyan-4.
> La boîte Data Files devrait rediriger vers la page DataFiles existante.
> Retirer la boîte "Storage" (Décision prise suite à une discussion avec Jean-Philippe)


## Screenshot (Before and After)
![Screenshot_20221011_115223](https://user-images.githubusercontent.com/65532894/195141022-a04760f1-f4b7-4d4a-b992-fd71bb01e482.png)

![Screenshot_20221011_115408](https://user-images.githubusercontent.com/65532894/195141031-9e1a75c0-32dc-4089-8602-9143c67824d3.png)

