### PR TITLE
🧨feat(participant): SKFP-385 add user-defined columns

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -281,6 +281,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'race',
     title: 'Race',
     dataIndex: 'race',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -290,6 +291,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'ethnicity',
     title: 'Ethnicity',
     dataIndex: 'ethnicity',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -299,6 +301,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'external_id',
     title: 'Participant External ID',
     dataIndex: 'external_id',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -308,6 +311,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'diagnosis_ncit',
     title: 'Diagnosis (NCIT)',
     dataIndex: 'diagnosis',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -319,6 +323,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'diagnosis_source_text',
     title: 'Diagnosis (Source Text)',
     dataIndex: 'diagnosis',
+    defaultHidden: true,
     render: (mondo: ArrangerResultsTree<IParticipantDiagnosis>) => {
       const sourceTexts = mondo?.hits?.edges.map((m) => m.node.source_text);
 
@@ -339,6 +344,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'clinical_status',
     title: 'Clinical Status',
     dataIndex: 'diagnosis',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -349,6 +355,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'disease_related',
     title: 'Disease Related',
     dataIndex: 'outcomes',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -358,6 +365,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'vital_status',
     title: 'Vital Status',
     dataIndex: 'outcomes',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -368,6 +376,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'phenotypes_hpo_not_observed',
     title: 'Not Observed Phenotype (HPO)',
     dataIndex: 'phenotype',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -377,6 +386,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'source_text_phenotype',
     title: 'Observed Phenotype (Source Text)',
     dataIndex: 'phenotype',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -386,6 +396,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'observed_phenotype_age_at_event_days',
     title: 'Age at Diagnosis',
     dataIndex: 'observed_phenotype',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -399,6 +410,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'outcomes_age_at_event_days',
     title: 'Age at Outcome',
     dataIndex: 'outcomes',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },
@@ -412,6 +424,7 @@ const defaultColumns: ProColumnType[] = [
     key: 'outcomes_age_at_event_days',
     title: 'Age at Observed Phenotype',
     dataIndex: 'phenotype',
+    defaultHidden: true,
     sorter: {
       multiple: 1,
     },


### PR DESCRIPTION
# FEAT

- closes #[385](https://d3b.atlassian.net/browse/SKFP-385)

## Description

Implement the Data Exploration-- Participant tab facets and columns. 

## Screenshot (Before and After)
![Screenshot_20221013_092322](https://user-images.githubusercontent.com/65532894/195609141-94671b03-68bc-4ebe-836e-f53cafd37d7c.png)
![Screenshot_20221013_092332](https://user-images.githubusercontent.com/65532894/195609144-745225db-331d-45a7-9636-6c8887ef86d3.png)
![Screenshot_20221013_092344](https://user-images.githubusercontent.com/65532894/195609145-ed8681d0-e4ab-43c0-883a-cd6e8fabb143.png)

