### PR TITLE
🩹 fix(data-explore): SKFP-386 adjust data file tab

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -308,6 +308,52 @@ const en = {
       storage: 'Storage',
       files: 'Data Files',
     },
+    uploadIds: {
+      modal: {
+        title: 'Upload a {entity} list',
+        submittedColTitle: 'Submitted {entity} identifiers',
+        uploadBtnText: 'Upload a {entity} list',
+        mappedTo: 'Mapped To',
+        collapseTitle: 'Summary Table  ({matchCount} matched, {unMatchCount} unmatched)',
+        inputLabel: 'Copy-paste a list of identifiers or upload a file',
+        match: 'Matched ({count})',
+        unmatch: 'Unmatched ({count})',
+        tableMessage:
+          '{submittedCount} submitted identifiers mapped to {mappedCount} unique system identifiers',
+        matchTable: {
+          idcol: '{entity} ID',
+          participant: {
+            matchcol: 'Participant ID',
+            mappedcol: 'Study ID',
+          },
+          file: {
+            matchcol: 'File ID',
+            mappedcol: 'Study ID',
+          },
+          biospecimen: {
+            matchcol: 'Sample ID',
+            mappedcol: 'Study ID',
+          },
+        },
+        pillTitle: 'Uploaded List',
+        upload: {
+          fileBtn: 'Upload a file',
+          btn: 'Upload',
+        },
+        clearBtn: 'Clear',
+        cancelBtn: 'Cancel',
+        emptyTable: 'No data',
+        popover: {
+          title: 'Identifiers and File Formats',
+          identifiers: 'Identifiers',
+          separatedBy: {
+            title: 'Separated by',
+            values: 'comma, space, new line',
+          },
+          uploadFileFormats: 'Upload file formats',
+        },
+      },
+    },
   },
   layout: {
     main: {

--- a/src/style/themes/kids-first/antd/buttons.less
+++ b/src/style/themes/kids-first/antd/buttons.less
@@ -30,17 +30,19 @@
     color: @cyan-7;
 
     &:hover {
-      background-color: @gray-5;
-      border-color: @gray-3;
+      background-color: @gray-2;
+      border-color: @gray-5;
     }
 
     &:focus {
       background-color: @gray-1;
       border-color: @cyan-7;
     }
+
+    &.@{dropdown-prefix-cls}-open,
     &:active {
-      background-color: @gray-5;
-      border-color: @gray-3;
+      background-color: @gray-3;
+      border-color: @gray-5;
     }
     &:focus-visible {
       background-color: @gray-1;

--- a/src/views/Dashboard/components/DashboardCards/Cavatica/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/Cavatica/index.tsx
@@ -66,7 +66,7 @@ const Cavatica = ({ id, className = '' }: DashboardCardProps) => {
                 <Space align="start">
                   <SafetyOutlined className={styles.safetyIcon} />
                   <Text className={styles.notice}>
-                    {intl.get('screen.dashboard.cards.cavatica.connectedNotice')}{' '}
+                    {intl.get('screen.dashboard.cards.cavatica.connectedNotice')}
                     <Button
                       type="link"
                       size="small"

--- a/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
@@ -19,7 +19,7 @@ const FileUploadIds = ({ queryBuilderId }: OwnProps) => (
     entityId="file"
     entityIdTrans="File"
     entityIdentifiers="File ID"
-    placeHolder="e.g. GF_001CSF26, HTP.007855d5-e22e-405f-91f4-d54b4b8a9136.g.vcf.gz"
+    placeHolder="e.g. GF_2JAYWYDX, GF_TP6PG8Z0"
     fetchMatch={async (ids) => {
       const response = await ArrangerApi.graphqlRequest({
         query: CHECK_FILE_MATCH.loc?.source.body,


### PR DESCRIPTION
# BUG 

- closes #[386](https://d3b.atlassian.net/browse/SKFP-386)

## Description and Screenshot (Before and After)
1. Typo Access URL
![image](https://user-images.githubusercontent.com/65532894/195692215-57fb9692-a4a3-400b-b79b-a33086266930.png)

2. Ajuster la couleur du "Hover State » et du « Pressed State » du bouton « Save file set »
![image](https://user-images.githubusercontent.com/65532894/195692237-49ad2a02-0b6f-4a70-a333-9d75661ddf59.png)

3. Voir les spécifications ajoutées pour la colonne Data Access 
![image](https://user-images.githubusercontent.com/65532894/195692431-3ab450e7-5144-42b4-8c0c-6bb562c89e72.png)


4. Nommer les 2 premières colonnes pour la personnalisation des colonnes
![image](https://user-images.githubusercontent.com/65532894/195692346-81b003a7-1944-46ba-9342-fda66248658a.png)

5. Ajouter un label au bouton d’upload

![image](https://user-images.githubusercontent.com/65532894/195692377-e5ff7890-8c7c-42fd-b5c1-a59348a061d1.png)
![image](https://user-images.githubusercontent.com/65532894/195692391-f6f915da-d26d-4847-bddc-3eab6938d6c3.png)


