### PR TITLE
:adhesive_bandage: : Remove sorter since api is broken for large values

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -63,9 +63,6 @@ const defaultColumns: ProColumnType[] = [
     key: 'variant_class',
     title: 'Type',
     dataIndex: 'variant_class',
-    sorter: {
-      multiple: 1,
-    },
   },
   {
     key: 'rsnumber',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54366437/196564196-c7de7f31-007e-458d-8fd8-3219a96207f1.png)
Remove sorter since api is broken (we cannot paginate when results exceeds 10k results)