### PR TITLE
🐛fix(dashboard): SKFP-381 fix colors

### DIFF
--- a/src/components/uiKit/PopoverContentLink/index.module.scss
+++ b/src/components/uiKit/PopoverContentLink/index.module.scss
@@ -4,6 +4,6 @@
   padding: 0;
   &,
   &:hover {
-    color: $gray-8;
+    color: $body-1;
   }
 }

--- a/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.module.scss
@@ -4,7 +4,7 @@
 .wrapper {
   padding: $default-padding;
   background-color: $gray-1;
-  border: 1px solid $gray-5;
+  border: 1px solid $gray-4;
   border-radius: 2px;
   display: flex;
   align-items: center;

--- a/src/views/Dashboard/components/DashboardCards/Notebook/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/Notebook/index.module.scss
@@ -4,7 +4,7 @@
 .wrapper {
   padding: $default-padding;
   background-color: $gray-1;
-  border: 1px solid $gray-5;
+  border: 1px solid $gray-4;
   border-radius: 2px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
# BUG 

- closes #[381](https://d3b.atlassian.net/browse/SKFP-381)

## Description
Link text colour inside tooltip: the link colour should inherit from parent (is same as text colour)

Border colour around content in FHIR and Zeppelin is wrong. Update to be like the others.

## Screenshot (Before and After)
![Screenshot_20221024_143745](https://user-images.githubusercontent.com/65532894/197600779-7e8d7710-6048-4239-9f38-4d826ff4009d.png)
![Screenshot_20221024_143322](https://user-images.githubusercontent.com/65532894/197600835-540cdf6f-c21e-491c-8ba3-3078741001f7.png)

