### PR TITLE
🐛fix(dataexplore): SKFP-393 fix summary

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -687,6 +687,7 @@ const en = {
             cardTitle: 'Demographics',
             sexTitle: 'Sex',
             raceTitle: 'Race',
+            familyComposition: 'Family Composition',
             ethnicityTitle: 'Ethnicity',
           },
           availableData: {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/AgeAtDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/AgeAtDiagnosisGraphCard/index.tsx
@@ -136,14 +136,19 @@ const AgeAtDiagnosisGraphCard = ({ id, className = '' }: OwnProps) => {
             <BarChart
               showCursor
               data={ageAtDiagnosisresults}
-              tooltipLabel={(node) => `Participant${node.data.value > 1 ? 's' : ''} #`}
+              tooltipLabel={(node) => `Participant${node.data.value > 1 ? 's' : ''}`}
+              axisLeft={{
+                legend: '# Participants',
+                legendPosition: 'middle',
+                legendOffset: -45,
+              }}
               axisBottom={{
                 legend: 'Age at Diagnosis (years)',
                 legendPosition: 'middle',
                 legendOffset: 35,
               }}
               onClick={(datum) =>
-                addToQuery('diagnosis__age_at_event_days', datum.data.label as string)
+                addToQuery('diagnosis.age_at_event_days', datum.data.label as string)
               }
               {...graphSetting}
             />

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
@@ -106,18 +106,6 @@ const DemographicsGraphCard = ({ id, className = '' }: OwnProps) => {
             )}
           </Col>
           <Col sm={12} md={12} lg={8}>
-            {isEmpty(raceData) ? (
-              <Empty imageType="grid" />
-            ) : (
-              <PieChart
-                title={intl.get('screen.dataExploration.tabs.summary.demographic.raceTitle')}
-                data={raceData}
-                onClick={(datum) => addToQuery('race', datum.id as string, history)}
-                {...graphSetting}
-              />
-            )}
-          </Col>
-          <Col sm={12} md={12} lg={8}>
             {isEmpty(enthicityData) ? (
               <Empty imageType="grid" />
             ) : (
@@ -125,6 +113,18 @@ const DemographicsGraphCard = ({ id, className = '' }: OwnProps) => {
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.ethnicityTitle')}
                 data={enthicityData}
                 onClick={(datum) => addToQuery('ethnicity', datum.id as string, history)}
+                {...graphSetting}
+              />
+            )}
+          </Col>
+          <Col sm={12} md={12} lg={8}>
+            {isEmpty(raceData) ? (
+              <Empty imageType="grid" />
+            ) : (
+              <PieChart
+                title={intl.get('screen.dataExploration.tabs.summary.demographic.raceTitle')}
+                data={raceData}
+                onClick={(datum) => addToQuery('race', datum.id as string, history)}
                 {...graphSetting}
               />
             )}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.module.scss
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.module.scss
@@ -1,0 +1,10 @@
+.graphContentWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+
+  .graphRowWrapper {
+    width: 100%;
+  }
+}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
@@ -12,10 +12,13 @@ import { PARTICIPANT_BY_STUDIES_QUERY } from 'graphql/summary/queries';
 import useApi from 'hooks/useApi';
 import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
 import { BasicTooltip } from '@nivo/tooltip';
-import { capitalize, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import Empty from '@ferlab/ui/core/components/Empty';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+
+import styles from './index.module.scss';
+import { Col, Row } from 'antd';
 
 interface OwnProps {
   id: string;
@@ -62,6 +65,7 @@ const StudiesGraphCard = ({ id, className = '' }: OwnProps) => {
   return (
     <GridCard
       wrapperClassName={className}
+      contentClassName={styles.graphContentWrapper}
       theme="shade"
       loading={loading}
       loadingType="spinner"
@@ -73,24 +77,26 @@ const StudiesGraphCard = ({ id, className = '' }: OwnProps) => {
         />
       }
       content={
-        <>
-          {isEmpty(data) ? (
-            <Empty imageType="grid" />
-          ) : (
-            <PieChart
-              data={data}
-              onClick={(datum) => addToQuery('study__study_code', datum.id as string, history)}
-              tooltip={(value) => (
-                <BasicTooltip
-                  id={capitalize(value.datum.id.toString())}
-                  value={value.datum.value}
-                  color={value.datum.color}
-                />
-              )}
-              {...graphSetting}
-            />
-          )}
-        </>
+        <Row className={styles.graphRowWrapper}>
+          <Col md={24}>
+            {isEmpty(data) ? (
+              <Empty imageType="grid" />
+            ) : (
+              <PieChart
+                data={data}
+                onClick={(datum) => addToQuery('study__study_code', datum.id as string, history)}
+                tooltip={(value) => (
+                  <BasicTooltip
+                    id={value.datum.id.toString()}
+                    value={value.datum.value}
+                    color={value.datum.color}
+                  />
+                )}
+                {...graphSetting}
+              />
+            )}
+          </Col>
+        </Row>
       }
     />
   );


### PR DESCRIPTION
# BUG 

- closes #[393](https://d3b.atlassian.net/browse/SKFP-393)

## Description

2. Demographics : Mettre les graphs dans le même ordre que la liste de l’analyse
![Screenshot_20221027_111318](https://user-images.githubusercontent.com/65532894/198362781-ecc700bb-6446-4d55-9de1-ecb3ceb91a6a.png)

 
3. Age at Diagnosis: Il manque le titre de l’axe des y
4. Age at Diagnosis: Typo dans le texte du Mouseover
![Screenshot_20221027_112255](https://user-images.githubusercontent.com/65532894/198362917-0b132fac-c8f5-4da6-9342-f48585b5137e.png)


5. Age at Diagnosis: Cliquer sur une barre du graph ne construit pas la bonne requête

![Screenshot_20221027_132321](https://user-images.githubusercontent.com/65532894/198362943-84312472-7d51-4d2e-9a36-eaedbaf34d9a.png)
![Screenshot_20221027_132354](https://user-images.githubusercontent.com/65532894/198362946-28237106-02d6-4e0d-a955-799cb4fc055e.png)

 

6. Studies: Afficher les codes en majuscule, comme c’est fait dans la facette
7. Studies: Centrer le graph verticalement dans la carte

![Peek 2022-10-27 11-21](https://user-images.githubusercontent.com/65532894/198363149-d56630c0-0bb8-4272-8c5e-d71df1b0fe1b.gif)




