### PR TITLE
🐛fix(dashboard): SKFP-537 Update FHIR api widget popover content

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -507,8 +507,9 @@ const en = {
         fhirDataResource: {
           title: 'Kids First FHIR API',
           infoPopover: {
+            title: 'Query KF Data via FHIR API',
             content:
-              'FHIR & Data Resources for NIH’s Collaboration to Assess Risk and Identify LoNG-term outcomes for Children with COVID. Expanded clinical, treatment, and lab result data for these patients are available via the Kids First FHIR API.',
+              'The HL7® FHIR® format defines how clinical health data for research can be made interoperable across different computer systems via an API regardless of how it is stored in those systems. The NIH encourages biomedical investigators to use the FHIR standard to support exchange of data between NCPI’s participating platforms.',
           },
           caringApi: {
             title: '<i>CARING</i> Data FHIR API Endpoint',

--- a/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.tsx
@@ -1,14 +1,15 @@
 import intl from 'react-intl-universal';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { Space, Tooltip, Typography } from 'antd';
+
+import FHIR_ICON from 'components/assets/FHIR.png';
 
 import CardHeader from '../../CardHeader';
 import { DashboardCardProps } from '..';
 
 import styles from './index.module.scss';
-import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
-import FHIR_ICON from 'components/assets/FHIR.png';
-import { InfoCircleOutlined } from '@ant-design/icons';
 
 const { Text } = Typography;
 
@@ -46,7 +47,7 @@ const CaringForChildrenWithCovid = ({ id, key, className = '' }: DashboardCardPr
         key={key}
         title={intl.get('screen.dashboard.cards.fhirDataResource.title')}
         infoPopover={{
-          title: intl.get('screen.dashboard.cards.fhirDataResource.title'),
+          title: intl.get('screen.dashboard.cards.fhirDataResource.infoPopover.title'),
           content: (
             <Space direction="vertical" className={styles.content} size={0}>
               <Text>


### PR DESCRIPTION
- closes #[537](https://d3b.atlassian.net/browse/SKFP-537)

Ajustement du contenu du popover pour l'icône d'info de KF FHIR API

Before:
![4389C2ED-87E0-434F-8A8C-15A4EFC99252](https://user-images.githubusercontent.com/116835792/202019753-c80b0b59-f29f-4de1-8dff-8cd540dbea9d.jpeg)

After:
![4B4B4708-533D-4C02-B9C3-0A05A45C4777](https://user-images.githubusercontent.com/116835792/202019743-e3315107-a71c-4b0d-aa8f-4b7467c90a1f.jpeg)