### PR TITLE
🐛fix(pagination): SKFP-522 fix next button disable behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
         "@ferlab/style": "^1.25.0",
-        "@ferlab/ui": "^4.6.0",
+        "@ferlab/ui": "^4.6.2",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.6.0.tgz",
-      "integrity": "sha512-fKtveeJvhpDS8EJaVjGEVgEj1QFDB4qp496MH6KpXEs6bwJzqriQ/AKtC4HT8Q7LTRA7RSwRWl7dziv/YEvxvg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.6.2.tgz",
+      "integrity": "sha512-XMyu/qgD8sG58zCCXEwKtuXkeeENWtqzcaJFxVU+2ozynwObc+2JeEoK885+IiR86hUKIogkeuaM6bm0a+GZaA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -10219,7 +10219,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -10231,7 +10231,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21152,9 +21152,9 @@
       }
     },
     "@ferlab/ui": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.6.0.tgz",
-      "integrity": "sha512-fKtveeJvhpDS8EJaVjGEVgEj1QFDB4qp496MH6KpXEs6bwJzqriQ/AKtC4HT8Q7LTRA7RSwRWl7dziv/YEvxvg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.6.2.tgz",
+      "integrity": "sha512-XMyu/qgD8sG58zCCXEwKtuXkeeENWtqzcaJFxVU+2ozynwObc+2JeEoK885+IiR86hUKIogkeuaM6bm0a+GZaA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -27054,7 +27054,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -27063,7 +27063,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "devOptional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@ferlab/style": "^1.25.0",
-    "@ferlab/ui": "^4.6.0",
+    "@ferlab/ui": "^4.6.2",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -94,8 +94,6 @@ export const SEARCH_VARIANT_QUERY = gql`
                         total
                         edges {
                           node {
-                            id
-                            score
                             tumour_types_germline
                           }
                         }
@@ -106,8 +104,6 @@ export const SEARCH_VARIANT_QUERY = gql`
                         total
                         edges {
                           node {
-                            #id
-                            #score
                             disease_name
                           }
                         }

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -29,7 +29,7 @@ import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQuery
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { INDEXES } from 'graphql/constants';
-import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { DATA_EXPLORATION_QB_ID, DEFAULT_PAGE_INDEX } from 'views/DataExploration/utils/constant';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import {
   IQueryResults,
@@ -39,6 +39,8 @@ import {
 } from '@ferlab/ui/core/graphql/types';
 
 interface OwnProps {
+  pageIndex: number;
+  setPageIndex: (value: number) => void;
   results: IQueryResults<IVariantEntity[]>;
   setQueryConfig: TQueryConfigCb;
   queryConfig: IQueryConfig;
@@ -184,12 +186,15 @@ const defaultColumns: ProColumnType[] = [
   },
 ];
 
-const DEFAULT_PAGE_INDEX = 1;
-
-const VariantsTable = ({ results, setQueryConfig, queryConfig }: OwnProps) => {
+const VariantsTable = ({
+  results,
+  setQueryConfig,
+  queryConfig,
+  pageIndex,
+  setPageIndex,
+}: OwnProps) => {
   const { filters }: { filters: ISyntheticSqon } = useFilters();
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
-  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
 
   useEffect(() => {
     if (selectedKeys.length) {

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -16,6 +16,7 @@ import { useVariant } from 'graphql/variants/actions';
 import { IVariantResultTree } from 'graphql/variants/models';
 import { GET_VARIANT_COUNT } from 'graphql/variants/queries';
 import {
+  DEFAULT_OFFSET,
   DEFAULT_PAGE_INDEX,
   DEFAULT_QUERY_CONFIG,
   DEFAULT_SORT_QUERY,
@@ -56,18 +57,18 @@ const PageContent = ({ variantMapping }: OwnProps) => {
   const dispatch = useDispatch();
   const { queryList, activeQuery } = useQueryBuilderState(VARIANT_REPO_QB_ID);
   const { savedFilters, defaultFilter } = useSavedFilter(SavedFilterTag.VariantsExplorationPage);
-
   const [variantQueryConfig, setVariantQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
   const [selectedFilterContent, setSelectedFilterContent] = useState<ReactElement | undefined>(
     undefined,
   );
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
 
   const variantResolvedSqon = resolveSyntheticSqon(queryList, activeQuery);
 
   const variantResults = useVariant(
     {
       first: variantQueryConfig.size,
-      offset: DEFAULT_PAGE_INDEX,
+      offset: DEFAULT_OFFSET,
       searchAfter: variantQueryConfig.searchAfter,
       sqon: variantResolvedSqon,
       sort: tieBreaker({
@@ -98,8 +99,9 @@ const PageContent = ({ variantMapping }: OwnProps) => {
     setVariantQueryConfig({
       ...variantQueryConfig,
       searchAfter: undefined,
-      pageIndex: DEFAULT_PAGE_INDEX,
     });
+
+    setPageIndex(DEFAULT_PAGE_INDEX);
     // eslint-disable-next-line
   }, [JSON.stringify(activeQuery)]);
 
@@ -196,6 +198,8 @@ const PageContent = ({ variantMapping }: OwnProps) => {
         }}
       />
       <VariantsTable
+        pageIndex={pageIndex}
+        setPageIndex={setPageIndex}
         results={variantResults}
         setQueryConfig={setVariantQueryConfig}
         queryConfig={variantQueryConfig}

--- a/src/views/Variants/utils/constants.ts
+++ b/src/views/Variants/utils/constants.ts
@@ -10,7 +10,9 @@ export const VARIANT_REPO_QB_ID = 'kf-variant-repo-key';
 
 export const VARIANT_FILTER_TAG = SavedFilterTag.VariantsExplorationPage;
 
-export const DEFAULT_PAGE_INDEX = 0;
+export const DEFAULT_OFFSET = 0;
+export const DEFAULT_PAGE_INDEX = 1;
+
 export const DEFAULT_PAGE_SIZE = PaginationViewPerQuery.Ten;
 
 export const DEFAULT_SORT_QUERY = [
@@ -19,7 +21,7 @@ export const DEFAULT_SORT_QUERY = [
 ] as ISort[];
 
 export const DEFAULT_QUERY_CONFIG: IQueryConfig = {
-  pageIndex: DEFAULT_PAGE_INDEX,
+  pageIndex: DEFAULT_OFFSET,
   size: DEFAULT_PAGE_SIZE,
   sort: DEFAULT_SORT_QUERY,
   searchAfter: undefined,


### PR DESCRIPTION
# BUG 

- closes #[522](https://d3b.atlassian.net/browse/SKFP-522)

## Description

Notion updated : https://www.notion.so/ferlab/Search-After-guide-de-migration-Front-End-8a0cd7ed40984f219f0174d64404b09b

## Screenshot

1. Désactiver le bouton Next quand il n’y a qu’une seule page d’affichée pour éviter d’afficher une page vide en cliquant sur Next.
![Peek 2022-11-17 15-27](https://user-images.githubusercontent.com/65532894/202555553-33fe1b57-6d06-4a8f-9b83-050b3c2e778b.gif)
![Screenshot_20221117_152830](https://user-images.githubusercontent.com/65532894/202555622-cd62b94a-79fc-47c7-b6ed-17f471430736.png)


2. Désactiver le bouton Next lorsqu’il n’y a aucun résultat. Note: Cliquer sur Next ne fait rien ici.
![Screenshot_20221117_153025](https://user-images.githubusercontent.com/65532894/202555385-788cadd7-bb46-4645-9f8f-c2445af67c08.png)

3. Retourner à la première page au changement de requête.
![Peek 2022-11-17 15-44](https://user-images.githubusercontent.com/65532894/202555969-8f7635ba-a28b-4ae2-b077-512b70eb5a4e.gif)

4. Il n’est pas possible d’afficher les résultats au delà de 10K éléments.

https://user-images.githubusercontent.com/65532894/202556063-99313a42-06f6-480a-8447-1ddbb47c4377.mp4


