### PR TITLE
🐛fix(exploration): SKFP-544 use shared filter instead of filterid

### DIFF
--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -27,7 +27,7 @@ import {
   TAB_IDS,
 } from 'views/DataExploration/utils/constant';
 
-import { FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
+import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
 import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
 import { ArrangerApi } from 'services/api/arranger';
@@ -153,7 +153,7 @@ const PageContent = ({ fileMapping, participantMapping, tabId = TAB_IDS.SUMMARY 
   const handleOnSaveAsFavorite = (filter: ISavedFilter) =>
     dispatch(setSavedFilterAsDefault(addTagToFilter(filter)));
   const handleOnShareFilter = (filter: ISavedFilter) => {
-    copy(`${getCurrentUrl()}?${FILTER_ID_QUERY_PARAM_KEY}=${filter.id}`);
+    copy(`${getCurrentUrl()}?${SHARED_FILTER_ID_QUERY_PARAM_KEY}=${filter.id}`);
     dispatch(
       globalActions.displayMessage({
         content: 'Copied share url',


### PR DESCRIPTION
# BUG

- closes #[544](https://d3b.atlassian.net/browse/SKFP-544)

## Description
Pour reproduire:

Avoir deux Saved Filters

Copier la Share url d’un filtre

Basculer sur l’autre filtre 
Coller l’url dans le browser

 Le nom du filtre copié s’affiche, mais avec les requêtes du filtre qui était affiché (ce qui modifie le contenu du filtre copié - icône orange).

## Screenshot
![Peek 2022-11-23 10-22](https://user-images.githubusercontent.com/65532894/203584896-53472fcb-3418-4848-94b0-0a609396f6d8.gif)

