### PR TITLE
🐛fix(registration): SKFP-550 should register roles at account creation

### DIFF
--- a/src/services/api/persona/index.ts
+++ b/src/services/api/persona/index.ts
@@ -132,8 +132,8 @@ const create = (user: IPersonaUser) =>
     data: {
       variables: user,
       query: `
-        mutation($egoId: String!, $firstName: String, $lastName: String, $email: String, $acceptedTerms: Boolean, $acceptedKfOptIn: Boolean, $acceptedDatasetSubscriptionKfOptIn: Boolean) {
-          userCreate(record:{egoId: $egoId, firstName: $firstName, lastName: $lastName, email: $email, acceptedTerms: $acceptedTerms, acceptedKfOptIn: $acceptedKfOptIn, acceptedDatasetSubscriptionKfOptIn: $acceptedDatasetSubscriptionKfOptIn}) {
+        mutation($egoId: String!, $firstName: String, $lastName: String, $email: String, $roles: [EnumUserModelRoles], $acceptedTerms: Boolean, $acceptedKfOptIn: Boolean, $acceptedDatasetSubscriptionKfOptIn: Boolean) {
+          userCreate(record:{egoId: $egoId, firstName: $firstName, lastName: $lastName, email: $email, roles: $roles, acceptedTerms: $acceptedTerms, acceptedKfOptIn: $acceptedKfOptIn, acceptedDatasetSubscriptionKfOptIn: $acceptedDatasetSubscriptionKfOptIn}) {
             record {
               ${DEFAULT_FIELDS_SELF}
             }


### PR DESCRIPTION
# BUG 

- closes #[550](https://d3b.atlassian.net/browse/SKFP-550)

## Description

Pour reproduire:
> Créer un nouveau membre
> Renseigner le rôle à la création
> À l’affichage de la Profile Settings Page, aucune information du rôle renseignée n’est présente.


## Screenshot (Before and After)


https://user-images.githubusercontent.com/65532894/203601228-73319f18-9b19-487b-8af7-b2eb518eedbb.mp4


https://user-images.githubusercontent.com/65532894/203601231-67eabf0b-d1c5-4cad-912d-eded09bf8dbd.mp4


