### PR TITLE
🐛fix(variant): SKFP-553 add translation for sift values

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -141,6 +141,10 @@ export const getQueryBuilderDictionary = (
       return set ? set.tag : setId;
     },
     facetValueMapping: {
+      'consequences.predictions.sift_pred': {
+        T: 'Tolerated',
+        D: 'Damaging',
+      },
       down_syndrome_status: {
         D21: intl.get('facets.options.D21'),
         T21: intl.get('facets.options.T21'),


### PR DESCRIPTION
# BUG 

- closes #[553](https://d3b.atlassian.net/browse/SKFP-553)

## Description
Adjust the query pill values to the ones seen in the facets. Currently it is set as “T” which is an acronym for Tolerated. This was fixed in the facets, but the query pills will need to be updated.

## Screenshot 
Before
![image](https://user-images.githubusercontent.com/65532894/203639097-bba473d4-9ac6-48e1-a3fc-231f521fd8a2.png)

After
![Screenshot_20221123_151748](https://user-images.githubusercontent.com/65532894/203639166-ce769397-a98e-4a0a-9b95-5c77973b3bce.png)

