### PR TITLE
🐛fix(variants): SKFP-518 change clinvar and vep order

### DIFF
--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -119,10 +119,12 @@ const filterGroups: {
   [FilterTypes.Pathogenicity]: {
     groups: [
       {
+        facets: ['clinvar__clin_sig', 'consequences__vep_impact'],
+        tooltips: ['consequences__vep_impact'],
+      },
+      {
         title: 'Predictions',
         facets: [
-          'clinvar__clin_sig',
-          'consequences__vep_impact',
           'consequences__predictions__sift_pred',
           'consequences__predictions__polyphen2_hvar_pred',
           'consequences__predictions__fathmm_pred',
@@ -131,7 +133,7 @@ const filterGroups: {
           'consequences__predictions__lrt_pred',
           'consequences__predictions__revel_rankscore',
         ],
-        tooltips: ['consequences__predictions__sift_pred', 'consequences__vep_impact'],
+        tooltips: ['consequences__predictions__sift_pred'],
       },
     ],
   },


### PR DESCRIPTION
# BUG 

- closes #[518](https://d3b.atlassian.net/browse/SKFP-518)

## Description
Page Variants - Pathogenicity: Déplacer ClinVar et VEP en haut de la section Predictions
Acceptance Criterias


## Screenshot
Before
![image](https://user-images.githubusercontent.com/65532894/204305578-952a178d-278f-461f-8bdb-1abc9565d490.png)

After
![image](https://user-images.githubusercontent.com/65532894/204305613-1f821057-ebf8-4343-a117-81775328e39c.png)




