### PR TITLE
🐛fix(variant): SKFP-553 fix query pill values

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,6 +36,7 @@
   "facets.options.zygosity.HET": "Heterozygote",
   "facets.options.zygosity.WT": "Wild Type",
   "facets.options.zygosity.HOM": "Homozygote",
+  "facets.options.zygosity.UNK": "Unknown",
   "family": "family",
   "father": "father",
   "female": "Female",

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -142,12 +142,32 @@ export const getQueryBuilderDictionary = (
     },
     facetValueMapping: {
       'consequences.predictions.sift_pred': {
-        T: 'Tolerated',
-        D: 'Damaging',
+        T: intl.get('facets.options.consequences__predictions__sift_pred.T'),
+        D: intl.get('facets.options.consequences__predictions__sift_pred.D'),
+      },
+      'consequences.predictions.polyphen2_hvar_pred': {
+        B: intl.get('facets.options.consequences__predictions__polyphen2_hvar_pred.B'),
+        D: intl.get('facets.options.consequences__predictions__polyphen2_hvar_pred.D'),
+        P: intl.get('facets.options.consequences__predictions__polyphen2_hvar_pred.P'),
+      },
+      'consequences.predictions.fathmm_pred': {
+        T: intl.get('facets.options.consequences__predictions__fathmm_pred.T'),
+        D: intl.get('facets.options.consequences__predictions__fathmm_pred.D'),
+      },
+      'consequences.predictions.lrt_pred': {
+        N: intl.get('facets.options.consequences__predictions__lrt_pred.N'),
+        D: intl.get('facets.options.consequences__predictions__lrt_pred.D'),
+        U: intl.get('facets.options.consequences__predictions__lrt_pred.U'),
       },
       down_syndrome_status: {
         D21: intl.get('facets.options.D21'),
         T21: intl.get('facets.options.T21'),
+      },
+      zygosity: {
+        HET: intl.get('facets.options.zygosity.HET'),
+        WT: intl.get('facets.options.zygosity.WT'),
+        HOM: intl.get('facets.options.zygosity.HOM'),
+        UNK: intl.get('facets.options.zygosity.UNK'),
       },
     },
   },


### PR DESCRIPTION
# BUG

- closes #[553](https://d3b.atlassian.net/browse/SKFP-553)

## Description
Sync query pill values
![image](https://user-images.githubusercontent.com/65532894/204322371-b6f7aa50-6572-45e7-a47f-59772cd508bd.png)


## Screenshot 
![Screenshot_20221123_151748](https://user-images.githubusercontent.com/65532894/204322466-0979801a-adb2-49af-8cc7-1f2ff4aab3b6.png)
![Screenshot_20221128_104706](https://user-images.githubusercontent.com/65532894/204322468-78a90f27-c526-481b-b1f3-f6b50947d851.png)
![Screenshot_20221128_104726](https://user-images.githubusercontent.com/65532894/204322469-8a57912d-df24-4f45-afbc-dbf4daed2e94.png)
![Screenshot_20221128_104742](https://user-images.githubusercontent.com/65532894/204322471-6674333d-de97-488e-b564-1f04507163a1.png)
![Screenshot_20221128_104801](https://user-images.githubusercontent.com/65532894/204322473-0357b079-3907-4de3-82d0-5bcc241084aa.png)

With translations since the facet doesn't return all the case
![Screenshot_20221128_105146](https://user-images.githubusercontent.com/65532894/204322476-11360cb7-57ba-452c-ae00-901f51b0e869.png)
![Screenshot_20221128_105155](https://user-images.githubusercontent.com/65532894/204322477-d115acc8-9e4b-4bb7-a58e-5e0c02446e38.png)


