### PR TITLE
🐛fix(variants): SKFP-473 minor fixs

### DIFF
--- a/src/components/uiKit/FilterList/CollapsePlaceHolderFacet/index.module.scss
+++ b/src/components/uiKit/FilterList/CollapsePlaceHolderFacet/index.module.scss
@@ -1,8 +1,11 @@
+@import 'src/style/themes/kids-first/colors';
+
 .collapseLikeFacet {
   .collapse {
     &,
     :global(.ant-collapse-item) {
       border: none;
+      color: $geekblue-7;
     }
 
     div[class$='-header'] {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -944,14 +944,12 @@ const en = {
     //Variants
     variant_class: 'Variant Type',
     type: 'Type',
-    variant_external_reference: 'External Reference',
     chromosome: 'Chromosome',
     position: 'Position',
     zygosity: 'Zygosity',
     transmissions: 'Transmission',
     genePanels: 'Gene Panels',
     start: 'Position',
-    gene_external_reference: 'External Reference',
     locus: 'Variant',
     consequences: {
       consequences: 'Consequence',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -141,6 +141,10 @@ export const getQueryBuilderDictionary = (
       return set ? set.tag : setId;
     },
     facetValueMapping: {
+      variant_external_reference: {
+        DBSNP: intl.get('screen.variants.table.dbsnp'),
+        Clinvar: intl.get('filters.group.clinvar.clin_sig'),
+      },
       'consequences.predictions.sift_pred': {
         T: intl.get('facets.options.consequences__predictions__sift_pred.T'),
         D: intl.get('facets.options.consequences__predictions__sift_pred.D'),


### PR DESCRIPTION
# BUG 
- closes #[473](https://d3b.atlassian.net/browse/SKFP-473)

## Description
Under the Variant and Gene category, currently we only specify “ External Reference” as a facet. However, this becomes problematic when we add a filter and the query pill for both categories is the same “External Reference”. Therefore, we will modify the facets and query pills to correspond to Variant External Reference / Gene External Reference for the Variant category and the Gene category respectively. [DONE]

Under Participant category, update the Phenotype (HPO) & Diagnosis (MONDO) facet to KF UI color theme  [DONE]

## Screenshot 

![image](https://user-images.githubusercontent.com/65532894/204610171-34cbd774-de13-4c33-aafc-c53505f3c2f9.pn
![Screenshot_20221129_130133](https://user-images.githubusercontent.com/65532894/204610256-21ea3fb5-188a-41b9-ac64-97e036127cc4.png)
g)

