### PR TITLE
🐛fix(cavatica): SKFP-510 change placeholder

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/Cavatica/CreateProjectModal/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/Cavatica/CreateProjectModal/index.tsx
@@ -93,7 +93,7 @@ const CreateProjectModal = ({
           rules={[{ required: true, type: 'string' }]}
           required={false}
         >
-          <Input placeholder="ex: Lorem ipsum dolor"></Input>
+          <Input placeholder="e.g. KF-NBL Neuroblastoma Aligned Reads"></Input>
         </Form.Item>
         <Form.Item
           name={FORM_FIELDS.PROJECT_BILLING_GROUP}


### PR DESCRIPTION
# BUG 

- closes #[510](https://d3b.atlassian.net/browse/SKFP-510)

## Description

Adjust the lorem ipsum placeholder to “e.g. KF-NBL Neuroblastoma Aligned Reads” in the New project modal when analyzing in cavatica. This modal can also be accessed using the Cavatica widget > New project button