### PR TITLE
🐛fix(data-exploration): SKFP-560 Study column sorting

### DIFF
--- a/src/utils/helper.test.tsx
+++ b/src/utils/helper.test.tsx
@@ -3,7 +3,7 @@ import { SorterResult } from 'antd/lib/table/interface';
 
 import { formatQuerySortList, getOrderFromAntdValue } from './helper';
 
-describe('getOrderFromAntdValue()', () => {
+describe(`${getOrderFromAntdValue.name}()`, () => {
   test('should return SortDirection.Asc for "ascend"', () => {
     expect(getOrderFromAntdValue('ascend')).toBe(SortDirection.Asc);
   });
@@ -13,7 +13,7 @@ describe('getOrderFromAntdValue()', () => {
   });
 });
 
-describe('formatQuerySortList()', () => {
+describe(`${formatQuerySortList.name}()`, () => {
   it('should handle a single sorter', () => {
     const sorter1: SorterResult<any> = {
       columnKey: 'field1',

--- a/src/utils/helper.test.tsx
+++ b/src/utils/helper.test.tsx
@@ -1,7 +1,7 @@
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { SorterResult } from 'antd/lib/table/interface';
 
-import { convertToArray, formatQuerySortList, getOrderFromAntdValue } from './helper';
+import { formatQuerySortList, getOrderFromAntdValue } from './helper';
 
 describe('getOrderFromAntdValue()', () => {
   test('should return SortDirection.Asc for "ascend"', () => {
@@ -10,18 +10,6 @@ describe('getOrderFromAntdValue()', () => {
 
   test('should return SortDirection.Desc for any other value', () => {
     expect(getOrderFromAntdValue('foo')).toBe(SortDirection.Desc);
-  });
-});
-
-describe('convertToArray()', () => {
-  it('should return an array if input is an array', () => {
-    const array = [1, 2, 3];
-    expect(convertToArray(array)).toEqual(array);
-  });
-
-  it('should return an array if input is not an array', () => {
-    const value = 'Hello World';
-    expect(convertToArray(value)).toEqual([value]);
   });
 });
 

--- a/src/utils/helper.test.tsx
+++ b/src/utils/helper.test.tsx
@@ -1,0 +1,51 @@
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { SorterResult } from 'antd/lib/table/interface';
+
+import { convertToArray, formatQuerySortList, getOrderFromAntdValue } from './helper';
+
+describe('getOrderFromAntdValue()', () => {
+  test('should return SortDirection.Asc for "ascend"', () => {
+    expect(getOrderFromAntdValue('ascend')).toBe(SortDirection.Asc);
+  });
+
+  test('should return SortDirection.Desc for any other value', () => {
+    expect(getOrderFromAntdValue('foo')).toBe(SortDirection.Desc);
+  });
+});
+
+describe('convertToArray()', () => {
+  it('should return an array if input is an array', () => {
+    const array = [1, 2, 3];
+    expect(convertToArray(array)).toEqual(array);
+  });
+
+  it('should return an array if input is not an array', () => {
+    const value = 'Hello World';
+    expect(convertToArray(value)).toEqual([value]);
+  });
+});
+
+describe('formatQuerySortList()', () => {
+  it('should handle a single sorter', () => {
+    const sorter1: SorterResult<any> = {
+      columnKey: 'field1',
+      order: 'ascend',
+    };
+    expect(formatQuerySortList(sorter1)).toEqual([{ field: 'field1', order: 'asc' }]);
+  });
+
+  it('should handle an array of sorters', () => {
+    const sorter2: SorterResult<any> = {
+      columnKey: 'field2',
+      order: 'descend',
+    };
+    const sorter3: SorterResult<any> = {
+      columnKey: 'field3',
+      order: 'ascend',
+    };
+    expect(formatQuerySortList([sorter2, sorter3])).toEqual([
+      { field: 'field2', order: 'desc' },
+      { field: 'field3', order: 'asc' },
+    ]);
+  });
+});

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -11,26 +11,21 @@ export const scrollToTop = (scrollContentId: string) =>
 
 export const orderCardIfNeeded = (cards: TSortableItems[], userCardConfig: string[] | undefined) =>
   userCardConfig
-    ? cards.sort((a, b) => {
-        return userCardConfig.indexOf(a.id) > userCardConfig.indexOf(b.id) ? 1 : -1;
-      })
+    ? cards
+        .slice()
+        .sort((a, b) => (userCardConfig.indexOf(a.id) > userCardConfig.indexOf(b.id) ? 1 : -1))
     : cards;
 
 export const getOrderFromAntdValue = (order: string): SortDirection =>
   order === 'ascend' ? SortDirection.Asc : SortDirection.Desc;
 
-export const formatQuerySortList = (sorter: SorterResult<any> | SorterResult<any>[]) => {
-  const sorters = (isArray(sorter) ? sorter : [sorter]).filter(
-    (sorter) => !!sorter.column || !!sorter.order,
-  );
+export const convertToArray = <T>(value: T | T[]) => (isArray(value) ? value : [value]);
 
-  const r = sorters.map((sorter) => ({
-    field: (sorter.field?.toString()! || sorter.columnKey?.toString()!).replaceAll('__', '.'),
+export const formatQuerySortList = (sorter: SorterResult<any> | SorterResult<any>[]) =>
+  convertToArray(sorter).map((sorter) => ({
+    field: sorter.columnKey as string,
     order: getOrderFromAntdValue(sorter.order!),
   }));
-
-  return r;
-};
 
 export const getCurrentUrl = () =>
   window.location.protocol + '//' + window.location.host + window.location.pathname;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,7 +1,6 @@
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { TSortableItems } from '@ferlab/ui/core/layout/SortableGrid/SortableItem';
 import { SorterResult } from 'antd/lib/table/interface';
-import { isArray } from 'lodash';
 
 export const scrollToTop = (scrollContentId: string) =>
   document
@@ -19,10 +18,8 @@ export const orderCardIfNeeded = (cards: TSortableItems[], userCardConfig: strin
 export const getOrderFromAntdValue = (order: string): SortDirection =>
   order === 'ascend' ? SortDirection.Asc : SortDirection.Desc;
 
-export const convertToArray = <T>(value: T | T[]) => (isArray(value) ? value : [value]);
-
 export const formatQuerySortList = (sorter: SorterResult<any> | SorterResult<any>[]) =>
-  convertToArray(sorter).map((sorter) => ({
+  [sorter].flat().map((sorter) => ({
     field: sorter.columnKey as string,
     order: getOrderFromAntdValue(sorter.order!),
   }));

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -1,57 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { DownloadOutlined } from '@ant-design/icons';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import ProTable from '@ferlab/ui/core/components/ProTable';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import useQueryBuilderState, {
+  addQuery,
+} from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import {
-  IParticipantOutcomes,
+  IArrangerResultsTree,
+  IQueryConfig,
+  IQueryResults,
+  TQueryConfigCb,
+} from '@ferlab/ui/core/graphql/types';
+import { Button, Dropdown, Menu, Tag } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import {
   IParticipantDiagnosis,
   IParticipantEntity,
   IParticipantObservedPhenotype,
+  IParticipantOutcomes,
   IParticipantPhenotype,
   IParticipantStudy,
   ITableParticipantEntity,
 } from 'graphql/participants/models';
+import { capitalize } from 'lodash';
+import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import {
   DATA_EXPLORATION_QB_ID,
   DEFAULT_PAGE_SIZE,
   SCROLL_WRAPPER_ID,
   TAB_IDS,
 } from 'views/DataExploration/utils/constant';
-import { SEX, TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
-import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
 import {
   extractMondoTitleAndCode,
   extractPhenotypeTitleAndCode,
 } from 'views/DataExploration/utils/helper';
-import ProTable from '@ferlab/ui/core/components/ProTable';
-import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
-import { getProTableDictionary } from 'utils/translation';
-import { Button, Dropdown, Menu, Tag } from 'antd';
-import { useDispatch } from 'react-redux';
-import { updateUserConfig } from 'store/user/thunks';
-import { useUser } from 'store/user';
-import { ReportType } from 'services/api/reports/models';
-import { DownloadOutlined } from '@ant-design/icons';
-import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { STATIC_ROUTES } from 'utils/routes';
-import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { INDEXES } from 'graphql/constants';
-import { fetchReport, fetchTsvReport } from 'store/report/thunks';
-import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
-import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
-import { capitalize } from 'lodash';
-import { formatQuerySortList, scrollToTop } from 'utils/helper';
-import useQueryBuilderState, {
-  addQuery,
-} from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
-import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
+
+import { SEX, TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { ReportType } from 'services/api/reports/models';
 import { SetType } from 'services/api/savedSet/models';
+import { fetchReport, fetchTsvReport } from 'store/report/thunks';
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+import { formatQuerySortList, scrollToTop } from 'utils/helper';
+import { STATIC_ROUTES } from 'utils/routes';
+import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
-import {
-  IQueryResults,
-  IQueryConfig,
-  TQueryConfigCb,
-  IArrangerResultsTree,
-} from '@ferlab/ui/core/graphql/types';
 
 interface OwnProps {
   results: IQueryResults<IParticipantEntity[]>;
@@ -70,12 +71,12 @@ const defaultColumns: ProColumnType[] = [
     },
   },
   {
-    key: 'study',
+    key: 'study.study_code',
     title: 'Study',
-    dataIndex: 'study',
     sorter: {
       multiple: 1,
     },
+    dataIndex: 'study',
     className: styles.studyIdCell,
     render: (study: IParticipantStudy) => study.study_code || TABLE_EMPTY_PLACE_HOLDER,
   },
@@ -95,7 +96,7 @@ const defaultColumns: ProColumnType[] = [
       ),
   },
   {
-    key: 'proband',
+    key: 'is_proband',
     title: 'Proband',
     dataIndex: 'is_proband',
     sorter: {
@@ -139,8 +140,8 @@ const defaultColumns: ProColumnType[] = [
     title: 'Diagnosis (MONDO)',
     dataIndex: 'diagnosis',
     className: styles.diagnosisCell,
-    render: (mondo: IArrangerResultsTree<IParticipantDiagnosis>) => {
-      const mondoNames = mondo?.hits?.edges.map((m) => m.node.mondo_id_diagnosis);
+    render: (diagnosis: IArrangerResultsTree<IParticipantDiagnosis>) => {
+      const mondoNames = diagnosis?.hits?.edges.map((m) => m.node.mondo_id_diagnosis);
       if (!mondoNames || mondoNames.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
@@ -269,8 +270,8 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
-    render: (record: ITableParticipantEntity) => {
-      return record.nb_files ? (
+    render: (record: ITableParticipantEntity) =>
+      record.nb_files ? (
         <Link
           to={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
           onClick={() =>
@@ -293,8 +294,7 @@ const defaultColumns: ProColumnType[] = [
         </Link>
       ) : (
         record.nb_files || 0
-      );
-    },
+      ),
   },
   {
     key: 'race',
@@ -554,8 +554,14 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
             selectedAllResults={selectedAllResults}
             sqon={getCurrentSqon()}
             type={SetType.PARTICIPANT}
+            key="participant-set-management"
           />,
-          <Dropdown disabled={selectedKeys.length === 0} overlay={menu} placement="bottomLeft">
+          <Dropdown
+            disabled={selectedKeys.length === 0}
+            overlay={menu}
+            placement="bottomLeft"
+            key={'download-clinical-data-dropdown'}
+          >
             <Button icon={<DownloadOutlined />}>Download clinical data</Button>
           </Dropdown>,
         ],

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -21,7 +21,7 @@ import cx from 'classnames';
 import { INDEXES } from 'graphql/constants';
 import {
   IClinVar,
-  IConsequenceNode,
+  IConsequenceEntity,
   IExternalFrequenciesEntity,
   ITableVariantEntity,
   IVariantEntity,
@@ -97,7 +97,7 @@ const defaultColumns: ProColumnType[] = [
     title: intl.get('screen.variants.table.consequences'),
     dataIndex: 'consequences',
     width: 300,
-    render: (consequences: { hits: { edges: IConsequenceNode[] } }) => (
+    render: (consequences: IArrangerResultsTree<IConsequenceEntity>) => (
       <ConsequencesCell consequences={consequences?.hits?.edges || []} />
     ),
   },
@@ -124,7 +124,7 @@ const defaultColumns: ProColumnType[] = [
   {
     title: intl.get('screen.variants.table.participant.title'),
     tooltip: intl.get('screen.variants.table.participant.tooltip'),
-    key: 'part',
+    key: 'participant_number',
     render: (record: IVariantEntity) => {
       const participantNumber = record.participant_number || 0;
       if (participantNumber <= 10) {
@@ -238,7 +238,7 @@ const VariantsTable = ({
             current: pageIndex,
             queryConfig,
             setQueryConfig,
-            onChange: (page: number, _) => {
+            onChange: (page: number) => {
               scrollToTop(SCROLL_WRAPPER_ID);
               setPageIndex(page);
             },


### PR DESCRIPTION
# BUG

- closes [SKFP-562](https://d3b.atlassian.net/browse/SKFP-560)

## Description

Refact of the ```formatQuerySortList()``` function. Made sure it still works everywhere it's used.

Only thing to keep in mind is that when creating a table, the 'key' property will now always be used as the ```field``` value sent to the backend for sorting (i.e. we can use ```key: 'study.study_code'``` for nested data) and the ```dataIndex```property will only be used to render the cell content.

Before, `dataIndex` would become ```sorter.field``` in the ```formatQuerySortList()``` function, which created inconsistent ways of using ```key``` vs ```dataIndex``` and would sometimes result in breaking the sorting because the wrong key was sent to the backend. 

## Screenshot
Before:
![560_before](https://user-images.githubusercontent.com/116835792/207161818-26198cab-23d4-40e8-9b67-c08905b702e7.gif)

After:
![560_after](https://user-images.githubusercontent.com/116835792/207161798-4a6da066-76bf-4589-b157-bd1c8148e031.gif)