### PR TITLE
🐛fix(variant): SKFP-569 Display hgvsp data in ConsequencesCell

### DIFF
--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -72,6 +72,7 @@ export interface IConsequenceEntity {
   consequences: string[];
   vep_impact: Impact;
   aa_change: string | undefined | null;
+  hgvsp: string | null;
   impact_score: number | null;
   canonical: boolean;
   coding_dna_change: string;

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -227,6 +227,7 @@ export const SEARCH_VARIANT_QUERY = gql`
                       fathmm_converted_rankscore
                     }
                     hgvsc
+                    hgvsp
                     consequences
                     vep_impact
                     symbol

--- a/src/views/Variants/components/ConsequencesCell/index.tsx
+++ b/src/views/Variants/components/ConsequencesCell/index.tsx
@@ -1,4 +1,5 @@
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
 import { IConsequenceEntity, Impact } from 'graphql/variants/models';
 
@@ -11,7 +12,6 @@ import { toKebabCase } from 'utils/helper';
 import { generateConsequencesDataLines } from './consequences';
 
 import style from './index.module.scss';
-import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
 
 const impactToColorClassName = Object.freeze({
   [Impact.High]: <HighBadgeIcon svgClass={`${style.bullet} ${style.highImpact}`} />,
@@ -50,7 +50,7 @@ const ConsequencesCell = ({
                   </ExternalLink>
                 </span>
               )}
-              {node.aa_change && <span>{node.aa_change}</span>}
+              {node.hgvsp && <span>{node.hgvsp.split(':')[1]}</span>}
             </StackLayout>
           );
         }


### PR DESCRIPTION
# BUG

- closes #[SKFP-569](https://d3b.atlassian.net/browse/SKFP-569)

## Description

Replace the aa_change value by hgvsp like it was done here: [CLIN-1518](https://ferlab-crsj.atlassian.net/browse/CLIN-1518)

## Screenshot
Before:
![image-20221212-185450](https://user-images.githubusercontent.com/116835792/207653521-66601523-a544-4da5-a748-0ab4b748fbb1.png)

After:
![D5FA4AA9-D780-40F4-A9FF-ADE5EB721D63](https://user-images.githubusercontent.com/116835792/207653597-35be297e-8219-43b0-871a-837563adf8c7.jpeg)