### PR TITLE
✨feat(variant): SKFP-573 add column sort

### DIFF
--- a/src/services/api/user/models.ts
+++ b/src/services/api/user/models.ts
@@ -48,6 +48,11 @@ export type TUserConfig = {
       study?: TUserTableConfig;
     };
   };
+  variant?: {
+    tables?: {
+      variants?: TUserTableConfig;
+    };
+  };
   dashboard?: {
     cards?: {
       order?: string[];

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -37,6 +37,9 @@ import { STATIC_ROUTES } from 'utils/routes';
 import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+import { useDispatch } from 'react-redux';
 
 interface OwnProps {
   pageIndex: number;
@@ -196,7 +199,9 @@ const VariantsTable = ({
   pageIndex,
   setPageIndex,
 }: OwnProps) => {
+  const dispatch = useDispatch();
   const { filters }: { filters: ISyntheticSqon } = useFilters();
+  const { userInfo } = useUser();
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
 
   useEffect(() => {
@@ -213,6 +218,7 @@ const VariantsTable = ({
           tableId="variants_table"
           columns={defaultColumns}
           enableRowSelection
+          initialColumnState={userInfo?.config.variant?.tables?.variants?.columns}
           wrapperClassName={styles.variantTabWrapper}
           loading={results.loading}
           initialSelectedKey={selectedKeys}
@@ -231,6 +237,19 @@ const VariantsTable = ({
               pageSize: queryConfig.size,
               total: results.total,
             },
+            enableColumnSort: true,
+            onColumnSortChange: (newState) =>
+              dispatch(
+                updateUserConfig({
+                  variant: {
+                    tables: {
+                      variants: {
+                        columns: newState,
+                      },
+                    },
+                  },
+                }),
+              ),
           }}
           bordered
           size="small"


### PR DESCRIPTION
# FEAT

- closes #[573](https://d3b.atlassian.net/browse/SKFP-573)

## Description
Add column selection tool to the table of results in the Variant exploration page. All the columns can be set as default for the display. 

## Screenshot 
BEFORE
![image](https://user-images.githubusercontent.com/65532894/207914704-76620b46-ceb5-47a3-ba02-62d78e7bef3f.png)

AFTER
![image](https://user-images.githubusercontent.com/65532894/207914760-255e5279-8e26-4a8d-a0f4-1d4a6cabb77c.png)
