### PR TITLE
✨ feat(variant): SKFP-574 add gnomAD column, SKFFP-576 replace _ with space

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -643,6 +643,10 @@ const en = {
       table: {
         consequences: 'Consequences',
         clinvar: 'ClinVar',
+        gnomAD: {
+          title: 'gnomAD',
+          tooltip: 'gnomAD 3.1.1 Allele Frequency',
+        },
         type: 'Type',
         variant_class: 'Variant class',
         variant_id: 'Variant ID',

--- a/src/views/Variants/components/ConsequencesCell/index.tsx
+++ b/src/views/Variants/components/ConsequencesCell/index.tsx
@@ -39,7 +39,7 @@ const ConsequencesCell = ({
             <StackLayout center key={index}>
               {pickImpactBadge(node.vep_impact)}
               <span key={index} className={style.detail}>
-                {node.consequences[0]}
+                {node.consequences[0].replaceAll('_', ' ')}
               </span>
               {node.symbol && (
                 <span key={toKebabCase(node.symbol)} className={style.symbol}>

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -112,7 +112,7 @@ const defaultColumns: ProColumnType[] = [
     render: (clinVar: IClinVar) =>
       clinVar?.clin_sig && clinVar.clinvar_id ? (
         <ExternalLink href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinVar.clinvar_id}`}>
-          {clinVar.clin_sig.join(', ')}
+          {clinVar.clin_sig.join(', ').replaceAll('_', ' ')}
         </ExternalLink>
       ) : (
         TABLE_EMPTY_PLACE_HOLDER

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -119,6 +119,17 @@ const defaultColumns: ProColumnType[] = [
       ),
   },
   {
+    key: 'gnomad_genomes_3_1_1.af',
+    title: intl.get('screen.variants.table.gnomAD.title'),
+    tooltip: intl.get('screen.variants.table.gnomAD.tooltip'),
+    dataIndex: 'frequencies',
+    className: cx(styles.variantTableCell, styles.variantTableCellElipsis),
+    render: (gnomad: IExternalFrequenciesEntity) =>
+      gnomad.gnomad_genomes_3_1_1.af
+        ? toExponentialNotation(gnomad.gnomad_genomes_3_1_1.af)
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     title: 'Studies',
     dataIndex: 'studies',
     key: 'studies',

--- a/src/views/Variants/utils/constants.ts
+++ b/src/views/Variants/utils/constants.ts
@@ -13,7 +13,7 @@ export const VARIANT_FILTER_TAG = SavedFilterTag.VariantsExplorationPage;
 export const DEFAULT_OFFSET = 0;
 export const DEFAULT_PAGE_INDEX = 1;
 
-export const DEFAULT_PAGE_SIZE = PaginationViewPerQuery.Ten;
+export const DEFAULT_PAGE_SIZE = PaginationViewPerQuery.Twenty;
 
 export const DEFAULT_SORT_QUERY = [
   { field: 'max_impact_score', order: SortDirection.Desc },


### PR DESCRIPTION
# FEAT

- closes #[574](https://d3b.atlassian.net/browse/SKFP-574)
- closes #[576](https://d3b.atlassian.net/browse/SKFP-576)

## Description
Goal: Add a column for the gnomAD 3.1.1 allele frequency between the ClinVar and Studies column. Currently, we only have the allele frequency of gnomAD 3.1.1 but once we update the Variant ETL we will have gnomAD  version 3.1.2 and at this point, we will need to update the column values, column header and tooltip. 

Replace underscores with spaces for ClinVar -- Gene consequences values in Variant Exploration page.

## Screenshot (Before and After)
![Screenshot_20221215_150239](https://user-images.githubusercontent.com/65532894/207956379-15a03d11-8968-43b9-96ad-911d837a661a.png)
![Screenshot_20221215_135151](https://user-images.githubusercontent.com/65532894/207956403-d9af239b-25ea-47e8-84fb-a2dba4a74cec.png)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@ QA, Design ...
