### PR TITLE
Feat/skfp 574 575 576 578

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
         "@ferlab/style": "^1.26.2",
-        "@ferlab/ui": "^4.7.9",
+        "@ferlab/ui": "^4.8.0",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/core": "^0.80.0",
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.7.9.tgz",
-      "integrity": "sha512-gFpCEL2e1GO4EJtAR9aCDxartQhh9gy3d5ACVS4Ic0xjIRVpXHPK7Nx65mCKSRirH2hDSYdVVIYk3KodkelsbQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.8.0.tgz",
+      "integrity": "sha512-CCCra8ZuoKn2m1aXC+Q5QTor60Tw4KsF9Z1BRYRhI25HU4NQp4BhdmTN4g2Fcjufi0CM2pKdAXhEPHEAlCeu+A==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -35363,9 +35363,9 @@
       }
     },
     "@ferlab/ui": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.7.9.tgz",
-      "integrity": "sha512-gFpCEL2e1GO4EJtAR9aCDxartQhh9gy3d5ACVS4Ic0xjIRVpXHPK7Nx65mCKSRirH2hDSYdVVIYk3KodkelsbQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.8.0.tgz",
+      "integrity": "sha512-CCCra8ZuoKn2m1aXC+Q5QTor60Tw4KsF9Z1BRYRhI25HU4NQp4BhdmTN4g2Fcjufi0CM2pKdAXhEPHEAlCeu+A==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@ferlab/style": "^1.26.2",
-    "@ferlab/ui": "^4.7.9",
+    "@ferlab/ui": "^4.8.0",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.80.0",

--- a/src/services/api/user/models.ts
+++ b/src/services/api/user/models.ts
@@ -1,3 +1,4 @@
+import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
 import { TColumnStates } from '@ferlab/ui/core/components/ProTable/types';
 
 export type TUser = {
@@ -27,7 +28,8 @@ export type TUser = {
 };
 
 export type TUserTableConfig = {
-  columns: TColumnStates;
+  columns?: TColumnStates;
+  viewPerQuery?: PaginationViewPerQuery;
 };
 
 export type TUserConfig = {

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -17,6 +17,7 @@ import { GET_VARIANT_COUNT } from 'graphql/variants/queries';
 import {
   DEFAULT_OFFSET,
   DEFAULT_PAGE_INDEX,
+  DEFAULT_PAGE_SIZE,
   DEFAULT_QUERY_CONFIG,
   DEFAULT_SORT_QUERY,
   VARIANT_REPO_QB_ID,
@@ -42,6 +43,7 @@ import VariantsTable from './VariantsTable';
 
 import styles from './index.module.scss';
 import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
+import { useUser } from 'store/user';
 
 type OwnProps = {
   variantMapping: IExtendedMappingResults;
@@ -54,9 +56,13 @@ const addTagToFilter = (filter: ISavedFilter) => ({
 
 const PageContent = ({ variantMapping }: OwnProps) => {
   const dispatch = useDispatch();
+  const { userInfo } = useUser();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =
     useQBStateWithSavedFilters(VARIANT_REPO_QB_ID, SavedFilterTag.VariantsExplorationPage);
-  const [variantQueryConfig, setVariantQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
+  const [variantQueryConfig, setVariantQueryConfig] = useState({
+    ...DEFAULT_QUERY_CONFIG,
+    size: userInfo?.config.variant?.tables?.variants?.viewPerQuery || DEFAULT_PAGE_SIZE,
+  });
   const [selectedFilterContent, setSelectedFilterContent] = useState<ReactElement | undefined>(
     undefined,
   );


### PR DESCRIPTION
# FEAT

- closes #[581](https://d3b.atlassian.net/browse/SKFP-581)
- closes #[578](https://d3b.atlassian.net/browse/SKFP-578)
- closes #[575](https://d3b.atlassian.net/browse/SKFP-575)

## Description
Replace underscores with spaces for Interpretation and Consequences values in Variant Entity page.

 The value “ Conflicting Interpretations of Pathogenicity” is cut off since it is longer than the column width. Add an ellipsis and tooltip to complete the value when the value surpasses the max-width of the column. Similar to the Variant column:

Vincent requested we adjust the default row view from 10/view to 20/view. Also save the user’s parameter to the latest row view setting. E.g. if the user select 100/view, closes his session, relogs in, the table of results should be maintained at 100/view and not reinitialized to 20/view (being the default).

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot (Before and After)
![Screenshot_20221216_112019](https://user-images.githubusercontent.com/65532894/208148733-c621c6a5-e625-4430-bf18-36ad33918e85.png)

https://user-images.githubusercontent.com/65532894/208148797-13264a03-3a19-44dc-a987-2da91d23b1c8.mp4




## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@ QA, Design ...
