### PR TITLE
✨feat(study): SKFP-586 use study_code instead of study_id

### DIFF
--- a/src/graphql/studies/queries.ts
+++ b/src/graphql/studies/queries.ts
@@ -33,6 +33,7 @@ export const SEARCH_STUDIES_BY_ID_AND_NAME_QUERY = gql`
         edges {
           node {
             study_id
+            study_code
             study_name
             external_id
           }

--- a/src/views/Studies/components/StudySearch/index.tsx
+++ b/src/views/Studies/components/StudySearch/index.tsx
@@ -16,8 +16,8 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
   return (
     <GlobalSearch<IStudiesEntity>
       queryBuilderId={queryBuilderId}
-      field="study_id"
-      searchFields={['study_id', 'study_name', 'external_id']}
+      field="study_code"
+      searchFields={['study_code', 'study_name', 'study_id', 'external_id']}
       tooltipText={intl.getHTML('global.search.study.tooltip')}
       index={INDEXES.STUDIES}
       placeholder={intl.get(`global.search.study.placeholder`)}
@@ -29,7 +29,7 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
           label: (
             <SelectItem
               icon={<ReadOutlined />}
-              title={highlightSearchMatch(option.study_id, matchRegex, search)}
+              title={highlightSearchMatch(option.study_code, matchRegex, search)}
               caption={highlightSearchMatch(option.study_name, matchRegex, search)}
             />
           ),

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -42,10 +42,10 @@ const filterInfo: FilterInfo = {
 
 const columns: ProColumnType<any>[] = [
   {
-    key: 'study_id',
+    key: 'study_code',
     title: 'Code',
     render: (record: IStudiesEntity) => (
-      <ExternalLink href={record.website}>{record.study_id}</ExternalLink>
+      <ExternalLink href={record.website}>{record.study_code}</ExternalLink>
     ),
   },
   {


### PR DESCRIPTION
# FEAT

- closes #[586](https://d3b.atlassian.net/browse/SKFP-586)

## Description

Change the Study codes seen in the studies page (SD_XXXXXXXX) for the short KF Study codes. The ones currently displayed are the operational Study codes that the CHOP team uses, whereas the short  KF study codes are the user friendly ones that we display on the portal (KF-XXX). The short KF study codes are used in the Data Exploration page under the Study category. 


## Screenshot (Before and After)
![image](https://user-images.githubusercontent.com/65532894/210394314-439c059c-9746-4bcc-8487-e07f20832d5d.png)

After
![Screenshot_20230103_105903](https://user-images.githubusercontent.com/65532894/210394389-6d7ab995-04d9-4c69-a959-14170ff317c7.png)


