### PR TITLE
🐛fix(facets): SKFP-584 Number input always red

### DIFF
--- a/src/style/themes/kids-first/antd/input.less
+++ b/src/style/themes/kids-first/antd/input.less
@@ -91,7 +91,7 @@
       rgba(red(@input-color-default), green(@input-color-default), blue(@input-color-default), 50%);
   }
 
-  &-number,
+  &-number-status-error:not(&-disabled):not(&-borderless).@{input-prefix-cls}-number,
   &-status-error:not(&-disabled):not(&-borderless)& {
     .input-status-mixins(@red-1, @red-8);
   }


### PR DESCRIPTION
# BUG

- closes [SKFP-584](https://d3b.atlassian.net/browse/SKFP-584)

## Description

Fix the InputNumber that was displaying in red even when not in error

## Screenshot
Before:
![1EE10E86-CC48-462A-9FAA-16930ADA729C_4_5005_c](https://user-images.githubusercontent.com/116835792/210609365-b2254450-b9f4-4e92-83f5-8774512d978f.jpeg)

After:
![968AF351-7EE4-4A7E-B168-C9A02383260A_4_5005_c](https://user-images.githubusercontent.com/116835792/210609381-1c13dd73-f67a-4793-b961-14aed6901c87.jpeg)

[SKFP-584]: https://d3b.atlassian.net/browse/SKFP-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKFP-584]: https://d3b.atlassian.net/browse/SKFP-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ