### PR TITLE
✨feat(savedset): SKFP-494 SKFP-493 add variants saved set

### DIFF
--- a/src/components/Icons/index.tsx
+++ b/src/components/Icons/index.tsx
@@ -1,8 +1,8 @@
 export type IconProps = {
   alt?: string;
-  height?: number;
+  height?: number | string;
   style?: object;
-  width?: number;
+  width?: number | string;
   className?: string;
   svgClass?: string;
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -497,6 +497,7 @@ const en = {
             biospecimens: 'Biospecimens',
             files: 'Files',
             participants: 'Participants',
+            variants: 'Variants',
           },
           title: 'Saved Sets',
           noSavedFilters: 'You have no saved sets',

--- a/src/services/api/savedSet/models.ts
+++ b/src/services/api/savedSet/models.ts
@@ -30,4 +30,5 @@ export enum SetType {
   PARTICIPANT = 'participant',
   FILES = 'files',
   BIOSPECIMEN = 'biospecimen',
+  VARIANT = 'variants',
 }

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
@@ -84,7 +84,7 @@ const CreateEditModal = ({
       } else {
         dispatch(
           createSavedSet({
-            idField: 'fhir_id',
+            idField: setType !== SetType.VARIANT ? 'fhir_id' : 'locus',
             projectId: PROJECT_ID,
             sort: [],
             sqon: sqon!,

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -19,6 +19,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import ListItem from './ListItem';
 
 import styles from './index.module.scss';
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;
@@ -137,6 +138,18 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             key="files"
           >
             {getItemList(SetType.FILES, savedSets, fetchingError, isLoading, <FileTextOutlined />)}
+          </TabPane>
+          <TabPane
+            tab={
+              <div>
+                <LineStyleIcon />
+                {intl.get('screen.dashboard.cards.savedSets.tabs.variants')} (
+                {savedSets.filter((s) => s.setType === SetType.VARIANT).length})
+              </div>
+            }
+            key="variants"
+          >
+            {getItemList(SetType.VARIANT, savedSets, fetchingError, isLoading, <LineStyleIcon />)}
           </TabPane>
         </Tabs>
       }

--- a/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
@@ -67,7 +67,7 @@ const AddRemoveSaveSetModal = ({ hideModalCb, userSets, setActionType, sqon, typ
           updateSavedSet({
             id: setId,
             subAction: setActionType,
-            idField: 'fhir_id',
+            idField: type !== SetType.VARIANT ? 'fhir_id' : 'locus',
             projectId: PROJECT_ID,
             sqon: sqon!,
             onCompleteCb: onSuccessCreateCb,

--- a/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
@@ -27,9 +27,13 @@ import { numberWithCommas } from 'utils/string';
 import AddRemoveSaveSetModal from './AddRemoveSaveSetModal';
 
 import styles from './index.module.scss';
+import { IVariantEntity } from 'graphql/variants/models';
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 
 type Props = {
-  results: IQueryResults<IParticipantEntity[] | IFileEntity[] | IBiospecimenEntity[]>;
+  results: IQueryResults<
+    IParticipantEntity[] | IFileEntity[] | IBiospecimenEntity[] | IVariantEntity[]
+  >;
   sqon?: ISqonGroupFilter;
   selectedAllResults: boolean;
   selectedKeys?: string[];
@@ -83,6 +87,8 @@ const itemIcon = (type: string) => {
       return <ExperimentOutlined width="14px" height="14px" />;
     case INDEXES.FILES:
       return <FileTextOutlined width="14px" height="14px" />;
+    case SetType.VARIANT:
+      return <LineStyleIcon width="14px" height="14px" />;
     default:
       return <UserOutlined width="14px" height="14px" />;
   }

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -204,6 +204,7 @@ const PageContent = ({ variantMapping }: OwnProps) => {
       />
       <VariantsTable
         pageIndex={pageIndex}
+        sqon={variantResolvedSqon}
         setPageIndex={setPageIndex}
         results={variantResults}
         setQueryConfig={setVariantQueryConfig}


### PR DESCRIPTION
# FEAT

- closes #[493](https://d3b.atlassian.net/browse/SKFP-493)
- closes #[494](https://d3b.atlassian.net/browse/SKFP-494)

## Description

Add “Variants” as an additional tab to the Saved Sets Widget. This will behave in the same way as it has for the other tabs. A user will open the Saved Set dropdown within the Variant Search page (see image below), and will add variants to a set. 

Add the “Saved variant set” above the table of results in the Variants Exploration.

## Screenshot
Before
![image](https://user-images.githubusercontent.com/65532894/210646651-8aa382c5-5d31-4331-b2d3-4d3a96797c40.png)
![image](https://user-images.githubusercontent.com/65532894/210646707-a57afd96-85c0-49a8-a2fb-774e2f1c924a.png)

After
![Screenshot_20230104_154152](https://user-images.githubusercontent.com/65532894/210646774-05ea2fe8-0d70-4fc1-bd0d-8afbd3127c14.png)
![Screenshot_20230104_154208](https://user-images.githubusercontent.com/65532894/210646776-77a6201c-6a49-48cc-a0d0-f7a0046a6823.png)
![Screenshot_20230104_154223](https://user-images.githubusercontent.com/65532894/210646777-6705ed0a-75c0-4d43-9cd3-49f357f60bf5.png)
![Screenshot_20230104_154234](https://user-images.githubusercontent.com/65532894/210646778-e7d4f7df-dbce-4d81-8adc-99e47dde7805.png)




[SKFP-493]: https://d3b.atlassian.net/browse/SKFP-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKFP-494]: https://d3b.atlassian.net/browse/SKFP-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ