### PR TITLE
🐛fix(dashboard): SKFP-591 No results for participant saved sets

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -582,7 +582,7 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
         total: results.total,
         onChange: () => scrollToTop(SCROLL_WRAPPER_ID),
       }}
-      dataSource={results.data.map((i, index) => ({ ...i, key: `${i.participant_id}:${index}` }))}
+      dataSource={results.data.map((i) => ({ ...i, key: i.participant_id }))}
       dictionary={getProTableDictionary()}
     />
   );


### PR DESCRIPTION
# BUG
- closes [SKFP-591](https://d3b.atlassian.net/browse/SKFP-591)

## Description

Fix for the participant saved sets that are displaying no results. I am reverting the fix done in [SKFP-559](https://d3b.atlassian.net/browse/SKFP-559) so the multi-sorting will be broken again, but it should be working again once [SKFP-590](https://d3b.atlassian.net/browse/SKFP-590) is addressed. 

## Screenshot 
Before:
![591_before](https://user-images.githubusercontent.com/116835792/210815297-e54052e7-a993-4c58-839e-232e2199b037.gif)

After:
![591_after](https://user-images.githubusercontent.com/116835792/210815307-c4de29dc-e1fc-4f88-927b-11ca9f9e7687.gif)


[SKFP-591]: https://d3b.atlassian.net/browse/SKFP-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKFP-559]: https://d3b.atlassian.net/browse/SKFP-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKFP-590]: https://d3b.atlassian.net/browse/SKFP-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ