### PR TITLE
✨feat(search): SKFP-598 implement new case sensitive api

### DIFF
--- a/src/components/uiKit/search/GlobalSearch/Search/index.tsx
+++ b/src/components/uiKit/search/GlobalSearch/Search/index.tsx
@@ -9,7 +9,6 @@ import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ArrangerApi } from 'services/api/arranger';
 import { DocumentNode } from 'graphql';
 import { ISuggestionPayload } from 'services/api/arranger/models';
-import { toPascalCase } from 'utils/helper';
 
 interface IGlobalSearch<T> {
   query: DocumentNode;
@@ -48,12 +47,7 @@ const Search = <T,>({
         newFilters: searchKey.map((key) =>
           generateValueFilter({
             field: key,
-            value: [
-              `${search}*`,
-              `${search.toUpperCase()}*`,
-              `${search.toLowerCase()}*`,
-              `${toPascalCase(search)}*`,
-            ],
+            value: [`${search}*`],
             index,
           }),
         ),

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -35,8 +35,3 @@ export const toKebabCase = (str: string) => {
   const match: string[] = (str && str.match(KEBAB_REGEX)) || [];
   return match.map((x: string) => x.toLowerCase()).join('-');
 };
-
-export const toPascalCase = (str: string) =>
-  str.replace(/(\w)(\w*)/g, function (g0, g1, g2) {
-    return g1.toUpperCase() + g2.toLowerCase();
-  });

--- a/src/views/DataExploration/components/BiospecimenSearch.tsx
+++ b/src/views/DataExploration/components/BiospecimenSearch.tsx
@@ -16,7 +16,7 @@ const BiospecimenSearch = ({ queryBuilderId }: ICustomSearchProps) => {
   return (
     <GlobalSearch<IBiospecimenEntity>
       queryBuilderId={queryBuilderId}
-      field="sample_id"
+      field="sample_id" // @todo: search_text, see when implemented
       index={INDEXES.BIOSPECIMENS}
       placeholder="e.g. BS_011DYZ2J, HTP0001B2_Plasma"
       emptyDescription="No samples found"
@@ -44,7 +44,7 @@ const BiospecimenCollectionSearch = ({ queryBuilderId }: ICustomSearchProps) => 
   return (
     <GlobalSearch<IBiospecimenEntity>
       queryBuilderId={queryBuilderId}
-      field="collection_sample_id"
+      field="collection_sample_id" // @todo: search_text, see when implemented
       index={INDEXES.BIOSPECIMENS}
       placeholder="e.g. HTP0001B2_Whole blood, BS_1YEZ2XR4_Saliva"
       emptyDescription="No collection ID found"

--- a/src/views/DataExploration/components/FileSearch.tsx
+++ b/src/views/DataExploration/components/FileSearch.tsx
@@ -14,7 +14,7 @@ const FileSearch = ({ queryBuilderId }: ICustomSearchProps) => {
   return (
     <GlobalSearch<IFileEntity>
       queryBuilderId={queryBuilderId}
-      field="file_id"
+      field="search_text"
       index={INDEXES.FILES}
       placeholder="e.g. GF_001CSF26"
       emptyDescription="No files found"

--- a/src/views/Studies/components/StudySearch/index.tsx
+++ b/src/views/Studies/components/StudySearch/index.tsx
@@ -16,8 +16,7 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
   return (
     <GlobalSearch<IStudiesEntity>
       queryBuilderId={queryBuilderId}
-      field="study_code"
-      searchFields={['study_code', 'study_name', 'study_id', 'external_id']}
+      field="search_text"
       tooltipText={intl.getHTML('global.search.study.tooltip')}
       index={INDEXES.STUDIES}
       placeholder={intl.get(`global.search.study.placeholder`)}


### PR DESCRIPTION
# FEAT

- closes #[598](https://d3b.atlassian.net/browse/SKFP-598)

## Description

Backend should work at this point (arranger-project=next_qa). Frontend must be updated:
In src/components/uiKit/search/GlobalSearch/Search/index.tsx remove
value: [ `${search}*`, `${search.toUpperCase()}*`, `${search.toLowerCase()}*`, `${toPascalCase(search)}*`,]
only `${search}*` should suffice.
For participants use
participant_id
field as-is.
For other searches use the field
search_text
For example:
query searchBiospecimenById($sqon: JSON) {    biospecimens {      hits(filters: $sqon) {       edges {          node {            study {search_text}         }        }      }    }  }
{
    "sqon":{
        "op":"or",
        "content":[
            {"content":{"field":"study.search_text","index":"participant","value":["opendipg*"]},"op":"in"}]
            }
}


## Screenshot (Before and After)
![Screenshot_20230109_154531](https://user-images.githubusercontent.com/65532894/211405533-4d518cb9-fa6f-4d61-8963-d8a4585dabd9.png)
![Screenshot_20230109_154640](https://user-images.githubusercontent.com/65532894/211405536-44efe89d-8383-46ff-85cd-7cbf7a6eeba2.png)
![Screenshot_20230109_154655](https://user-images.githubusercontent.com/65532894/211405543-16539676-a22a-4052-bfac-583d7f89b644.png)
![Screenshot_20230109_154739](https://user-images.githubusercontent.com/65532894/211405547-ffc52e55-e3bb-4d1e-9ce2-a1bb8df7356a.png)
![Screenshot_20230109_154816](https://user-images.githubusercontent.com/65532894/211405553-9f645189-77f4-40b4-bb39-f709e2b95c67.png)
![Screenshot_20230109_154829](https://user-images.githubusercontent.com/65532894/211405556-aa3ae847-d291-4d28-9dc0-4cedce6d1d42.png)

