### PR TITLE
🐛fix(files): SKFP-404 Save table config in FileEntity page

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1159,7 +1159,7 @@ const en = {
       },
       participant_sample: {
         collection_id: 'Collection ID',
-        collection_type: 'Collection Type',
+        collection_sample_type: 'Collection Sample Type',
         external_collection_id: 'External Collection ID',
         external_participant_id: 'External Participant ID',
         external_sample_id: 'External Sample ID',

--- a/src/services/api/user/models.ts
+++ b/src/services/api/user/models.ts
@@ -55,6 +55,11 @@ export type TUserConfig = {
       variants?: TUserTableConfig;
     };
   };
+  files?: {
+    tables?: {
+      biospecimens?: TUserTableConfig;
+    };
+  };
   dashboard?: {
     cards?: {
       order?: string[];

--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -1,0 +1,46 @@
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { IBiospecimenEntity } from 'graphql/biospecimens/models';
+import { IFileEntity } from 'graphql/files/models';
+
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+
+import getBiospecimensColumns from '../utils/getBiospecimensColumns';
+import { SectionId } from '..';
+
+interface OwnProps {
+  data?: IFileEntity;
+  loading: boolean;
+}
+
+const BiospecimenTable = ({ data, loading }: OwnProps) => {
+  const { userInfo } = useUser();
+  const dispatch = useDispatch();
+
+  const biospecimens: IBiospecimenEntity[] =
+    data?.biospecimens?.hits?.edges?.map((e) => ({ key: e.node.sample_id, ...e.node })) || [];
+
+  return (
+    <EntityTable
+      id={SectionId.PARTICIPANT_SAMPLE}
+      loading={loading}
+      data={biospecimens}
+      title={intl.get('entities.file.participant_sample.title')}
+      header={intl.get('entities.file.participant_sample.title')}
+      columns={getBiospecimensColumns()}
+      initialColumnState={userInfo?.config.files?.tables?.biospecimens?.columns}
+      headerConfig={{
+        enableTableExport: true,
+        enableColumnSort: true,
+        onColumnSortChange: (newState) =>
+          dispatch(
+            updateUserConfig({ files: { tables: { biospecimens: { columns: newState } } } }),
+          ),
+      }}
+    />
+  );
+};
+
+export default BiospecimenTable;

--- a/src/views/FileEntity/index.tsx
+++ b/src/views/FileEntity/index.tsx
@@ -1,19 +1,18 @@
 import intl from 'react-intl-universal';
 import { useParams } from 'react-router-dom';
-import { IAnchorLink } from '@ferlab/ui/core/components/AnchorMenu';
-import EntityPage, { EntityDescriptions, EntityTable } from '@ferlab/ui/core/pages/EntityPage';
-import { IBiospecimenEntity } from 'graphql/biospecimens/models';
+import EntityPage, { EntityDescriptions } from '@ferlab/ui/core/pages/EntityPage';
 import { useFileEntity } from 'graphql/files/actions';
 
-import getBiospecimensColumns from './utils/getBiospecimensColumns';
 import getDataAccessItems from './utils/getDataAccessItems';
 import getDataTypeItems from './utils/getDataTypeItems';
 import getExperimentalProcedureItems from './utils/getExperimentalProcedureItems';
+import getLinks from './utils/getLinks';
 import getSummaryItems from './utils/getSummaryItems';
+import BiospecimenTable from './BiospecimenTable';
 import SummaryHeader from './SummaryHeader';
 import FileEntityTitle from './Title';
 
-enum SectionId {
+export enum SectionId {
   SUMMARY = 'summary',
   DATA_ACCESS = 'data-access',
   DATA_TYPE = 'data-type',
@@ -22,20 +21,6 @@ enum SectionId {
 }
 
 export default function FileEntity() {
-  const links: IAnchorLink[] = [
-    { href: `#${SectionId.SUMMARY}`, title: intl.get('entities.file.summary.title') },
-    { href: `#${SectionId.DATA_ACCESS}`, title: intl.get('entities.file.data_access.title') },
-    { href: `#${SectionId.DATA_TYPE}`, title: intl.get('entities.file.data_type.title') },
-    {
-      href: `#${SectionId.PARTICIPANT_SAMPLE}`,
-      title: intl.get('entities.file.participant_sample.title'),
-    },
-    {
-      href: `#${SectionId.EXPERIMENTAL_PROCEDURE}`,
-      title: intl.get('entities.file.experimental_procedure.title'),
-    },
-  ];
-
   const { file_id } = useParams<{ file_id: string }>();
 
   const { data, loading } = useFileEntity({
@@ -43,12 +28,9 @@ export default function FileEntity() {
     value: file_id,
   });
 
-  const biospecimens: IBiospecimenEntity[] =
-    data?.biospecimens?.hits?.edges?.map((e) => ({ key: e.node.sample_id, ...e.node })) || [];
-
   return (
     <EntityPage
-      links={links}
+      links={getLinks()}
       pageId={'file-entity-page'}
       data={data}
       loading={loading}
@@ -77,18 +59,9 @@ export default function FileEntity() {
         title={intl.get('entities.file.data_type.title')}
         header={intl.get('entities.file.data_type.title')}
       />
-      <EntityTable
-        id={SectionId.PARTICIPANT_SAMPLE}
-        loading={loading}
-        data={biospecimens}
-        title={intl.get('entities.file.participant_sample.title')}
-        header={intl.get('entities.file.participant_sample.title')}
-        columns={getBiospecimensColumns()}
-        headerConfig={{
-          enableTableExport: true,
-          enableColumnSort: true,
-        }}
-      />
+
+      <BiospecimenTable data={data} loading={loading} />
+
       <EntityDescriptions
         id={SectionId.EXPERIMENTAL_PROCEDURE}
         loading={loading}

--- a/src/views/FileEntity/utils/getBiospecimensColumns.tsx
+++ b/src/views/FileEntity/utils/getBiospecimensColumns.tsx
@@ -37,7 +37,7 @@ const getBiospecimensColumns = (): ProColumnType[] => [
   },
   {
     key: 'composition',
-    title: intl.get('entities.file.participant_sample.collection_type'),
+    title: intl.get('entities.file.participant_sample.collection_sample_type'),
     render: (composition: string) => TABLE_EMPTY_PLACE_HOLDER, // TODO
   },
   {

--- a/src/views/FileEntity/utils/getLinks.tsx
+++ b/src/views/FileEntity/utils/getLinks.tsx
@@ -1,0 +1,20 @@
+import intl from 'react-intl-universal';
+import { IAnchorLink } from '@ferlab/ui/core/components/AnchorMenu';
+
+import { SectionId } from '..';
+
+const getLinks = (): IAnchorLink[] => [
+  { href: `#${SectionId.SUMMARY}`, title: intl.get('entities.file.summary.title') },
+  { href: `#${SectionId.DATA_ACCESS}`, title: intl.get('entities.file.data_access.title') },
+  { href: `#${SectionId.DATA_TYPE}`, title: intl.get('entities.file.data_type.title') },
+  {
+    href: `#${SectionId.PARTICIPANT_SAMPLE}`,
+    title: intl.get('entities.file.participant_sample.title'),
+  },
+  {
+    href: `#${SectionId.EXPERIMENTAL_PROCEDURE}`,
+    title: intl.get('entities.file.experimental_procedure.title'),
+  },
+];
+
+export default getLinks;


### PR DESCRIPTION
# BUG

- closes [SKFP-404](https://d3b.atlassian.net/browse/SKFP-404)

## Description

-Changed "Collection Type" column title to "Collection Sample Type" 
-Added functionality to save user config for Biospecimen table columns
-Extracted some logic in their own file to clean up a bit

## Screenshot
Before:
![404_before](https://user-images.githubusercontent.com/116835792/213016257-de397d24-100d-4ecc-ab37-e835d12f93eb.gif)

After:
![404_after](https://user-images.githubusercontent.com/116835792/213016240-655a07bc-2cd3-4021-a824-f01ca6bb64fc.gif)


[SKFP-404]: https://d3b.atlassian.net/browse/SKFP-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ