### PR TITLE
✨feat(particpant): SKFP-403 add partipant entity page and readable date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
         "@ferlab/style": "^1.27.1",
-        "@ferlab/ui": "^4.11.1",
+        "@ferlab/ui": "^4.11.2",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/core": "^0.80.0",
@@ -2715,9 +2715,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.11.1.tgz",
-      "integrity": "sha512-VtJEM20z6bde9IAXkvDskH699hZFx9QGKXWcizqlNyaoGoHihisZAmpl0FhmryzvZ1MVwtJMcjHApbqYfkkHVA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.11.2.tgz",
+      "integrity": "sha512-U3zNW+QXX5mqvQVX72Za1ZExyuPO8dMILVFwC0uAmPmhYRPazdlQTe3DIWE/Jtum2NQY0MJuzXYJTaTIQmViOA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -35363,9 +35363,9 @@
       }
     },
     "@ferlab/ui": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.11.1.tgz",
-      "integrity": "sha512-VtJEM20z6bde9IAXkvDskH699hZFx9QGKXWcizqlNyaoGoHihisZAmpl0FhmryzvZ1MVwtJMcjHApbqYfkkHVA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-4.11.2.tgz",
+      "integrity": "sha512-U3zNW+QXX5mqvQVX72Za1ZExyuPO8dMILVFwC0uAmPmhYRPazdlQTe3DIWE/Jtum2NQY0MJuzXYJTaTIQmViOA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@ferlab/style": "^1.27.1",
-    "@ferlab/ui": "^4.11.1",
+    "@ferlab/ui": "^4.11.2",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.80.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import Spinner from 'components/uiKit/Spinner';
 import NotificationContextHolder from 'components/utils/NotificationContextHolder';
 import { useLang } from 'store/global';
 import { DYNAMIC_ROUTES, STATIC_ROUTES } from 'utils/routes';
+import ParticipantEntity from 'views/ParticipantEntity';
 
 const loadableProps = { fallback: <Spinner size="large" /> };
 const Dashboard = loadable(() => import('views/Dashboard'), loadableProps);
@@ -123,6 +124,13 @@ const App = () => {
                   </ProtectedRoute>
                   <ProtectedRoute exact path={DYNAMIC_ROUTES.DATA_EXPLORATION} layout={PageLayout}>
                     <DataExploration />
+                  </ProtectedRoute>
+                  <ProtectedRoute
+                    exact
+                    path={DYNAMIC_ROUTES.PARTICIPANT_ENTITY}
+                    layout={PageLayout}
+                  >
+                    <ParticipantEntity />
                   </ProtectedRoute>
                   <ProtectedRoute exact path={STATIC_ROUTES.VARIANTS} layout={PageLayout}>
                     <Variants />

--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -6,13 +6,17 @@ export interface IParticipantResultTree {
   participant: IArrangerResultsTree<IParticipantEntity>;
 }
 
+export interface IParticipantFamilyMemberResultTree {
+  participant: IArrangerResultsTree<IParticipantEntityFamilyMember>;
+}
+
 export interface IParticipantDiagnosis {
   id: string;
   mondo_id_diagnosis: string;
   source_text: string;
   ncit_id_diagnosis: string;
   affected_status: boolean;
-  age_at_event_days?: string;
+  age_at_event_days: number;
 }
 
 export interface IParticipantPhenotype {
@@ -74,6 +78,7 @@ export interface IParticipantEntity {
   participant_id: string;
   study: IParticipantStudy;
   down_syndrome_status: string;
+  families_id: string;
   family_type: string;
   is_proband: boolean;
   age_at_data_collection: number;
@@ -94,7 +99,32 @@ export interface IParticipantEntity {
   race: string;
   outcomes: IArrangerResultsTree<IParticipantOutcomes>;
 }
+export interface IParticipantEntityFamilyMember {
+  id: string; //weird constraint imposed.
+  participant_id: string;
+  family_type: string;
+}
+
+export interface IParticipantEntityFamilyMemberReturn {
+  loading: boolean;
+  members: IParticipantEntityFamilyMember[];
+}
 
 export type ITableParticipantEntity = IParticipantEntity & {
   key: string;
 };
+
+export interface IUseParticipantEntityProps {
+  field: string;
+  values: string[];
+}
+
+export interface IUseParticipantEntityReturn {
+  loading: boolean;
+  data?: IParticipantEntity;
+}
+
+export interface IUseParticipantEntityFamilyReturn {
+  loading: boolean;
+  data?: IParticipantEntity[];
+}

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -92,6 +92,143 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
   }
 `;
 
+export const GET_PARTICIPANT_ENTITY = gql`
+  query getParticpantEntity($sqon: JSON) {
+    participant {
+      hits(filters: $sqon) {
+        edges {
+          node {
+            participant_id
+            sex
+            is_proband
+            families_id
+            ethnicity
+            external_id
+            study_external_id
+            family_type
+            race
+            study {
+              study_code
+              study_id
+              study_name
+            }
+            diagnosis {
+              hits {
+                total
+                edges {
+                  node {
+                    mondo_id_diagnosis
+                    source_text
+                    ncit_id_diagnosis
+                    age_at_event_days
+                  }
+                }
+              }
+            }
+            outcomes {
+              hits {
+                total
+                edges {
+                  node {
+                    fhir_id
+                    release_id
+                    study_id
+                    participant_fhir_id
+                    vital_status
+                    observation_id
+                    age_at_event_days {
+                      value
+                      units
+                    }
+                  }
+                }
+              }
+            }
+            phenotype {
+              hits {
+                total
+                edges {
+                  node {
+                    fhir_id
+                    hpo_phenotype_observed
+                    #                    is_observed
+                    age_at_event_days
+                  }
+                }
+              }
+            }
+            observed_phenotype {
+              hits {
+                total
+                edges {
+                  node {
+                    is_leaf
+                    is_tagged
+                    name
+                    parents
+                    age_at_event_days
+                  }
+                }
+              }
+            }
+            # files {
+            # hits {
+            # total
+            # edges {
+            # fhir_id
+            # biospecimens
+            # study_id
+            # release_id
+            # category
+            # status
+            # relatesTo
+            # access_urls
+            # acl
+            # external_id
+            # file_format
+            # file_name
+            # file_id
+            # is_harmonized
+            # repository
+            # urls
+            # sequencing_experiment
+            # file_facet_ids
+            # }
+            # }
+            # }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const SEARCH_PARTICIPANT_FAMILY_MEMBER_QUERY = gql`
+  query searchParticipantFamilyMember($sqon: JSON) {
+    participant {
+      hits(filters: $sqon) {
+        total
+        edges {
+          node {
+            participant_id
+            family_type
+            diagnosis {
+              hits {
+                total
+                edges {
+                  node {
+                    affected_status
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const MATCH_PARTICIPANT_QUERY = gql`
   query fetchMatchParticipant($sqon: JSON) {
     participant {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -18,6 +18,10 @@ const filesFacets = {
 
 const en = {
   ...translations,
+  date: {
+    yearsDaysFormat:
+      '{years, plural, =0 {} =1 {# year} other {# years}} {days, plural, =0 {} =1 {# day} other {# days}}',
+  },
   global: {
     yes: 'Yes',
     no: 'No',
@@ -390,6 +394,66 @@ const en = {
     },
   },
   screen: {
+    participantEntity: {
+      proband: 'Proband',
+      familyMember: 'Family Member',
+      downloadData: 'Download clinical data',
+      summary: {
+        title: 'Summary',
+        id: 'ID',
+        externalId: 'Ext. Participant ID',
+        study: 'Study',
+        dbGaP: 'dbGaP',
+        pedcBioPortal: 'PedcBioPortal',
+        diagnosisCategory: 'Diagnosis Category',
+        familyComposition: 'Family Composition',
+        proband: 'Proband',
+        vitalStatus: 'Vital Status',
+      },
+      profil: {
+        title: 'Profil',
+        race: 'Race',
+        ethnicity: 'Ethnicity',
+        sex: 'Sex',
+        vitalStatus: 'Viral Status',
+        deceased_date: 'Age at death',
+      },
+      family: {
+        title: 'Family',
+        id: 'Participant ID',
+        affectedStatus: 'Affected Status',
+        relationship: 'Family Relationship',
+      },
+      diagnosis: {
+        title: 'Diagnosis',
+        age: {
+          title: 'Age',
+          tooltip: 'Age at Diagnosis in days',
+        },
+        category: 'Diagnosis Category',
+        sourceText: 'Diagnosis (Source Text)',
+        sharedTerm: 'MONDO Shared Term',
+        ncit: 'Diagnosis (NCIT)',
+        mondo: 'Diagnosis (MONDO)',
+      },
+      phenotype: {
+        title: 'Phenotype',
+        hpoPhenotypeObserved: 'Phenotype (HPO)',
+        sourceText: 'Phenotype (Source Text)',
+        age: {
+          title: 'Age',
+          tooltip: 'Age at Phenotype in days',
+        },
+        interpretation: 'Interpretation',
+        sharedTerm: 'HPO Term',
+      },
+      biospecimen: {
+        title: 'Biospecimen',
+      },
+      dataFile: {
+        title: 'Data File',
+      },
+    },
     memberProfile: {
       notFound: 'User not found',
       rolesTitle: 'Role',

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,3 +1,8 @@
+import intl from 'react-intl-universal';
+
+// @see https://sciencenotes.org/how-to-convert-days-to-years/
+const LEAP_YEARS = 365.2425;
+
 export const datesAreOnSameDay = (first: Date, second: Date) =>
   first.getFullYear() === second.getFullYear() &&
   first.getMonth() === second.getMonth() &&
@@ -15,4 +20,10 @@ export const sortByUpdateDate = <
       return new Date(a.updated_date) < new Date(b.updated_date) ? 0 : -1;
     }
     return a.updated_date ? 0 : -1;
+  });
+
+export const readableDistanceByDays = (distanceInDays: number | string) =>
+  intl.get('date.yearsDaysFormat', {
+    years: Math.floor(Number(distanceInDays) / LEAP_YEARS),
+    days: Math.floor(Number(distanceInDays) % LEAP_YEARS),
   });

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -31,6 +31,7 @@ export enum DYNAMIC_ROUTES {
   DATA_EXPLORATION = '/data-exploration/:tab?',
   VARIANT_ENTITY = '/variants/:locus?',
   FILE_ENTITY = '/files/:file_id?',
+  PARTICIPANT_ENTITY = '/data-exploration/participants/:id',
   ERROR = '/error/:status?',
   COMMUNITY_MEMBER = '/member/:id',
 }

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -17,12 +17,11 @@ import {
   IQueryResults,
   TQueryConfigCb,
 } from '@ferlab/ui/core/graphql/types';
-import { Button, Dropdown, Menu, Tag } from 'antd';
+import { Button, Dropdown, Menu, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import {
   IParticipantDiagnosis,
   IParticipantEntity,
-  IParticipantObservedPhenotype,
   IParticipantOutcomes,
   IParticipantPhenotype,
   IParticipantStudy,
@@ -52,6 +51,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
+import { readableDistanceByDays } from 'utils/dates';
 
 interface OwnProps {
   results: IQueryResults<IParticipantEntity[]>;
@@ -68,6 +68,11 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
+    render: (id: string) => (
+      <Tooltip placement="topLeft" title={id}>
+        <Link to={`${STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}/${id}`}>{id}</Link>
+      </Tooltip>
+    ),
   },
   {
     key: 'study.study_code',
@@ -415,20 +420,6 @@ const defaultColumns: ProColumnType[] = [
     render: (_) => TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'diagnosis.age_at_event_days',
-    title: 'Age at Diagnosis',
-    dataIndex: 'diagnosis',
-    defaultHidden: true,
-    sorter: {
-      multiple: 1,
-    },
-    render: (diagnosis: IArrangerResultsTree<IParticipantDiagnosis>) =>
-      diagnosis?.hits?.edges
-        ?.filter((e) => e.node?.age_at_event_days !== null)
-        .map((e) => e.node?.age_at_event_days)
-        ?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
     key: 'outcomes.age_at_event_days.value',
     title: 'Age at Outcome',
     dataIndex: 'outcomes',
@@ -439,25 +430,8 @@ const defaultColumns: ProColumnType[] = [
     render: (outcomes: IArrangerResultsTree<IParticipantOutcomes>) =>
       outcomes?.hits?.edges
         ?.filter((e) => e.node.age_at_event_days?.value)
-        ?.map((e) => e.node.age_at_event_days.value)
-        ?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
-  },
-
-  {
-    key: 'observed_phenotype.age_at_event_days',
-    title: 'Age at Observed Phenotype',
-    dataIndex: 'observed_phenotype',
-    defaultHidden: true,
-    sorter: {
-      multiple: 1,
-    },
-    render: (observed_phenotype: IArrangerResultsTree<IParticipantObservedPhenotype>) =>
-      observed_phenotype?.hits?.edges
-        ?.reduce<number[][]>((ages, phenotype) => {
-          phenotype.node.age_at_event_days.length && ages.push(phenotype.node.age_at_event_days);
-          return ages;
-        }, [])
-        ?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+        ?.map((e) => readableDistanceByDays(e.node.age_at_event_days.value))
+        ?.join(',\n') || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
@@ -2,7 +2,6 @@ import { Col, Form, Row, Select } from 'antd';
 import { Store } from 'antd/lib/form/interface';
 import { FormInstance } from 'antd/lib/form';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
-import { UserOutlined } from '@ant-design/icons';
 
 import styles from './index.module.scss';
 import { singularizeSetTypeIfNeeded, itemIcon } from '..';

--- a/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
@@ -12,7 +12,6 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { IQueryResults } from '@ferlab/ui/core/graphql/types';
 import { Button, Dropdown, Menu, Tooltip } from 'antd';
 import { IBiospecimenEntity } from 'graphql/biospecimens/models';
-import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { MenuClickEventHandler } from 'rc-menu/lib/interface';

--- a/src/views/ParticipantEntity/index.tsx
+++ b/src/views/ParticipantEntity/index.tsx
@@ -1,0 +1,175 @@
+import intl from 'react-intl-universal';
+import { DownloadOutlined, UserOutlined } from '@ant-design/icons';
+import { useParticipantEntity, useParticipantsFamily } from 'graphql/participants/actions';
+import { useHistory, useParams } from 'react-router-dom';
+import { IAnchorLink } from '@ferlab/ui/core/components/AnchorMenu';
+import EntityPageWrapper, {
+  EntityDescriptions,
+  EntityTitle,
+} from '@ferlab/ui/core/pages/EntityPage';
+import EntityTable from '@ferlab/ui/core/pages/EntityPage/EntityTable';
+import { Button, Tag } from 'antd';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { INDEXES } from 'graphql/constants';
+import { STATIC_ROUTES } from 'utils/routes';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { getDiagnosisDefaultColumns } from './utils/diagnosis';
+import { getFamilyDefaultColumns } from './utils/family';
+import { getPhenotypeDefaultColumns } from './utils/phenotype';
+import { getProfilItems } from './utils/profil';
+import { getSummaryItems } from './utils/summary';
+
+enum SectionId {
+  SUMMARY = 'summary',
+  PROFIL = 'profil',
+  FAMILY = 'family',
+  DIAGNOSIS = 'diagnosis',
+  PHENOTYPE = 'phenotype',
+  BIOSPECIMEN = 'biospecimen',
+  DATAFILE = 'datafile',
+}
+
+const ParticipantEntity = () => {
+  const history = useHistory();
+  const { id } = useParams<{ id: string }>();
+  const { data, loading } = useParticipantEntity({
+    field: 'participant_id',
+    values: [id],
+  });
+  const { members, loading: memberLoading } = useParticipantsFamily(data?.families_id || '');
+
+  const links: IAnchorLink[] = [
+    { href: `#${SectionId.SUMMARY}`, title: intl.get('screen.participantEntity.summary.title') },
+    { href: `#${SectionId.PROFIL}`, title: intl.get('screen.participantEntity.profil.title') },
+    { href: `#${SectionId.FAMILY}`, title: intl.get('screen.participantEntity.family.title') },
+    {
+      href: `#${SectionId.DIAGNOSIS}`,
+      title: intl.get('screen.participantEntity.diagnosis.title'),
+    },
+    {
+      href: `#${SectionId.PHENOTYPE}`,
+      title: intl.get('screen.participantEntity.phenotype.title'),
+    },
+    // { href: `#${SectionId.BIOSPECIMEN}`, title: intl.get('screen.participantEntity.biospecimen.title') },
+    { href: `#${SectionId.DATAFILE}`, title: intl.get('screen.participantEntity.dataFile.title') },
+  ];
+
+  return (
+    <EntityPageWrapper
+      pageId="particpant-entity-page"
+      links={links}
+      data={data}
+      loading={loading}
+      emptyText={intl.get('no.data.available')}
+    >
+      <>
+        <EntityTitle
+          text={id}
+          icon={<UserOutlined />}
+          loading={loading}
+          tag={
+            data?.is_proband ? (
+              <Tag>{intl.get('screen.participantEntity.proband')}</Tag>
+            ) : (
+              <Tag>{intl.get('screen.participantEntity.familyMember')}</Tag>
+            )
+          }
+          extra={
+            <Button type="primary" icon={<DownloadOutlined />}>
+              {intl.get('screen.participantEntity.downloadData')}
+            </Button>
+          }
+        />
+        <EntityDescriptions
+          id={SectionId.SUMMARY}
+          loading={loading}
+          title={intl.get('screen.participantEntity.summary.title')}
+          header={intl.get('screen.participantEntity.summary.title')}
+          descriptions={getSummaryItems(data)}
+        />
+
+        <EntityDescriptions
+          id={SectionId.PROFIL}
+          loading={loading}
+          title={intl.get('screen.participantEntity.profil.title')}
+          header={intl.get('screen.participantEntity.profil.title')}
+          descriptions={getProfilItems(data)}
+        />
+
+        {data?.families_id && (
+          <EntityTable
+            id={SectionId.SUMMARY}
+            loading={memberLoading}
+            data={members}
+            title={intl.get('screen.participantEntity.family.title')}
+            header={
+              <>
+                {intl.get('screen.participantEntity.family.title')}
+                <Button
+                  type="link"
+                  onClick={() => {
+                    history.push(STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS);
+                    addQuery({
+                      queryBuilderId: DATA_EXPLORATION_QB_ID,
+                      query: generateQuery({
+                        newFilters: [
+                          generateValueFilter({
+                            field: 'families_id',
+                            value: [data.families_id],
+                            index: INDEXES.PARTICIPANT,
+                          }),
+                        ],
+                      }),
+                    });
+                  }}
+                >
+                  ({data?.families_id})
+                </Button>
+              </>
+            }
+            columns={getFamilyDefaultColumns()}
+          />
+        )}
+
+        <EntityTable
+          id={SectionId.DIAGNOSIS}
+          loading={loading}
+          data={hydrateResults(data?.diagnosis?.hits?.edges || [])}
+          title={intl.get('screen.participantEntity.diagnosis.title')}
+          header={intl.get('screen.participantEntity.diagnosis.title')}
+          columns={getDiagnosisDefaultColumns()}
+        />
+
+        <EntityTable
+          id={SectionId.PHENOTYPE}
+          loading={loading}
+          data={hydrateResults(data?.phenotype?.hits?.edges || [])}
+          title={intl.get('screen.participantEntity.phenotype.title')}
+          header={intl.get('screen.participantEntity.phenotype.title')}
+          columns={getPhenotypeDefaultColumns()}
+        />
+
+        {/* <EntityTable
+          id={SectionId.BIOSPECIMEN}
+          loading={loading}
+          data={data}
+          title={intl.get('screen.participantEntity.biospecimen.title')}
+          defaultColumns={familyDefaultColumns}
+        /> */}
+        {/* 
+        <EntityTable
+          id={SectionId.DATAFILE}
+          loading={loading}
+          data={hydrateResults(data?.files.hits.edges || [])}
+          title={intl.get('screen.participantEntity.dataFile.title')}
+          header={intl.get('screen.participantEntity.dataFile.title')}
+          columns={dataFileDefaultColumns}
+        /> */}
+      </>
+    </EntityPageWrapper>
+  );
+};
+
+export default ParticipantEntity;

--- a/src/views/ParticipantEntity/utils/dataFile.tsx
+++ b/src/views/ParticipantEntity/utils/dataFile.tsx
@@ -1,0 +1,12 @@
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantPhenotype } from 'graphql/participants/models';
+
+export const dataFileDefaultColumns: ProColumnType[] = [
+  {
+    key: 'hpo_phenotype_observed',
+    title: 'Phenotype (HPO)',
+    render: (phenotype: IParticipantPhenotype) =>
+      phenotype?.hpo_phenotype_observed || TABLE_EMPTY_PLACE_HOLDER,
+  },
+];

--- a/src/views/ParticipantEntity/utils/diagnosis.tsx
+++ b/src/views/ParticipantEntity/utils/diagnosis.tsx
@@ -1,0 +1,112 @@
+import intl from 'react-intl-universal';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantDiagnosis } from 'graphql/participants/models';
+import { capitalize } from 'lodash';
+import {
+  extractMondoTitleAndCode,
+  extractNcitTissueTitleAndCode,
+} from 'views/DataExploration/utils/helper';
+import { readableDistanceByDays } from 'utils/dates';
+
+export const getDiagnosisDefaultColumns = (): ProColumnType[] => [
+  {
+    key: 'mondo_id_diagnosis',
+    title: intl.get('screen.participantEntity.diagnosis.mondo'),
+    render: (diagnosis: IParticipantDiagnosis) => {
+      const mondoNames = diagnosis.mondo_id_diagnosis;
+      return (
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[mondoNames]}
+          renderItem={(mondo_id, index): React.ReactNode => {
+            const mondoInfo = extractMondoTitleAndCode(mondo_id);
+            return mondoInfo ? (
+              <div key={index}>
+                {capitalize(mondoInfo.title)} (MONDO:
+                <ExternalLink href={`http://purl.obolibrary.org/obo/MONDO_${mondoInfo.code}`}>
+                  {mondoInfo.code}
+                </ExternalLink>
+                )
+              </div>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            );
+          }}
+        />
+      );
+    },
+  },
+  {
+    key: 'diagnosis_ncit',
+    title: intl.get('screen.participantEntity.diagnosis.ncit'),
+    render: (diagnosis: IParticipantDiagnosis) => {
+      const ncitId = diagnosis.ncit_id_diagnosis;
+      return (
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[ncitId]}
+          renderItem={(ncit_id_diagnosis, index): React.ReactNode => {
+            const ncitInfo = extractNcitTissueTitleAndCode(ncit_id_diagnosis);
+            return ncitInfo ? (
+              <div key={index}>
+                {capitalize(ncitInfo.title)} (NCIT:
+                <ExternalLink href={`http://purl.obolibrary.org/obo/NCIT_${ncitInfo.code}`}>
+                  {ncitInfo.code}
+                </ExternalLink>
+                )
+              </div>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            );
+          }}
+        />
+      );
+    },
+  },
+  {
+    key: 'diagnosis_source_text',
+    title: intl.get('screen.participantEntity.diagnosis.sourceText'),
+    render: (mondo: IParticipantDiagnosis) => {
+      const sourceTexts = mondo.source_text;
+
+      if (!sourceTexts || sourceTexts.length === 0) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+
+      return (
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[sourceTexts]}
+          renderItem={(sourceText, index): React.ReactNode => <div key={index}>{sourceText}</div>}
+        />
+      );
+    },
+  },
+  {
+    key: 'age_at_event_days',
+    title: intl.get('screen.participantEntity.diagnosis.age.title'),
+    tooltip: intl.get('screen.participantEntity.diagnosis.age.tooltip'),
+    render: (diagnosis: IParticipantDiagnosis) =>
+      diagnosis.age_at_event_days
+        ? readableDistanceByDays(diagnosis.age_at_event_days)
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  // TODO: Need to be added
+  {
+    key: 'diagnosis_category',
+    title: intl.get('screen.participantEntity.diagnosis.category'),
+    render: (_) => TABLE_EMPTY_PLACE_HOLDER,
+  },
+  // TODO: Need to be added
+  {
+    key: 'diagnosis_mondo_shared_term',
+    title: intl.get('screen.participantEntity.diagnosis.sharedTerm'),
+    sorter: {
+      multiple: 1,
+    },
+    render: (_) => TABLE_EMPTY_PLACE_HOLDER,
+  },
+];

--- a/src/views/ParticipantEntity/utils/family.tsx
+++ b/src/views/ParticipantEntity/utils/family.tsx
@@ -1,0 +1,27 @@
+import intl from 'react-intl-universal';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantDiagnosis } from 'graphql/participants/models';
+
+export const getFamilyDefaultColumns = (): ProColumnType[] => [
+  {
+    key: 'participant_id',
+    title: intl.get('screen.participantEntity.family.id'),
+    dataIndex: 'participant_id',
+  },
+  {
+    key: 'family_type',
+    title: intl.get('screen.participantEntity.family.relationship'),
+    dataIndex: 'family_type',
+  },
+  {
+    key: 'diagnosis',
+    title: intl.get('screen.participantEntity.family.affectedStatus'),
+    dataIndex: 'diagnosis',
+    render: (diagnosis: IArrangerResultsTree<IParticipantDiagnosis>) =>
+      diagnosis?.hits?.edges?.some((dn) => dn.node.affected_status)
+        ? 'Affected'
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+];

--- a/src/views/ParticipantEntity/utils/phenotype.tsx
+++ b/src/views/ParticipantEntity/utils/phenotype.tsx
@@ -1,0 +1,67 @@
+import intl from 'react-intl-universal';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantPhenotype } from 'graphql/participants/models';
+import { capitalize } from 'lodash';
+import { extractPhenotypeTitleAndCode } from 'views/DataExploration/utils/helper';
+import { readableDistanceByDays } from 'utils/dates';
+
+export const getPhenotypeDefaultColumns = (): ProColumnType[] => [
+  {
+    key: 'hpo_phenotype_observed',
+    title: intl.get('screen.participantEntity.phenotype.hpoPhenotypeObserved'),
+    render: (phenotype: IParticipantPhenotype) => {
+      const phenotypeNames = phenotype.hpo_phenotype_observed;
+      if (!phenotypeNames || phenotypeNames.length === 0) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return (
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[phenotypeNames]}
+          renderItem={(hpo_id_phenotype, index): React.ReactNode => {
+            const phenotypeInfo = extractPhenotypeTitleAndCode(hpo_id_phenotype);
+
+            return phenotypeInfo ? (
+              <div key={index}>
+                {capitalize(phenotypeInfo.title)} (HP:
+                <ExternalLink href={`http://purl.obolibrary.org/obo/HP_${phenotypeInfo.code}`}>
+                  {phenotypeInfo.code}
+                </ExternalLink>
+                )
+              </div>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            );
+          }}
+        />
+      );
+    },
+  },
+  {
+    key: 'hpo_phenotype_source_text',
+    title: intl.get('screen.participantEntity.phenotype.sourceText'),
+    render: (phenotype: IParticipantPhenotype) => TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'interpretation',
+    title: intl.get('screen.participantEntity.phenotype.interpretation'),
+    render: (phenotype: IParticipantPhenotype) => TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'age_at_event_days',
+    title: intl.get('screen.participantEntity.phenotype.age.title'),
+    tooltip: intl.get('screen.participantEntity.phenotype.age.tooltip'),
+    render: (phenotype: IParticipantPhenotype) =>
+      phenotype.age_at_event_days
+        ? readableDistanceByDays(phenotype.age_at_event_days)
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'shared_term',
+    title: intl.get('screen.participantEntity.phenotype.sharedTerm'),
+    render: (phenotype: IParticipantPhenotype) => TABLE_EMPTY_PLACE_HOLDER,
+  },
+];

--- a/src/views/ParticipantEntity/utils/profil.tsx
+++ b/src/views/ParticipantEntity/utils/profil.tsx
@@ -1,0 +1,31 @@
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { IEntityDescriptionsItem } from '@ferlab/ui/core/pages/EntityPage';
+import { Tag } from 'antd';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantEntity } from 'graphql/participants/models';
+import intl from 'react-intl-universal';
+
+export const getProfilItems = (participant?: IParticipantEntity): IEntityDescriptionsItem[] => {
+  const outcomes = hydrateResults(participant?.outcomes.hits.edges || []);
+
+  return [
+    {
+      label: intl.get('screen.participantEntity.profil.race'),
+      value: participant?.race || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.profil.ethnicity'),
+      value: participant?.ethnicity || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.profil.sex'),
+      value: participant?.sex || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.profil.vitalStatus'),
+      value: outcomes.length
+        ? outcomes.map(({ vital_status }) => <Tag key={vital_status}>{vital_status}</Tag>)
+        : TABLE_EMPTY_PLACE_HOLDER,
+    },
+  ];
+};

--- a/src/views/ParticipantEntity/utils/summary.tsx
+++ b/src/views/ParticipantEntity/utils/summary.tsx
@@ -1,0 +1,51 @@
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { IEntityDescriptionsItem } from '@ferlab/ui/core/pages/EntityPage';
+import { Tag } from 'antd';
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { IParticipantEntity } from 'graphql/participants/models';
+import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
+import { DYNAMIC_ROUTES } from 'utils/routes';
+
+export const getSummaryItems = (participant?: IParticipantEntity): IEntityDescriptionsItem[] => {
+  const diagnosis = hydrateResults(participant?.diagnosis?.hits?.edges || []);
+
+  return [
+    {
+      label: intl.get('screen.participantEntity.summary.id'),
+      value: participant?.participant_id || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.summary.externalId'),
+      value: participant?.external_id || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.summary.study'),
+      value: participant?.study.study_name ? (
+        <Link to={`${DYNAMIC_ROUTES.STUDY_ENTITY}/${participant?.study.study_code}`}>
+          {participant?.study.study_name} ({participant?.study.study_code})
+        </Link>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+    },
+    {
+      label: intl.get('screen.participantEntity.summary.diagnosisCategory'),
+      value: diagnosis.length
+        ? diagnosis.map(({ source_text }) => <Tag key={source_text}>{source_text}</Tag>)
+        : TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.summary.familyComposition'),
+      value: participant?.family_type || TABLE_EMPTY_PLACE_HOLDER,
+    },
+    {
+      label: intl.get('screen.participantEntity.summary.proband'),
+      value: participant?.is_proband ? (
+        <Tag>{intl.get('screen.participantEntity.summary.proband')}</Tag>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+    },
+  ];
+};


### PR DESCRIPTION
# FEAT

- closes #[601](https://d3b.atlassian.net/browse/SKFP-601)
- Create a basic template for https://d3b.atlassian.net/browse/SKFP-403

## Description

**For conversion**
Convert the Age fields that are all in days into Year + Days. Therefore the rule would be Age in days / 365.2425 to capture the years +leap year and we would round down to the nearest whole number without the decimals. The remainder of that value will represent the remaining days rounded down without decimals. 

If there is number of days are smaller than 365, only represent the values in days without indicating 0 years. 

This will only apply in the Data Exploration tables and the Entity pages of the portal. The Report API and export as TSV that generates the downloaded reports will remain in days to ensure ease of data manipulation. 

Follow the [Figma Design](https://www.figma.com/file/baxEfYnqjk3d87iQAPEz8S/Pages-Entit%C3%A9s?node-id=223%3A17889&t=fsjlchASs43KJDzo-1) for the styling but with KF theme

** If there is a better way to calculate these two values separate, feel free to adjust. 

Example: 

Years: floor(days / 365.2425)
Days:  floor(days % 365.2425)

Display in the table: 2 years 25 days

Also remove age_at_event day for Phenotype and diagnosis


**For Participant Entity**
Add the basic template and test the readable date.  It's not completed


## Screenshot
Before
![image](https://user-images.githubusercontent.com/65532894/213498796-a977f353-10e6-415c-8979-117cfe8d78e8.png)

After
![image](https://user-images.githubusercontent.com/65532894/213498893-7eac155a-7178-4701-8921-45b70b0b4a60.png)

