### PR TITLE
✨feat(variant): SKFP-611 remove download data button

### DIFF
--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -32,7 +32,7 @@ export enum DYNAMIC_ROUTES {
   VARIANT_ENTITY = '/variants/:locus?',
   FILE_ENTITY = '/files/:file_id?',
   PARTICIPANT_ENTITY = '/data-exploration/participants/:id',
-  STUDY_ENTITY = '',
+  STUDY_ENTITY = '/study/:study_id?',
   ERROR = '/error/:status?',
   COMMUNITY_MEMBER = '/member/:id',
 }

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@ferlab/ui/core/graphql/types';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import { Button, Dropdown, Menu, Tooltip } from 'antd';
+import { Menu, Tooltip } from 'antd';
 import cx from 'classnames';
 import { INDEXES } from 'graphql/constants';
 import {
@@ -44,9 +44,7 @@ import { getProTableDictionary } from 'utils/translation';
 import styles from './index.module.scss';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import { SetType } from 'services/api/savedSet/models';
-import { DownloadOutlined } from '@ant-design/icons';
-import { fetchReport, fetchTsvReport } from 'store/report/thunks';
-import { ReportType } from 'services/api/reports/models';
+import { fetchReport } from 'store/report/thunks';
 
 interface OwnProps {
   pageIndex: number;
@@ -259,12 +257,6 @@ const VariantsTable = ({
           }),
         )
       }
-      items={[
-        {
-          key: ReportType.CLINICAL_DATA,
-          label: 'Selected variant',
-        },
-      ]}
     />
   );
 
@@ -315,16 +307,6 @@ const VariantsTable = ({
                   },
                 }),
               ),
-
-            onTableExportClick: () =>
-              dispatch(
-                fetchTsvReport({
-                  columnStates: userInfo?.config.variant?.tables?.variants?.columns,
-                  columns: defaultColumns,
-                  index: INDEXES.VARIANTS,
-                  sqon: getCurrentSqon(),
-                }),
-              ),
             onSelectAllResultsChange: setSelectedAllResults,
             onSelectedRowsChange: (keys, selectedRows) => {
               setSelectedKeys(keys);
@@ -340,14 +322,6 @@ const VariantsTable = ({
                 type={SetType.VARIANT}
                 key="variants-set-management"
               />,
-              <Dropdown
-                disabled={selectedKeys.length === 0}
-                overlay={menu}
-                placement="bottomLeft"
-                key={'download-clinical-data-dropdown'}
-              >
-                <Button icon={<DownloadOutlined />}>Download clinical data</Button>
-              </Dropdown>,
             ],
           }}
           bordered


### PR DESCRIPTION
# FEAT

- closes #[611](https://d3b.atlassian.net/browse/SKFP-611)

## Description
Remove clinical download data

[Bonus] Re-add study route with the futur correct URL. Used in ParticipantEntity

Acceptance Criterias


## Screenshot
Before
![image](https://user-images.githubusercontent.com/65532894/213531602-2a7390f6-5e93-4208-a8c5-1126c506a77c.png)


After
![image](https://user-images.githubusercontent.com/65532894/213531203-75b7ed82-c01c-4e26-b1b1-7165b908044e.png)



@ QA, Design ...
