### PR TITLE
🐛 fix(report): SKFP-609 fix tsv export

### DIFF
--- a/src/services/api/reports/index.ts
+++ b/src/services/api/reports/index.ts
@@ -45,7 +45,7 @@ const generateReport = (config: ReportConfig) => {
     data: {
       sqon: reportSqon,
       projectId: arrangerProjectId,
-      filename: format(new Date(), `[${name}_]YYYYMMDD[.xlsx]`),
+      filename: format(new Date(), `[${name}_]yyyymmDD[.xlsx]`),
     },
     headers: headers(),
   });

--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -89,8 +89,8 @@ const fetchTsvReport = createAsyncThunk<void, TFetchTSVArgs, { rejectValue: stri
     );
 
     try {
-      const filename = `[include-${args.index}-table]-YYYY-MM-DD`;
-      const formattedFileName = format(new Date(), `${filename}[.tsv]`);
+      const formattedDate = format(new Date(), 'yyyy-MM-dd');
+      const formattedFileName = `kidsfirst-${args.index}-table-${formattedDate}.tsv`;
 
       const { data, error } = await ArrangerApi.columnStates({
         query: getColumnStateQuery(args.index),

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -245,21 +245,6 @@ const VariantsTable = ({
           ],
         });
 
-  const menu = (
-    <Menu
-      onClick={(e) =>
-        dispatch(
-          fetchReport({
-            data: {
-              sqon: getCurrentSqon(),
-              name: e.key,
-            },
-          }),
-        )
-      }
-    />
-  );
-
   useEffect(() => {
     if (selectedKeys.length) {
       setSelectedKeys([]);


### PR DESCRIPTION
# BUG 

- closes #[609](https://d3b.atlassian.net/browse/SKFP-609)

## Description

Implement the report tied to the Export as TSV button. When a user clicks the Export as TSV button, it will download a TSV file of the table of results. This is seen in the Studies page, Data Exploration-- Participant/File tab, File Entity (Participant / Sample table), Participant Entity page (Diagnostic, Phenotype, Biospecimen table).

When specific rows are selected, the Export as TSV should generate the table that is displayed in the portal for those rows specifically

The Export as TSV should correlate with the Column Selection tool. In other words, if a user adjusts the columns he wants to see, the TSV report should correspond to the display of the table and not include the columns that are unchecked in the column selection tool. 

Similarly, if the “Select All results” is selected, the export will generate a TSV for all of the rows. 

If there is no checkbox selection, the export as TSV will generate a TSV for all of the rows. 

For the Data Exploration--Data Files tab, there are two icon headers. “File Authorization” and “Data Access”. Since the File Authorization can change based on a users fence connection, we will NOT include it as part of the TSV export. We will only include the Data Access and display either “Registered”, “Open”, “Controlled” in the export. 


Bonus
Solution: format doesn't support YYYY and MM format
https://date-fns.org/v2.29.3/docs/format

## Screenshot
![Peek 2023-01-20 13-32](https://user-images.githubusercontent.com/65532894/213779813-78956217-6f89-4556-80ed-949c73882c6d.gif)
![Screenshot_20230120_133253](https://user-images.githubusercontent.com/65532894/213779814-9a6e3b61-ae1e-4ae4-8287-485f7356b084.png)
