### PR TITLE
fix(variant): SKFP-617 fix consequence row size

### DIFF
--- a/src/views/Variants/components/ConsequencesCell/index.module.scss
+++ b/src/views/Variants/components/ConsequencesCell/index.module.scss
@@ -1,5 +1,9 @@
 @import 'src/style/themes/kids-first/colors';
 
+.stackLayout {
+  min-width: 375px;
+}
+
 .consequenceUl {
   list-style: none;
   padding: 0;
@@ -27,6 +31,8 @@
 
 .bullet {
   margin-right: 8px;
+  min-width: 10px;
+  min-height: 10px;
 }
 
 .symbol {

--- a/src/views/Variants/components/ConsequencesCell/index.tsx
+++ b/src/views/Variants/components/ConsequencesCell/index.tsx
@@ -1,7 +1,7 @@
-import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
 import StackLayout from '@ferlab/ui/core/layout/StackLayout';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import { IConsequenceEntity, Impact } from 'graphql/variants/models';
 
 import HighBadgeIcon from 'components/Icons/VariantBadgeIcons/HighBadgeIcon';
@@ -37,7 +37,7 @@ const ConsequencesCell = ({
 
         if (node.consequences) {
           return (
-            <StackLayout center key={index}>
+            <StackLayout className={style.stackLayout} center key={index}>
               {pickImpactBadge(node.vep_impact)}
               <span key={index} className={style.detail}>
                 {removeUnderscoreAndCapitalize(node.consequences[0])}

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -29,11 +29,13 @@ import {
   IVariantEntity,
   IVariantStudyEntity,
 } from 'graphql/variants/models';
+import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import { DATA_EXPLORATION_QB_ID, DEFAULT_PAGE_INDEX } from 'views/DataExploration/utils/constant';
 import ConsequencesCell from 'views/Variants/components/ConsequencesCell';
 import { SCROLL_WRAPPER_ID, VARIANT_SAVED_SETS_FIELD } from 'views/Variants/utils/constants';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { SetType } from 'services/api/savedSet/models';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { formatQuerySortList, scrollToTop } from 'utils/helper';
@@ -42,8 +44,6 @@ import { truncateString } from 'utils/string';
 import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';
-import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
-import { SetType } from 'services/api/savedSet/models';
 
 interface OwnProps {
   pageIndex: number;
@@ -104,7 +104,6 @@ const defaultColumns: ProColumnType[] = [
     key: 'consequences',
     title: intl.get('screen.variants.table.consequences.title'),
     dataIndex: 'consequences',
-    width: 300,
     tooltip: intl.get('screen.variants.table.consequences.tooltip'),
     render: (consequences: IArrangerResultsTree<IConsequenceEntity>) => (
       <ConsequencesCell consequences={consequences?.hits?.edges || []} />
@@ -136,7 +135,6 @@ const defaultColumns: ProColumnType[] = [
     title: intl.get('screen.variants.table.gnomAD.title'),
     tooltip: intl.get('screen.variants.table.gnomAD.tooltip'),
     dataIndex: 'frequencies',
-    width: '7%',
     render: (gnomad: IExternalFrequenciesEntity) =>
       gnomad.gnomad_genomes_3_1_1.af
         ? toExponentialNotation(gnomad.gnomad_genomes_3_1_1.af)


### PR DESCRIPTION
# BUG 

- closes #[617](https://d3b.atlassian.net/browse/SKFP-617)

## Description
Goal: Currently, the Consequence column cells has a set width for the column and so it causes the consequence (e.g. Frameshift variant) to wrap. It also decreases the impact icon size. 

Remove the set width for the Consequence column, and allow the table to resize based on the content of the consequence column cell. (This will surely cause the horizontal scroll to be present more frequently)

Ultimately the goal is to remove the wrap because the consequence value (e.g. frameshift variant should never be wrapped

Ensure that the impact icon size does not alter from one row to another. 


## Screenshot 
Before
![image](https://user-images.githubusercontent.com/65532894/215578746-9c71e238-2f7a-402e-b82c-c5c5fca1ded5.png)

After

![Screenshot_20230130_143733](https://user-images.githubusercontent.com/65532894/215578785-860edb66-c7f2-4766-a0e0-c5dda1eebf76.png)
![Screenshot_20230130_143740](https://user-images.githubusercontent.com/65532894/215578789-5e924ac7-0e45-4213-a943-1578abf5676f.png)

