### PR TITLE
🐛fix(participant): SKFP-632 fix search participants query

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -12,6 +12,8 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
             is_proband
             families_id
             ethnicity
+            nb_files
+            nb_biospecimens
             external_id
             study_external_id
             family_type


### PR DESCRIPTION
# BUG 

- closes #[632](https://d3b.atlassian.net/browse/SKFP-632)

## Description
files et biospecimens retourne toujours 0 dans data-exploration/participants

## Screenshot 
![image](https://user-images.githubusercontent.com/65532894/220643312-6d517f7d-9920-4647-8be8-c0001b6bdb7a.png)

