### PR TITLE
fix: SKFP-628 TreeFacetModal query gives wrong results in querybuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ dist
 .DS_Store
 
 build/
+
+.vscode

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -10,6 +10,7 @@ import SidebarMenu, { ISidebarMenuItem } from '@ferlab/ui/core/components/Sideba
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
 import { INDEXES } from 'graphql/constants';
 import PageContent from 'views/DataExploration/components/PageContent';
+import TreeFacet from 'views/DataExploration/components/TreeFacet';
 import {
   DATA_EXPLORATION_QB_ID,
   SCROLL_WRAPPER_ID,
@@ -19,23 +20,22 @@ import {
 import FilterList from 'components/uiKit/FilterList';
 import { FilterInfo } from 'components/uiKit/FilterList/types';
 import useGetExtendedMappings from 'hooks/graphql/useGetExtendedMappings';
+import { RemoteComponentList } from 'store/remote/types';
 import { mapFilterForFiles, mapFilterForParticipant } from 'utils/fieldMapper';
 
-import ParticipantSearch from './components/ParticipantSearch';
-import ParticipantSetSearch from './components/ParticipantSetSearch';
-
-import styles from './index.module.scss';
 import { BiospecimenCollectionSearch, BiospecimenSearch } from './components/BiospecimenSearch';
 import BiospecimenSetSearch from './components/BiospecimenSetSearch';
-import FileSetSearch from './components/FileSetSearch';
-import FileUploadIds from './components/UploadIds/FileUploadIds';
-import BiospecimenUploadIds from './components/UploadIds/BiospecimenUploadIds';
 import FileSearch from './components/FileSearch';
-import ParticipantUploadIds from './components/UploadIds/ParticipantUploadIds';
-import TreeFacet from 'views/DataExploration/components/TreeFacet';
-import { formatHpoTitleAndCode, formatMondoTitleAndCode } from './utils/helper';
-import { RemoteComponentList } from 'store/remote/types';
+import FileSetSearch from './components/FileSetSearch';
+import ParticipantSearch from './components/ParticipantSearch';
+import ParticipantSetSearch from './components/ParticipantSetSearch';
 import TreeFacetModal from './components/TreeFacet/TreeFacetModal';
+import BiospecimenUploadIds from './components/UploadIds/BiospecimenUploadIds';
+import FileUploadIds from './components/UploadIds/FileUploadIds';
+import ParticipantUploadIds from './components/UploadIds/ParticipantUploadIds';
+import { formatHpoTitleAndCode, formatMondoTitleAndCode } from './utils/helper';
+
+import styles from './index.module.scss';
 
 enum FilterTypes {
   Study,
@@ -223,12 +223,14 @@ const DataExploration = () => {
     <div className={styles.dataExplorationLayout}>
       <TreeFacetModal
         type={RemoteComponentList.MondoTree}
-        field={'mondo'}
+        modalField={'mondo'}
+        queryBuilderField={'mondo.name'}
         titleFormatter={formatMondoTitleAndCode}
       />
       <TreeFacetModal
         type={RemoteComponentList.HPOTree}
-        field={'observed_phenotype'}
+        modalField={'observed_phenotype'}
+        queryBuilderField={'phenotype.hpo_phenotype_observed'}
         titleFormatter={formatHpoTitleAndCode}
       />
       <SidebarMenu


### PR DESCRIPTION
# BUG

- closes [SKFP-628](https://d3b.atlassian.net/browse/SKFP-628)
- closes [SKFP-593](https://d3b.atlassian.net/browse/SKFP-593)

## Description

- Fixed querybuilder not displaying the correct results when searching from TreeFacetModal
- Fixed duplicate options in Apply button dropdown

## Screenshot
Before:
![628_before](https://user-images.githubusercontent.com/116835792/220766211-e5db156f-ce49-453e-9b52-f13a7f07960c.gif)

After:
![628_after](https://user-images.githubusercontent.com/116835792/220766226-314a455e-25e2-42d0-9afd-cfb6a06aee58.gif)

[SKFP-628]: https://d3b.atlassian.net/browse/SKFP-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKFP-593]: https://d3b.atlassian.net/browse/SKFP-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ