### PR TITLE
🐛fix(study): SKFP-606 fix search query

### DIFF
--- a/src/views/Studies/components/StudySearch/index.tsx
+++ b/src/views/Studies/components/StudySearch/index.tsx
@@ -16,7 +16,7 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
   return (
     <GlobalSearch<IStudiesEntity>
       queryBuilderId={queryBuilderId}
-      field="search_text"
+      field="study_code"
       tooltipText={intl.getHTML('global.search.study.tooltip')}
       index={INDEXES.STUDIES}
       placeholder={intl.get(`global.search.study.placeholder`)}
@@ -32,7 +32,7 @@ const StudySearch = ({ queryBuilderId }: ICustomSearchProps) => {
               caption={highlightSearchMatch(option.study_name, matchRegex, search)}
             />
           ),
-          value: option.study_id,
+          value: option.study_code,
         }))
       }
       title={intl.get(`global.search.study.title`)}

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -34,7 +34,7 @@ const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
   dataCategory ? dataCategory.includes(category) ? <CheckOutlined /> : undefined : undefined;
 
 const filterInfo: FilterInfo = {
-  customSearches: [<StudySearch queryBuilderId={STUDIES_REPO_QB_ID} />],
+  customSearches: [<StudySearch key={1} queryBuilderId={STUDIES_REPO_QB_ID} />],
   defaultOpenFacets: ['program', 'data_category', 'experimental_strategy', 'family_data'],
   groups: [
     {


### PR DESCRIPTION
# BUG

- closes #[606](https://d3b.atlassian.net/browse/SKFP-606)

## Description

go to study page

search for a study

select a suggestion

you will see that study_id from the response is used to create a query in the querybuilder. Make sure that study_id is used instead of searchText in the querybuilder.

Ensure that the query pill has it displayed as the “Study Code”: Study Code for example. 

## Screenshot
Before
![image](https://user-images.githubusercontent.com/65532894/221267377-48f73295-8b12-4e85-9cbc-da597e56c509.png)

After

![Peek 2023-02-24 13-54](https://user-images.githubusercontent.com/65532894/221267411-5089fce5-1fc7-4d11-b61a-2af1b6a6b5eb.gif)



