### PR TITLE
✨feat(report): SKFP-614 add report api

### DIFF
--- a/src/services/api/reports/index.ts
+++ b/src/services/api/reports/index.ts
@@ -1,10 +1,12 @@
-import EnvironmentVariables from 'helpers/EnvVariables';
-import keycloak from 'auth/keycloak-api/keycloak';
-import { ReportConfig, ReportType } from './models';
-import isEmpty from 'lodash/isEmpty';
-import { format } from 'date-fns';
-import downloader from 'common/downloader';
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
+import keycloak from 'auth/keycloak-api/keycloak';
+import { format } from 'date-fns';
+import EnvironmentVariables from 'helpers/EnvVariables';
+import isEmpty from 'lodash/isEmpty';
+
+import downloader from 'common/downloader';
+
+import { ReportConfig, ReportType } from './models';
 
 const REPORT_API_URL = EnvironmentVariables.configFor('REPORTS_API_URL');
 const arrangerProjectId = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID');
@@ -15,11 +17,25 @@ const REPORTS_ROUTES = {
   [ReportType.BIOSEPCIMEN_DATA]: `${REPORT_API_URL}/reports/biospecimen-data`,
 };
 
+const joinWithPadding = (l: number[]) => l.reduce((xs, x) => xs + `${x}`.padStart(2, '0'), '');
+const makeFilenameDatePart = (date = new Date()) => {
+  const prefixes = joinWithPadding([
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+  ]);
+  const suffixes = joinWithPadding([
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  ]);
+  return `${prefixes}T${suffixes}Z`;
+};
+
 const headers = () => ({
   'Content-Type': 'application/json',
   Accept: '*/*',
   Authorization: `Bearer ${keycloak.token}`,
-  'Accept-Encoding': 'gzip, deflate, br',
 });
 
 const generateReport = (config: ReportConfig) => {
@@ -43,9 +59,10 @@ const generateReport = (config: ReportConfig) => {
     method: 'POST',
     responseType: 'blob',
     data: {
+      isKfNext: true,
       sqon: reportSqon,
       projectId: arrangerProjectId,
-      filename: format(new Date(), `[${name}_]yyyymmDD[.xlsx]`),
+      filename: `kf_${name}_${makeFilenameDatePart(new Date())}.xlsx`,
     },
     headers: headers(),
   });


### PR DESCRIPTION
# FEAT

- closes #[614](https://d3b.atlassian.net/browse/SKFP-614)

## Description

File naming:

If the user selected “Download Clinical data – Selected participants”

Report file name: "kf_clinicalData_date/time (year/month/day/Time, "T"/hour/minute/seconds/UTC, "Z")". e.g. kf_clinicalData_20220208T080910Z

If the user selected “ Download Clinical data – Selected participants & families”

Report file name: "kf_familyClinicalData_date/time (year/month/day/Time, "T"/hour/minute/seconds/UTC, "Z")". e.g. kf_familyClinicalData_20220208T080910Z

https://github.com/Ferlab-Ste-Justine/clin-portal-ui/blob/2af6f0a07a59924c4390d4cf2d86156794405102/src/views/Prescriptions/utils/export.ts#L52 

Here is an example of the payload

```
{
    "isKfNext": true, <=== hack to switch to kids-first next config.
    "sqon": {
        "op": "and",
        "content": [
            {
                "op": "in",
                "content": {
                    "field": "participant.sex",
                    "value": [
                        "female"
                    ]
                }
            }
        ]
    },
    "projectId": "next_qa",
    "filename": <myFileName>
}
```


## Screenshot (Before and After)

https://user-images.githubusercontent.com/65532894/221627800-0eb6a500-457d-45f3-84f7-2b876233b131.mp4



![image](https://user-images.githubusercontent.com/65532894/221627695-f579abba-9e7f-4137-95d7-cda8c9be6ad0.png)
![image](https://user-images.githubusercontent.com/65532894/221627741-4f136c2c-ebb8-42bc-a49c-b18c0d66b627.png)
