### PR TITLE
🐛fix(link): SKFP-646 remove link on family data

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.module.scss
@@ -7,7 +7,11 @@
   border-radius: 2px;
   border: 1px solid $cyan-7;
 
-  &:hover {
+  &.disabled {
+    cursor: default !important;
+  }
+
+  &:not(&.disabled):hover {
     background-color: $cyan-9;
     border-color: $cyan-9;
 

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/LinkBox/index.tsx
@@ -1,9 +1,10 @@
 import { Link } from 'react-router-dom';
-import { Space } from 'antd';
+import { ArrowRightOutlined } from '@ant-design/icons';
 import MultiLabel, {
   MultiLabelIconPositionEnum,
 } from '@ferlab/ui/core/components/labels/MultiLabel';
-import { ArrowRightOutlined } from '@ant-design/icons';
+import { Space } from 'antd';
+import cx from 'classnames';
 
 import styles from './index.module.scss';
 
@@ -13,21 +14,43 @@ interface OwnProps {
   label: string | number;
   subLabel: string;
   href: string;
+  disabled?: boolean;
 }
 
-const LinkBox = ({ multiLabelClassName = '', label, subLabel, icon, href }: OwnProps) => (
-  <Link to={href} className={styles.dataExploBox}>
-    <Space direction="horizontal" size={16} align="start">
-      <MultiLabel
-        iconPosition={MultiLabelIconPositionEnum.Top}
-        label={label}
-        Icon={icon}
-        className={multiLabelClassName}
-        subLabel={subLabel}
-      />
-      <ArrowRightOutlined className={styles.linkArrow} />
-    </Space>
-  </Link>
-);
+const LinkBox = ({
+  multiLabelClassName = '',
+  label,
+  subLabel,
+  icon,
+  href,
+  disabled = false,
+}: OwnProps) =>
+  disabled ? (
+    <div className={cx(styles.dataExploBox, styles.disabled)}>
+      <Space direction="horizontal" size={16} align="start">
+        <MultiLabel
+          iconPosition={MultiLabelIconPositionEnum.Top}
+          label={label}
+          Icon={icon}
+          className={multiLabelClassName}
+          subLabel={subLabel}
+        />
+        <ArrowRightOutlined className={styles.linkArrow} />
+      </Space>
+    </div>
+  ) : (
+    <Link to={href} className={styles.dataExploBox}>
+      <Space direction="horizontal" size={16} align="start">
+        <MultiLabel
+          iconPosition={MultiLabelIconPositionEnum.Top}
+          label={label}
+          Icon={icon}
+          className={multiLabelClassName}
+          subLabel={subLabel}
+        />
+        <ArrowRightOutlined className={styles.linkArrow} />
+      </Space>
+    </Link>
+  );
 
 export default LinkBox;

--- a/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/DataExplorationLinks/index.tsx
@@ -1,18 +1,20 @@
 import { useEffect } from 'react';
-import { Row, Col } from 'antd';
-import { FileTextOutlined, ReadOutlined, TeamOutlined, UserOutlined } from '@ant-design/icons';
-import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import LinkBox from './LinkBox';
-import { STATIC_ROUTES } from 'utils/routes';
 import intl from 'react-intl-universal';
-import CardHeader from 'views/Dashboard/components/CardHeader';
 import { useDispatch } from 'react-redux';
+import { FileTextOutlined, ReadOutlined, TeamOutlined, UserOutlined } from '@ant-design/icons';
+import { numberFormat } from '@ferlab/ui/core/utils/numberUtils';
+import GridCard from '@ferlab/ui/core/view/v2/GridCard';
+import { Col, Row } from 'antd';
+import CardHeader from 'views/Dashboard/components/CardHeader';
+
+import BiospecimenIcon from 'components/Icons/BiospecimenIcon';
 import { useGlobals } from 'store/global';
 import { fetchStats } from 'store/global/thunks';
-import { numberFormat } from '@ferlab/ui/core/utils/numberUtils';
+import { STATIC_ROUTES } from 'utils/routes';
+
+import LinkBox from './LinkBox';
 
 import styles from './index.module.scss';
-import BiospecimenIcon from 'components/Icons/BiospecimenIcon';
 
 const DataExplorationLinks = () => {
   const dispatch = useDispatch();
@@ -50,6 +52,7 @@ const DataExplorationLinks = () => {
           </Col>
           <Col flex="auto" className={styles.customCol}>
             <LinkBox
+              disabled
               href=""
               multiLabelClassName={styles.dataReleaseStatsLabel}
               label={numberFormat(stats?.families!)}


### PR DESCRIPTION
# BUG 

- closes #[646](https://d3b.atlassian.net/browse/SKFP-646)

## Description

Remove the redirect link and hover state for the families button. Since there is no “official” families tab in the Data Exploration page we will simply remove the redirect link. 


## Screenshot 
Before
![image](https://user-images.githubusercontent.com/65532894/221651777-31be3ffe-aad5-4696-8a90-9cbaa16f45eb.png)

After

https://user-images.githubusercontent.com/65532894/221651829-0be093d3-8ed5-44e5-a37f-fdb477b32f48.mp4


