### PR TITLE
🐛fix(ontology): SKFP-628 Change field to search in query builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^5.1.0",
+        "@ferlab/ui": "^5.1.1",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/core": "^0.80.0",
@@ -2693,9 +2693,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.1.0.tgz",
-      "integrity": "sha512-31tORfwEMMnmjOG+MxCJDVU8h3QZjMKyGAKtaO5vsTjf2KgIqvPEJ/6rxiqIRsh/Yr38MLiBD5zn2/nnFQe2rw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.1.1.tgz",
+      "integrity": "sha512-2mi9NAiUkFKrBEP2VSmLTNDquxnE+ta3W728X9ryN6RRA88uYW0cRP1aCXdcMfuxhXCDzV4Vh72CJTkNlMsMGw==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -35544,9 +35544,9 @@
       }
     },
     "@ferlab/ui": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.1.0.tgz",
-      "integrity": "sha512-31tORfwEMMnmjOG+MxCJDVU8h3QZjMKyGAKtaO5vsTjf2KgIqvPEJ/6rxiqIRsh/Yr38MLiBD5zn2/nnFQe2rw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.1.1.tgz",
+      "integrity": "sha512-2mi9NAiUkFKrBEP2VSmLTNDquxnE+ta3W728X9ryN6RRA88uYW0cRP1aCXdcMfuxhXCDzV4Vh72CJTkNlMsMGw==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^5.1.0",
+    "@ferlab/ui": "^5.1.1",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.80.0",

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -230,7 +230,7 @@ const DataExploration = () => {
       <TreeFacetModal
         type={RemoteComponentList.HPOTree}
         modalField={'observed_phenotype'}
-        queryBuilderField={'phenotype.hpo_phenotype_observed'}
+        queryBuilderField={'observed_phenotype.name'}
         titleFormatter={formatHpoTitleAndCode}
       />
       <SidebarMenu


### PR DESCRIPTION
# BUG
- closes [SKFP-628](https://d3b.atlassian.net/browse/SKFP-628)

## Description
- Change the field used to search in the QueryBuilder from the ontology browser. (the search results must include all participants in the hierarchy, not just the ones with the exact term)
- Related to https://github.com/Ferlab-Ste-Justine/ferlab-ui/pull/238 

## Screenshot
Before:
![333A2219-403F-4FE6-B2E0-3FD5F4E17FAC_4_5005_c](https://user-images.githubusercontent.com/116835792/221653549-5aa8d62a-b91c-492d-96dd-4b12e8f7389a.jpeg)

After:
![45BE0B6D-29E8-478C-870A-77F4F831A1FB_4_5005_c](https://user-images.githubusercontent.com/116835792/221653513-df80a11b-a7d1-4427-972c-e764ad001e31.jpeg)

[SKFP-628]: https://d3b.atlassian.net/browse/SKFP-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ