### PR TITLE
✨feat(variant): SKFP-542 add sort for alt. homo. and participants

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -150,6 +150,9 @@ const defaultColumns: ProColumnType[] = [
     title: intl.get('screen.variants.table.participant.title'),
     tooltip: intl.get('screen.variants.table.participant.tooltip'),
     key: 'participant_number',
+    sorter: {
+      multiple: 1,
+    },
     render: (record: IVariantEntity) => {
       const participantNumber = record.participant_number || 0;
       if (participantNumber <= 10) {
@@ -200,17 +203,22 @@ const defaultColumns: ProColumnType[] = [
   {
     title: intl.get('screen.variants.table.alt.title'),
     tooltip: intl.get('screen.variants.table.alt.tooltip'),
-    dataIndex: 'frequencies',
-    key: 'alternate',
-    render: (frequencies: IExternalFrequenciesEntity) => frequencies?.internal?.upper_bound_kf?.ac,
+    key: 'internal',
+    dataIndex: ['frequencies', 'internal', 'upper_bound_kf', 'ac'],
+    sorter: {
+      multiple: 1,
+    },
+    render: (ac: string) => ac,
   },
   {
     title: intl.get('screen.variants.table.homozygotes.title'),
     tooltip: intl.get('screen.variants.table.homozygotes.tooltip'),
-    dataIndex: 'frequencies',
+    dataIndex: ['frequencies', 'internal', 'upper_bound_kf', 'homozygotes'],
     key: 'homozygotes',
-    render: (frequencies: IExternalFrequenciesEntity) =>
-      frequencies?.internal?.upper_bound_kf?.homozygotes,
+    sorter: {
+      multiple: 1,
+    },
+    render: (homozygotes: string) => homozygotes,
   },
 ];
 


### PR DESCRIPTION
# FEAT

- closes #[542](https://d3b.atlassian.net/browse/SKFP-542)

## Description
As part of the new integration of Search After, we will be able to sort across the table of results despite having a large number of results. Add sort to the following columns:

participant
ALT (API need to be done)
Homo. (API need to be done)

## Screenshot 
![image](https://user-images.githubusercontent.com/65532894/221936051-015f58fd-6f5b-4faa-9764-96ac519fe022.png)


