### PR TITLE
✨ feat(data): SFKP-656 add search after on data-exploration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^5.4.5",
+        "@ferlab/ui": "^5.5.4",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/core": "^0.80.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.4.5.tgz",
-      "integrity": "sha512-vtFs+rnaznHnR/MWXNeL+FXTkNnU5VzkJvaC7++4urnvmdi2ech8fbq5WvMGC4wyDacPIeEujMiyIudHJyPJfA==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.5.5.tgz",
+      "integrity": "sha512-4csCMnVmQxtRQviLzCvH+0AkbhBt+LQhvE4SlgQjqIbNT+8a3qtOKG+lk3OklfagClfl+IMCTGQRyzF4/yLyVQ==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -2743,8 +2743,8 @@
       "peerDependencies": {
         "antd": "^4.20.0",
         "date-fns": "^2.29.3",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@formatjs/intl-unified-numberformat": {
@@ -35573,9 +35573,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.4.5.tgz",
-      "integrity": "sha512-vtFs+rnaznHnR/MWXNeL+FXTkNnU5VzkJvaC7++4urnvmdi2ech8fbq5WvMGC4wyDacPIeEujMiyIudHJyPJfA==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-5.5.5.tgz",
+      "integrity": "sha512-4csCMnVmQxtRQviLzCvH+0AkbhBt+LQhvE4SlgQjqIbNT+8a3qtOKG+lk3OklfagClfl+IMCTGQRyzF4/yLyVQ==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^5.4.5",
+    "@ferlab/ui": "^5.5.4",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.80.0",

--- a/src/graphql/biospecimens/actions.ts
+++ b/src/graphql/biospecimens/actions.ts
@@ -1,23 +1,43 @@
-import { IQueryResults, IQueryVariable } from '@ferlab/ui/core/graphql/types';
-import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import {
+  IQueryOperationsConfig,
+  IQueryResults,
+  IQueryVariable,
+} from '@ferlab/ui/core/graphql/types';
+import { computeSearchAfter, hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { INDEXES } from 'graphql/constants';
 import { IUseParticipantEntityProps } from 'graphql/participants/models';
 
 import useLazyResultQuery from 'hooks/graphql/useLazyResultQuery';
 
 import { IBiospecimenEntity, IBiospecimenResultTree } from './models';
-import { GET_PARTICIPANT_BIOSPECIMENS, SEARCH_BIOSPECIMEN_QUERY } from './queries';
+import {
+  GET_BIOSPECIMEN_COUNT,
+  GET_PARTICIPANT_BIOSPECIMENS,
+  SEARCH_BIOSPECIMEN_QUERY,
+} from './queries';
 
-export const useBiospecimen = (variables?: IQueryVariable): IQueryResults<IBiospecimenEntity[]> => {
+export const useBiospecimen = (
+  variables?: IQueryVariable,
+  operations?: IQueryOperationsConfig,
+): IQueryResults<IBiospecimenEntity[]> => {
   const { loading, result } = useLazyResultQuery<IBiospecimenResultTree>(SEARCH_BIOSPECIMEN_QUERY, {
     variables,
   });
 
   return {
     loading,
-    data: hydrateResults(result?.biospecimens?.hits?.edges || []),
+    data: hydrateResults(result?.biospecimens?.hits?.edges || [], operations?.previous),
     total: result?.biospecimens?.hits?.total || 0,
+    searchAfter: computeSearchAfter(result?.biospecimens?.hits?.edges || [], operations),
   };
+};
+
+export const useTotalBiospecimens = (variables?: IQueryVariable): number => {
+  const { result } = useLazyResultQuery<IBiospecimenResultTree>(GET_BIOSPECIMEN_COUNT, {
+    variables,
+  });
+
+  return result?.biospecimens?.hits?.total || 0;
 };
 
 export const useBiospecimenParticipant = ({

--- a/src/graphql/biospecimens/queries.ts
+++ b/src/graphql/biospecimens/queries.ts
@@ -1,11 +1,18 @@
 import { gql } from '@apollo/client';
 
 export const SEARCH_BIOSPECIMEN_QUERY = gql`
-  query searchBiospecimen($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort]) {
+  query searchBiospecimen(
+    $sqon: JSON
+    $first: Int
+    $offset: Int
+    $sort: [Sort]
+    $searchAfter: JSON
+  ) {
     biospecimens {
-      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort) {
+      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort, searchAfter: $searchAfter) {
         total
         edges {
+          searchAfter
           node {
             id
             sample_id
@@ -66,6 +73,16 @@ export const GET_PARTICIPANT_BIOSPECIMENS = gql`
             }
           }
         }
+      }
+    }
+  }
+`;
+
+export const GET_BIOSPECIMEN_COUNT = gql`
+  query getBiospecimenCount($sqon: JSON) {
+    biospecimens {
+      hits(filters: $sqon) {
+        total
       }
     }
   }

--- a/src/graphql/files/actions.ts
+++ b/src/graphql/files/actions.ts
@@ -1,22 +1,31 @@
-import { IQueryVariable } from '@ferlab/ui/core/graphql/types';
-import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { IQueryOperationsConfig, IQueryVariable } from '@ferlab/ui/core/graphql/types';
+import { computeSearchAfter, hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { INDEXES } from 'graphql/constants';
 
 import useLazyResultQuery from 'hooks/graphql/useLazyResultQuery';
 
 import { IFileEntity, IFileResultTree } from './models';
-import { GET_FILE_ENTITY, SEARCH_FILES_QUERY } from './queries';
+import { GET_FILE_COUNT, GET_FILE_ENTITY, SEARCH_FILES_QUERY } from './queries';
 
-export const useDataFiles = (variables?: IQueryVariable) => {
+export const useDataFiles = (variables?: IQueryVariable, operations?: IQueryOperationsConfig) => {
   const { loading, result } = useLazyResultQuery<IFileResultTree>(SEARCH_FILES_QUERY, {
     variables,
   });
 
   return {
     loading,
-    data: hydrateResults(result?.files?.hits?.edges || []),
+    data: hydrateResults(result?.files?.hits?.edges || [], operations?.previous),
     total: result?.files?.hits?.total || 0,
+    searchAfter: computeSearchAfter(result?.files?.hits?.edges || [], operations),
   };
+};
+
+export const useTotalDataFiles = (variables?: IQueryVariable): number => {
+  const { result } = useLazyResultQuery<IFileResultTree>(GET_FILE_COUNT, {
+    variables,
+  });
+
+  return result?.files?.hits?.total || 0;
 };
 
 interface IUseFileProps {

--- a/src/graphql/files/queries.ts
+++ b/src/graphql/files/queries.ts
@@ -1,11 +1,12 @@
 import { gql } from '@apollo/client';
 
 export const SEARCH_FILES_QUERY = gql`
-  query searchFiles($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort]) {
+  query searchFiles($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort], $searchAfter: JSON) {
     files {
-      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort) {
+      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort, searchAfter: $searchAfter) {
         total
         edges {
+          searchAfter
           node {
             id
             external_id
@@ -121,6 +122,16 @@ export const GET_FILE_ENTITY = gql`
             }
           }
         }
+      }
+    }
+  }
+`;
+
+export const GET_FILE_COUNT = gql`
+  query getFileCount($sqon: JSON) {
+    files {
+      hits(filters: $sqon) {
+        total
       }
     }
   }

--- a/src/graphql/participants/actions.ts
+++ b/src/graphql/participants/actions.ts
@@ -1,5 +1,9 @@
-import { IQueryResults, IQueryVariable } from '@ferlab/ui/core/graphql/types';
-import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import {
+  IQueryOperationsConfig,
+  IQueryResults,
+  IQueryVariable,
+} from '@ferlab/ui/core/graphql/types';
+import { computeSearchAfter, hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { INDEXES } from 'graphql/constants';
 
 import useLazyResultQuery from 'hooks/graphql/useLazyResultQuery';
@@ -10,10 +14,11 @@ import {
   IUseParticipantEntityProps,
   IUseParticipantEntityResults,
 } from './models';
-import { GET_PARTICIPANT_ENTITY, SEARCH_PARTICIPANT_QUERY } from './queries';
+import { GET_PARTICIPANT_COUNT, GET_PARTICIPANT_ENTITY, SEARCH_PARTICIPANT_QUERY } from './queries';
 
 export const useParticipants = (
   variables?: IQueryVariable,
+  operations?: IQueryOperationsConfig,
 ): IQueryResults<IParticipantEntity[]> => {
   const { loading, result } = useLazyResultQuery<IParticipantResultTree>(SEARCH_PARTICIPANT_QUERY, {
     variables,
@@ -21,9 +26,18 @@ export const useParticipants = (
 
   return {
     loading,
-    data: hydrateResults(result?.participant?.hits?.edges || []),
+    data: hydrateResults(result?.participant?.hits?.edges || [], operations?.previous),
     total: result?.participant?.hits?.total || 0,
+    searchAfter: computeSearchAfter(result?.participant?.hits?.edges || [], operations),
   };
+};
+
+export const useTotalParticipants = (variables?: IQueryVariable): number => {
+  const { result } = useLazyResultQuery<IParticipantResultTree>(GET_PARTICIPANT_COUNT, {
+    variables,
+  });
+
+  return result?.participant?.hits?.total || 0;
 };
 
 export const useParticipantEntity = ({

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -1,11 +1,18 @@
 import { gql } from '@apollo/client';
 
 export const SEARCH_PARTICIPANT_QUERY = gql`
-  query searchParticipant($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort]) {
+  query searchParticipant(
+    $sqon: JSON
+    $first: Int
+    $offset: Int
+    $sort: [Sort]
+    $searchAfter: JSON
+  ) {
     participant {
-      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort) {
+      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort, searchAfter: $searchAfter) {
         total
         edges {
+          searchAfter
           node {
             participant_id
             sex
@@ -247,6 +254,7 @@ export const GET_PARTICIPANT_COUNT = gql`
     }
   }
 `;
+
 export const CHECK_PARTICIPANT_MATCH = gql`
   query fetchMatchParticipant($sqon: JSON, $first: Int, $offset: Int) {
     participant {

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -86,8 +86,12 @@ export const getFiltersDictionary = (): FiltersDict => ({
     greaterThanOrEqual: intl.get('global.filters.operators.greaterthanorequal'),
   },
   range: {
-    noData: 'no data',
+    actualInterval: 'Actual Interval',
+    noData: 'No Data',
+    from: 'from',
+    to: 'to',
     is: intl.get('global.filters.range.is'),
+    unit: 'unit',
     min: 'min',
     max: 'max',
   },

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -1,5 +1,5 @@
 // TODO: Split into smaller files/components
-import { ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -15,26 +15,19 @@ import { ISavedFilter } from '@ferlab/ui/core/components/QueryBuilder/types';
 import { dotToUnderscore } from '@ferlab/ui/core/data/arranger/formatting';
 import { IRemoteComponent, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
 import { isEmptySqon, resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
-import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
 import { Space, Tabs, Typography } from 'antd';
 import copy from 'copy-to-clipboard';
-import { useBiospecimen } from 'graphql/biospecimens/actions';
+import { useTotalBiospecimens } from 'graphql/biospecimens/actions';
 import { INDEXES } from 'graphql/constants';
-import { useDataFiles } from 'graphql/files/actions';
-import { useParticipants } from 'graphql/participants/actions';
+import { useTotalDataFiles } from 'graphql/files/actions';
+import { useTotalParticipants } from 'graphql/participants/actions';
 import { IParticipantResultTree } from 'graphql/participants/models';
 import { GET_PARTICIPANT_COUNT } from 'graphql/participants/queries';
-import { isEmpty } from 'lodash';
 import DataFilesTabs from 'views/DataExploration/components/PageContent/tabs/DataFiles';
 import ParticipantsTab from 'views/DataExploration/components/PageContent/tabs/Participants';
 import SummaryTab from 'views/DataExploration/components/PageContent/tabs/Summary';
-import {
-  DATA_EXPLORATION_QB_ID,
-  DEFAULT_PAGE_INDEX,
-  DEFAULT_QUERY_CONFIG,
-  TAB_IDS,
-} from 'views/DataExploration/utils/constant';
+import { DATA_EXPLORATION_QB_ID, TAB_IDS } from 'views/DataExploration/utils/constant';
 
 import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
@@ -105,52 +98,9 @@ const PageContent = ({
     undefined,
   );
 
-  const [participantQueryConfig, setParticipantQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
-  const [biospecimenQueryConfig, setBiospecimenQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
-  const [datafilesQueryConfig, setDatafilesQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
-
   const participantResolvedSqon = resolveSqonForParticipants(queryList, activeQuery);
   const biospecimenResolvedSqon = resolveSqonForBiospecimens(queryList, activeQuery);
   const fileResolvedSqon = resolveSqonForFiles(queryList, activeQuery);
-
-  const participantResults = useParticipants({
-    first: participantQueryConfig.size,
-    offset: participantQueryConfig.size * (participantQueryConfig.pageIndex - 1),
-    sqon: participantResolvedSqon,
-    sort: isEmpty(participantQueryConfig.sort)
-      ? [{ field: 'participant_id', order: SortDirection.Asc }]
-      : participantQueryConfig.sort,
-  });
-
-  const fileResults = useDataFiles({
-    first: datafilesQueryConfig.size,
-    offset: datafilesQueryConfig.size * (datafilesQueryConfig.pageIndex - 1),
-    sqon: fileResolvedSqon,
-    sort: isEmpty(datafilesQueryConfig.sort)
-      ? [{ field: 'file_id', order: SortDirection.Asc }]
-      : datafilesQueryConfig.sort,
-  });
-
-  const biospecimenResults = useBiospecimen({
-    first: biospecimenQueryConfig.size,
-    offset: biospecimenQueryConfig.size * (biospecimenQueryConfig.pageIndex - 1),
-    sqon: biospecimenResolvedSqon,
-    sort: isEmpty(biospecimenQueryConfig.sort)
-      ? [{ field: 'sample_id', order: SortDirection.Asc }]
-      : biospecimenQueryConfig.sort,
-  });
-
-  useEffect(() => {
-    setParticipantQueryConfig({
-      ...participantQueryConfig,
-      pageIndex: DEFAULT_PAGE_INDEX,
-    });
-    setDatafilesQueryConfig({
-      ...datafilesQueryConfig,
-      pageIndex: DEFAULT_PAGE_INDEX,
-    });
-    // eslint-disable-next-line
-  }, [JSON.stringify(activeQuery)]);
 
   const facetTransResolver = (key: string) => {
     const title = intl.get(`facets.${key}`);
@@ -258,7 +208,6 @@ const PageContent = ({
         enableShowHideLabels
         IconTotal={<UserOutlined size={18} />}
         currentQuery={isEmptySqon(activeQuery) ? {} : activeQuery}
-        total={participantResults.total}
         dictionary={getQueryBuilderDictionary(facetTransResolver, savedSets)}
         getResolvedQueryForCount={(sqon) => resolveSqonForParticipants(queryList, sqon)}
         fetchQueryCount={async (sqon) => {
@@ -301,54 +250,39 @@ const PageContent = ({
             <span>
               <UserOutlined />
               {intl.get('screen.dataExploration.tabs.participants.title', {
-                count: numberWithCommas(participantResults.total),
+                count: numberWithCommas(useTotalParticipants({ sqon: participantResolvedSqon })),
               })}
             </span>
           }
           key={TAB_IDS.PARTICIPANTS}
         >
-          <ParticipantsTab
-            results={participantResults}
-            setQueryConfig={setParticipantQueryConfig}
-            queryConfig={participantQueryConfig}
-            sqon={participantResolvedSqon}
-          />
+          <ParticipantsTab sqon={participantResolvedSqon} />
         </Tabs.TabPane>
         <Tabs.TabPane
           tab={
             <span>
               <ExperimentOutlined />
               {intl.get('screen.dataExploration.tabs.biospecimens.title', {
-                count: numberWithCommas(biospecimenResults.total),
+                count: numberWithCommas(useTotalBiospecimens({ sqon: biospecimenResolvedSqon })),
               })}
             </span>
           }
           key={TAB_IDS.BIOSPECIMENS}
         >
-          <BioSpecimenTab
-            results={biospecimenResults}
-            setQueryConfig={setBiospecimenQueryConfig}
-            queryConfig={biospecimenQueryConfig}
-            sqon={biospecimenResolvedSqon}
-          />
+          <BioSpecimenTab sqon={biospecimenResolvedSqon} />
         </Tabs.TabPane>
         <Tabs.TabPane
           tab={
             <span>
               <FileTextOutlined />
               {intl.get('screen.dataExploration.tabs.datafiles.title', {
-                count: numberWithCommas(fileResults.total),
+                count: numberWithCommas(useTotalDataFiles({ sqon: fileResolvedSqon })),
               })}
             </span>
           }
           key={TAB_IDS.DATA_FILES}
         >
-          <DataFilesTabs
-            results={fileResults}
-            setQueryConfig={setDatafilesQueryConfig}
-            queryConfig={datafilesQueryConfig}
-            sqon={fileResolvedSqon}
-          />
+          <DataFilesTabs sqon={fileResolvedSqon} />
         </Tabs.TabPane>
       </Tabs>
     </Space>

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -5,21 +5,20 @@ import { DownloadOutlined } from '@ant-design/icons';
 import ColorTag, { ColorTagType } from '@ferlab/ui/core/components/ColorTag';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import ProTable from '@ferlab/ui/core/components/ProTable';
+import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
 import useQueryBuilderState, {
   addQuery,
 } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import {
-  IArrangerResultsTree,
-  IQueryConfig,
-  IQueryResults,
-  TQueryConfigCb,
-} from '@ferlab/ui/core/graphql/types';
-import { Button, Dropdown, Menu, Tag, Tooltip } from 'antd';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
+import { Button, Dropdown, Menu, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
+import { useParticipants } from 'graphql/participants/actions';
 import {
   IParticipantDiagnosis,
   IParticipantEntity,
@@ -33,7 +32,11 @@ import { capitalize } from 'lodash';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import {
   DATA_EXPLORATION_QB_ID,
+  DEFAULT_OFFSET,
+  DEFAULT_PAGE_INDEX,
   DEFAULT_PAGE_SIZE,
+  DEFAULT_PARTICIPANT_QUERY_SORT,
+  DEFAULT_QUERY_CONFIG,
   PARTICIPANTS_SAVED_SETS_FIELD,
   SCROLL_WRAPPER_ID,
 } from 'views/DataExploration/utils/constant';
@@ -57,9 +60,6 @@ import { getProTableDictionary } from 'utils/translation';
 import styles from './index.module.scss';
 
 interface OwnProps {
-  results: IQueryResults<IParticipantEntity[]>;
-  setQueryConfig: TQueryConfigCb;
-  queryConfig: IQueryConfig;
   sqon?: ISqonGroupFilter;
 }
 
@@ -441,34 +441,48 @@ const defaultColumns: ProColumnType[] = [
   },
 ];
 
-const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProps) => {
+const ParticipantsTab = ({ sqon }: OwnProps) => {
   const dispatch = useDispatch();
   const { userInfo } = useUser();
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
   const { activeQuery } = useQueryBuilderState(DATA_EXPLORATION_QB_ID);
   const [selectedAllResults, setSelectedAllResults] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [selectedRows, setSelectedRows] = useState<IParticipantEntity[]>([]);
-
-  useEffect(() => {
-    if (selectedKeys.length) {
-      setSelectedKeys([]);
-      setSelectedRows([]);
-    }
-    // eslint-disable-next-line
-  }, [JSON.stringify(activeQuery)]);
+  const [queryConfig, setQueryConfig] = useState({
+    ...DEFAULT_QUERY_CONFIG,
+    sort: DEFAULT_PARTICIPANT_QUERY_SORT,
+    size:
+      userInfo?.config?.data_exploration?.tables?.participants?.viewPerQuery || DEFAULT_PAGE_SIZE,
+  });
+  const results = useParticipants(
+    {
+      first: queryConfig.size,
+      offset: DEFAULT_OFFSET,
+      searchAfter: queryConfig.searchAfter,
+      sqon,
+      sort: tieBreaker({
+        sort: queryConfig.sort,
+        defaultSort: DEFAULT_PARTICIPANT_QUERY_SORT,
+        field: 'participant_id',
+        order: queryConfig.operations?.previous ? SortDirection.Desc : SortDirection.Asc,
+      }),
+    },
+    queryConfig.operations,
+  );
 
   const getCurrentSqon = (): any =>
     selectedAllResults || !selectedKeys.length
       ? sqon
       : generateQuery({
-          newFilters: [
-            generateValueFilter({
-              field: PARTICIPANTS_SAVED_SETS_FIELD,
-              index: INDEXES.PARTICIPANT,
-              value: selectedRows.map((row) => row[PARTICIPANTS_SAVED_SETS_FIELD]),
-            }),
-          ],
-        });
+        newFilters: [
+          generateValueFilter({
+            field: PARTICIPANTS_SAVED_SETS_FIELD,
+            index: INDEXES.PARTICIPANT,
+            value: selectedRows.map((row) => row[PARTICIPANTS_SAVED_SETS_FIELD]),
+          }),
+        ],
+      });
 
   const menu = (
     <Menu
@@ -495,6 +509,25 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
     />
   );
 
+  useEffect(() => {
+    if (selectedKeys.length) {
+      setSelectedKeys([]);
+      setSelectedRows([]);
+    }
+    // eslint-disable-next-line
+  }, [JSON.stringify(activeQuery)]);
+
+  useEffect(() => {
+    if (queryConfig.firstPageFlag !== undefined || queryConfig.searchAfter === undefined) {
+      return;
+    }
+
+    setQueryConfig({
+      ...queryConfig,
+      firstPageFlag: queryConfig.searchAfter,
+    });
+  }, [queryConfig]);
+
   return (
     <ProTable<ITableParticipantEntity>
       tableId="participants_table"
@@ -505,16 +538,17 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
       enableRowSelection={true}
       initialSelectedKey={selectedKeys}
       showSorterTooltip={false}
-      onChange={({ current, pageSize }, _, sorter) =>
+      onChange={(_pagination, _filter, sorter) => {
+        setPageIndex(DEFAULT_PAGE_INDEX);
         setQueryConfig({
-          pageIndex: current!,
-          size: pageSize!,
+          pageIndex: DEFAULT_PAGE_INDEX,
+          size: queryConfig.size!,
           sort: formatQuerySortList(sorter),
-        })
-      }
+        });
+      }}
       headerConfig={{
         itemCount: {
-          pageIndex: queryConfig.pageIndex,
+          pageIndex: pageIndex,
           pageSize: queryConfig.size,
           total: results.total,
         },
@@ -569,11 +603,29 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
       bordered
       size="small"
       pagination={{
-        current: queryConfig.pageIndex,
-        pageSize: queryConfig.size,
-        defaultPageSize: DEFAULT_PAGE_SIZE,
-        total: results.total,
-        onChange: () => scrollToTop(SCROLL_WRAPPER_ID),
+        current: pageIndex,
+        queryConfig,
+        setQueryConfig,
+        onChange: (page: number) => {
+          scrollToTop(SCROLL_WRAPPER_ID);
+          setPageIndex(page);
+        },
+        searchAfter: results.searchAfter,
+        onViewQueryChange: (viewPerQuery: PaginationViewPerQuery) => {
+          dispatch(
+            updateUserConfig({
+              data_exploration: {
+                tables: {
+                  participants: {
+                    ...userInfo?.config.data_exploration?.tables?.participants,
+                    viewPerQuery,
+                  },
+                },
+              },
+            }),
+          );
+        },
+        defaultViewPerQuery: queryConfig.size,
       }}
       dataSource={results.data.map((i) => ({ ...i, key: i.participant_id }))}
       dictionary={getProTableDictionary()}

--- a/src/views/DataExploration/utils/constant.ts
+++ b/src/views/DataExploration/utils/constant.ts
@@ -1,4 +1,7 @@
-import { IQueryConfig } from '@ferlab/ui/core/graphql/types';
+import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { IQueryConfig, ISort } from '@ferlab/ui/core/graphql/types';
+
 import { SavedFilterTag } from 'services/api/savedFilter/models';
 
 export const PARTICIPANTS_SAVED_SETS_FIELD = 'participant_id';
@@ -7,8 +10,9 @@ export const BIOSPECIMENS_SAVED_SETS_FIELD = 'fhir_id';
 
 export const DATA_EXPLORATION_QB_ID = 'data-exploration-repo-key';
 
+export const DEFAULT_OFFSET = 0;
 export const DEFAULT_PAGE_INDEX = 1;
-export const DEFAULT_PAGE_SIZE = 20;
+export const DEFAULT_PAGE_SIZE = PaginationViewPerQuery.Twenty;
 
 export const CAVATICA_FILE_BATCH_SIZE = 10000;
 
@@ -19,10 +23,23 @@ export const DEFAULT_PAGING_CONFIG = {
   size: DEFAULT_PAGE_SIZE,
 };
 
+export const DEFAULT_PARTICIPANT_QUERY_SORT = [
+  { field: 'participant_id', order: SortDirection.Asc },
+] as ISort[];
+
+export const DEFAULT_BIOSPECIMEN_QUERY_SORT = [
+  { field: 'sample_id', order: SortDirection.Asc },
+] as ISort[];
+
+export const DEFAULT_FILE_QUERY_SORT = [{ field: 'file_id', order: SortDirection.Asc }] as ISort[];
+
 export const DEFAULT_QUERY_CONFIG: IQueryConfig = {
   pageIndex: DEFAULT_PAGE_INDEX,
   size: DEFAULT_PAGE_SIZE,
   sort: [],
+  searchAfter: undefined,
+  firstPageFlag: undefined,
+  operations: undefined,
 };
 
 export const SCROLL_WRAPPER_ID = 'data-explore-scroll-wrapper';

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -233,14 +233,14 @@ const VariantsTable = ({
     selectedAllResults || !selectedKeys.length
       ? sqon
       : generateQuery({
-        newFilters: [
-          generateValueFilter({
-            field: 'locus',
-            index: INDEXES.VARIANTS,
-            value: selectedRows.map((row) => row.locus),
-          }),
-        ],
-      });
+          newFilters: [
+            generateValueFilter({
+              field: 'locus',
+              index: INDEXES.VARIANTS,
+              value: selectedRows.map((row) => row.locus),
+            }),
+          ],
+        });
 
   useEffect(() => {
     if (selectedKeys.length) {
@@ -262,7 +262,7 @@ const VariantsTable = ({
           loading={results.loading}
           initialSelectedKey={selectedKeys}
           showSorterTooltip={false}
-          onChange={({ current }, _, sorter) => {
+          onChange={(_pagination, _filter, sorter) => {
             setPageIndex(DEFAULT_PAGE_INDEX);
             setQueryConfig({
               pageIndex: DEFAULT_PAGE_INDEX,


### PR DESCRIPTION
# FEAT

- closes #[656](https://d3b.atlassian.net/browse/SKFP-656)

## Description
Les données de data-exploration dépassent les 10 000 résultats. Le search after a donc été implémenté.


## Screenshot (Before and After)
![image](https://user-images.githubusercontent.com/65532894/227597704-92533f29-f5c6-4d3f-8fcf-bdcc4fc741d5.png)

