### PR TITLE
:bug: BACKPORT-9 display study_code vs study_id in variant entity page

### DIFF
--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -34,8 +34,8 @@ type TInternalRow = {
 
 export const getFrequenciesItems = (): ProColumnType[] => [
   {
-    dataIndex: 'study_id',
-    key: 'study_id',
+    dataIndex: 'study_code',
+    key: 'study_code',
     title: intl.get('screen.variants.frequencies.studies'),
     render: (study_id: string) => study_id,
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54366437/233722093-71d6871f-aa01-47d8-9db4-1611264572d5.png)
