### PR TITLE
feat(entity): SKFP-695 SKFP-696 add tile and header extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.0.1",
+        "@ferlab/ui": "^7.3.0",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/core": "^0.80.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.0.1.tgz",
-      "integrity": "sha512-QG0CgGidKmu733jTLG9JHRtOE7sp49BubbGbBR5/utm8I7e9RwtaS7IpZVzeKy9wvEzbY+SQrQ9IhKotAP0z0w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.3.0.tgz",
+      "integrity": "sha512-uiWrMGEm4XJ6ddVb/BFYn37UpHGkR6W+w92fgIaUKn1QmS8h7SGo0g0CAJYlwiW2db5yGDnda4RDfmQwi05KyA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -35669,9 +35669,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.0.1.tgz",
-      "integrity": "sha512-QG0CgGidKmu733jTLG9JHRtOE7sp49BubbGbBR5/utm8I7e9RwtaS7IpZVzeKy9wvEzbY+SQrQ9IhKotAP0z0w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.3.0.tgz",
+      "integrity": "sha512-uiWrMGEm4XJ6ddVb/BFYn37UpHGkR6W+w92fgIaUKn1QmS8h7SGo0g0CAJYlwiW2db5yGDnda4RDfmQwi05KyA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.0.1",
+    "@ferlab/ui": "^7.3.0",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.80.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -23,6 +23,7 @@ const en = {
       '{years, plural, =0 {} =1 {# <span style="font-size: 12px">year</span>} other {# <span style="font-size: 12px">years</span>}} {days, plural, =0 {} =1 {# <span style="font-size: 12px">day</span>} other {# <span style="font-size: 12px">days</span>}}',
   },
   global: {
+    viewInDataExploration: 'View in data exploration',
     yes: 'Yes',
     no: 'No',
     connect: 'Connect',

--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -1,7 +1,12 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
-import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { EntityTable, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 import { SectionId } from 'views/FileEntity/utils/anchorLinks';
 import {
   getBiospecimenColumns,
@@ -10,6 +15,7 @@ import {
 
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
+import { STATIC_ROUTES } from 'utils/routes';
 
 interface OwnProps {
   file?: IFileEntity;
@@ -27,7 +33,32 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
       id={SectionId.PARTICIPANT_SAMPLE}
       loading={loading}
       data={biospecimens}
+      total={biospecimens.length}
       title={intl.get('entities.file.participant_sample.title')}
+      titleExtra={[
+        <EntityTableRedirectLink
+          key="1"
+          to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+          onClick={() =>
+            addQuery({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              query: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'file_id',
+                    value: file ? [file.file_id] : [],
+                    index: INDEXES.FILES,
+                  }),
+                ],
+              }),
+              setAsActive: true,
+            })
+          }
+          icon={<ExternalLinkIcon width={14} />}
+        >
+          {intl.get('global.viewInDataExploration')}
+        </EntityTableRedirectLink>,
+      ]}
       header={intl.get('entities.file.participant_sample.title')}
       columns={getBiospecimenColumns()}
       initialColumnState={userInfo?.config.files?.tables?.biospecimens?.columns}

--- a/src/views/ParticipantEntity/BiospecimensTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimensTable/index.tsx
@@ -1,13 +1,17 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { EntityTable, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
 import { useBiospecimenParticipant } from 'graphql/biospecimens/actions';
 import { INDEXES } from 'graphql/constants';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import { getBiospecimensDefaultColumns } from '../utils/biospecimens';
 import { SectionId } from '..';
@@ -20,7 +24,7 @@ const BiospecimensTable = ({ id }: OwnProps) => {
   const { userInfo } = useUser();
   const dispatch = useDispatch();
 
-  const { data, loading } = useBiospecimenParticipant({
+  const { data, loading, total } = useBiospecimenParticipant({
     field: 'participant.participant_id',
     values: [id],
   });
@@ -30,7 +34,32 @@ const BiospecimensTable = ({ id }: OwnProps) => {
       id={SectionId.BIOSPECIMEN}
       loading={loading}
       data={data}
+      total={total}
       title={intl.get('screen.participantEntity.biospecimen.title')}
+      titleExtra={[
+        <EntityTableRedirectLink
+          key="1"
+          to={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
+          icon={<ExternalLinkIcon width={14} />}
+          onClick={() =>
+            addQuery({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              query: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    value: [id],
+                    index: INDEXES.PARTICIPANT,
+                  }),
+                ],
+              }),
+              setAsActive: true,
+            })
+          }
+        >
+          {intl.get('global.viewInDataExploration')}
+        </EntityTableRedirectLink>,
+      ]}
       header={intl.get('screen.participantEntity.biospecimen.title')}
       columns={getBiospecimensDefaultColumns()}
       initialColumnState={userInfo?.config.participant?.tables?.biospecimens?.columns}

--- a/src/views/ParticipantEntity/DiagnosisTable/index.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/index.tsx
@@ -1,15 +1,17 @@
-import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
-import { IParticipantEntity } from 'graphql/participants/models';
 import intl from 'react-intl-universal';
-import { SectionId } from '..';
-import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
-import { getDiagnosisDefaultColumns } from '../utils/diagnosis';
-import { useUser } from 'store/user';
 import { useDispatch } from 'react-redux';
-import { updateUserConfig } from 'store/user/thunks';
-import { fetchTsvReport } from 'store/report/thunks';
-import { INDEXES } from 'graphql/constants';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
+import { IParticipantEntity } from 'graphql/participants/models';
+
+import { fetchTsvReport } from 'store/report/thunks';
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+
+import { getDiagnosisDefaultColumns } from '../utils/diagnosis';
+import { SectionId } from '..';
 
 const COLUMNS_PREFIX = 'diagnosis.';
 
@@ -23,16 +25,19 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
   const dispatch = useDispatch();
   const diagnosis = hydrateResults(participant?.diagnosis?.hits?.edges || []);
 
-  const initialColumnState = (userInfo?.config.participant?.tables?.diagnosis?.columns || []).map(column => ({
-    ...column,
-    key: column.key.replace(COLUMNS_PREFIX, '')
-  }))
+  const initialColumnState = (userInfo?.config.participant?.tables?.diagnosis?.columns || []).map(
+    (column) => ({
+      ...column,
+      key: column.key.replace(COLUMNS_PREFIX, ''),
+    }),
+  );
 
   return (
     <EntityTable
       id={SectionId.DIAGNOSIS}
       loading={loading}
       data={diagnosis}
+      total={diagnosis.length}
       title={intl.get('screen.participantEntity.diagnosis.title')}
       header={intl.get('screen.participantEntity.diagnosis.title')}
       columns={getDiagnosisDefaultColumns()}
@@ -46,10 +51,13 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
               participant: {
                 tables: {
                   diagnosis: {
-                    columns: newState.map(column => ({ ...column, key: `${COLUMNS_PREFIX}${column.key}` }))
-                  }
-                }
-              }
+                    columns: newState.map((column) => ({
+                      ...column,
+                      key: `${COLUMNS_PREFIX}${column.key}`,
+                    })),
+                  },
+                },
+              },
             }),
           ),
         onTableExportClick: () =>
@@ -71,8 +79,7 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
           ),
       }}
     />
-  )
-
-}
+  );
+};
 
 export default DiagnosisTable;

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -1,15 +1,17 @@
-import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
-import { IParticipantEntity } from 'graphql/participants/models';
 import intl from 'react-intl-universal';
-import { SectionId } from '..';
-import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
-import { useUser } from 'store/user';
 import { useDispatch } from 'react-redux';
-import { updateUserConfig } from 'store/user/thunks';
-import { fetchTsvReport } from 'store/report/thunks';
-import { INDEXES } from 'graphql/constants';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
+import { IParticipantEntity } from 'graphql/participants/models';
+
+import { fetchTsvReport } from 'store/report/thunks';
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+
 import { getPhenotypeDefaultColumns } from '../utils/phenotype';
+import { SectionId } from '..';
 
 const COLUMNS_PREFIX = 'phenotype.';
 
@@ -18,22 +20,24 @@ interface OwnProps {
   loading: boolean;
 }
 
-
 const PhenotypesTable = ({ participant, loading }: OwnProps) => {
   const { userInfo } = useUser();
   const dispatch = useDispatch();
   const phenotypes = hydrateResults(participant?.phenotype?.hits?.edges || []);
 
-  const initialColumnState = (userInfo?.config.participant?.tables?.phenotype?.columns || []).map(column => ({
-    ...column,
-    key: column.key.replace(COLUMNS_PREFIX, '')
-  }))
+  const initialColumnState = (userInfo?.config.participant?.tables?.phenotype?.columns || []).map(
+    (column) => ({
+      ...column,
+      key: column.key.replace(COLUMNS_PREFIX, ''),
+    }),
+  );
 
   return (
     <EntityTable
       id={SectionId.PHENOTYPE}
       loading={loading}
       data={phenotypes}
+      total={phenotypes.length}
       title={intl.get('screen.participantEntity.phenotype.title')}
       header={intl.get('screen.participantEntity.phenotype.title')}
       columns={getPhenotypeDefaultColumns()}
@@ -47,10 +51,13 @@ const PhenotypesTable = ({ participant, loading }: OwnProps) => {
               participant: {
                 tables: {
                   phenotype: {
-                    columns: newState.map(column => ({ ...column, key: `${COLUMNS_PREFIX}${column.key}` }))
-                  }
-                }
-              }
+                    columns: newState.map((column) => ({
+                      ...column,
+                      key: `${COLUMNS_PREFIX}${column.key}`,
+                    })),
+                  },
+                },
+              },
             }),
           ),
         onTableExportClick: () =>
@@ -72,8 +79,7 @@ const PhenotypesTable = ({ participant, loading }: OwnProps) => {
           ),
       }}
     />
-  )
-
-}
+  );
+};
 
 export default PhenotypesTable;

--- a/src/views/ParticipantEntity/SummaryHeader/index.tsx
+++ b/src/views/ParticipantEntity/SummaryHeader/index.tsx
@@ -4,13 +4,12 @@ import { FileTextOutlined, ReadOutlined } from '@ant-design/icons';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { INDEXES } from 'graphql/constants';
+import { IParticipantEntity } from 'graphql/participants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { STATIC_ROUTES } from 'utils/routes';
 
 import styles from './index.module.scss';
-import { IParticipantEntity } from 'graphql/participants/models';
-
 
 interface OwnProps {
   data?: IParticipantEntity;

--- a/src/views/ParticipantEntity/index.tsx
+++ b/src/views/ParticipantEntity/index.tsx
@@ -3,19 +3,25 @@ import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { DownloadOutlined, UserOutlined } from '@ant-design/icons';
 import { IAnchorLink } from '@ferlab/ui/core/components/AnchorMenu';
+import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import EntityPageWrapper, {
   EntityDescriptions,
   EntityTableMultiple,
+  EntityTableRedirectLink,
   EntityTitle,
 } from '@ferlab/ui/core/pages/EntityPage';
 import { Button, Dropdown, Menu, Tag } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
 import { useParticipantEntity } from 'graphql/participants/actions';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
 
 import { ReportType } from 'services/api/reports/models';
 import { fetchReport } from 'store/report/thunks';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import {
   getDataTypeColumns,
@@ -161,7 +167,32 @@ const ParticipantEntity = () => {
         <EntityTableMultiple
           id={SectionId.DATAFILE}
           loading={loading}
+          total={files.length}
           title={intl.get('screen.participantEntity.files.dataFile')}
+          titleExtra={[
+            <EntityTableRedirectLink
+              key="1"
+              to={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
+              onClick={() =>
+                addQuery({
+                  queryBuilderId: DATA_EXPLORATION_QB_ID,
+                  query: generateQuery({
+                    newFilters: [
+                      generateValueFilter({
+                        field: 'participant_id',
+                        value: [id],
+                        index: INDEXES.PARTICIPANT,
+                      }),
+                    ],
+                  }),
+                  setAsActive: true,
+                })
+              }
+              icon={<ExternalLinkIcon width={14} />}
+            >
+              {intl.get('global.viewInDataExploration')}
+            </EntityTableRedirectLink>,
+          ]}
           header={intl.get('screen.participantEntity.files.dataFile')}
           tables={[
             {


### PR DESCRIPTION
# FEATURE  

- closes #[695](https://d3b.atlassian.net/browse/SKFP-695)
- closes #[696](https://d3b.atlassian.net/browse/SKFP-696)

## Description
Goal: Similar to the Statistic buttons that are used to redirect to the Data Exploration, we will add a button “View in data exploration” on the right side of the table title for the respective entities. The filter to the Data Exploration page will be the same as the filters in the statistic button for the respective entity. 

Participant Entity tables:

Biospecimen (query = Participant ID, tab = Biospecimens)

Data File (query = Participant ID, tab = Data Files)

File Entity tables:

Participant / Sample  (query = File ID, tab = Participants)

----

Applies to KF/INCLUDE. Already implemented in FerlabUI

Goal:  Add number of total row items per table and place it beside the respective Table titles. 

This applies to the Diagnosis, Phenotype, Biospecimen Data File in Participant Entity page. 

This applies to the Participant / Sample table in the File Entity page

In the case of Data files table, since the files are not enumerated per row, take the total number of files associated with the Entity. 

For CQDG, There is an additional table that would need this feature, Files Generated by the Analysis, in the File Entity page which doesn’t appear in KF/INCLUDE.

Do not indicate the number “0” beside the table title if there is no data in the table.


## Screenshot 
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/91426823-c942-431b-9e79-5d8eb9cc9454)
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/ae5cf05c-d60c-4a82-a524-ff042637b155)



