### PR TITLE
fix(HPO/MONDO): SKFP-686 fix overlap

### DIFF
--- a/src/views/DataExploration/components/TreeFacet/index.module.scss
+++ b/src/views/DataExploration/components/TreeFacet/index.module.scss
@@ -6,6 +6,7 @@
     width: auto;
     height: auto;
     min-height: 600px;
+    overflow: hidden;
 
     .highlight {
       background-color: yellow;


### PR DESCRIPTION
#[BUG]
[SKFP-686](https://d3b.atlassian.net/browse/SKFP-686)

## Description
On a small screen, if you open for example the "Observed Phenotype (HPO) Browser" modal you can see the second column of selected items overlap and get out of the modal.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [x] Design/UI Approved from design

## Screenshot 
### Before
![image](https://github.com/kids-first/kf-portal-ui/assets/133775440/11293f58-50fa-403a-b746-84e88941bc40)

### After
I share with Lucas the behavior because now we have a scrollbar on the first column but we can access to the action item in the second column. He validate this behavior.
![image](https://github.com/kids-first/kf-portal-ui/assets/133775440/5cedd688-89ac-45d0-a2ee-0b69ee8214f4)



[SKFP-686]: https://d3b.atlassian.net/browse/SKFP-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ