### PR TITLE
fix(modal/form): SKFP-697-form-input-label-color

### DIFF
--- a/src/components/Cavatica/CreateProjectModal/index.tsx
+++ b/src/components/Cavatica/CreateProjectModal/index.tsx
@@ -1,15 +1,14 @@
-import Empty from '@ferlab/ui/core/components/Empty';
-import { Form, Input, Modal, Select, Typography } from 'antd';
 import { useEffect, useState } from 'react';
+import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { Form, Input, Modal, Select } from 'antd';
+
 import { useFenceCavatica } from 'store/fenceCavatica';
 import { fenceCavaticaActions } from 'store/fenceCavatica/slice';
 import { createProjet, fetchAllBillingGroups } from 'store/fenceCavatica/thunks';
-import intl from 'react-intl-universal';
 
 import styles from './index.module.scss';
-
-const { Text } = Typography;
 
 interface OwnProps {
   openAnalyseModalOnClose?: boolean;
@@ -89,7 +88,7 @@ const CreateProjectModal = ({
       >
         <Form.Item
           name={FORM_FIELDS.PROJECT_NAME}
-          label={<Text strong>Project name</Text>}
+          label="Project name"
           rules={[{ required: true, type: 'string' }]}
           required={false}
         >
@@ -97,7 +96,7 @@ const CreateProjectModal = ({
         </Form.Item>
         <Form.Item
           name={FORM_FIELDS.PROJECT_BILLING_GROUP}
-          label={<Text strong>Project billing group</Text>}
+          label="Project billing group"
           rules={[{ required: true, type: 'string' }]}
           required={false}
           className={styles.billingGroupItem}

--- a/src/style/themes/kids-first/antd/form.less
+++ b/src/style/themes/kids-first/antd/form.less
@@ -1,11 +1,15 @@
 .@{form-prefix-cls} {
-    &-item {
-        &.noMargin {
-            margin-bottom: 0;
-        }
-
-        &-optional {
-            font-weight: 400;
-        }
+  &-item {
+    &.noMargin {
+      margin-bottom: 0;
     }
+
+    &-optional {
+      font-weight: 400;
+    }
+
+    &-label > label {
+      color: @body-1;
+    }
+  }
 }

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -28,7 +28,7 @@ import {
   mapFilterForParticipant,
 } from 'utils/fieldMapper';
 
-import { BiospecimenCollectionSearch, BiospecimenSearch } from './components/BiospecimenSearch';
+import { BiospecimenSearch } from './components/BiospecimenSearch';
 import BiospecimenSetSearch from './components/BiospecimenSetSearch';
 import FileSearch from './components/FileSearch';
 import FileSetSearch from './components/FileSetSearch';


### PR DESCRIPTION
[SKFP-697](https://d3b.atlassian.net/browse/SKFP-697)

## Description

Fix input label color in modal form.
I have removed the `Text` element in create project modal because it's not needed to have the right style now.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
![image](https://github.com/kids-first/kf-portal-ui/assets/133775440/d75eec36-4615-4955-8cb9-8fcd3bd24a1f)

### After
![image](https://github.com/kids-first/kf-portal-ui/assets/133775440/6dc08960-d1ab-4841-abd0-536d36e3d4d6)


[SKFP-697]: https://d3b.atlassian.net/browse/SKFP-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ