### PR TITLE
fix: SKFP-702 Only display 1 experimental strategy

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.test.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.test.tsx
@@ -1,0 +1,122 @@
+import { IFileEntity } from 'graphql/files/models';
+
+import { getDefaultColumns } from './index';
+describe('getDefaultColumns', () => {
+  let fileEntity = {} as IFileEntity;
+
+  beforeEach(() => {
+    fileEntity = {
+      id: 'fileId',
+      acl: [],
+      //@ts-ignore
+      biospecimens: { hits: { edges: [{ node: { id: 'test' } }] } },
+      controlled_access: '',
+      access_urls: '',
+      data_category: '',
+      data_type: '',
+      external_id: '',
+      fhir_document_reference: '',
+      fhir_id: '',
+      file_format: '',
+      file_id: '',
+      file_name: '',
+      hashes: {
+        etag: '',
+        md5: '',
+      },
+      is_harmonized: false,
+      nb_participants: 3,
+      nb_biospecimens: 3,
+      participants: {
+        hits: {
+          edges: [
+            {
+              //@ts-ignore is irrelevant for this test
+              node: {},
+            },
+          ],
+        },
+      },
+      repository: '',
+      study: {
+        id: 'study test',
+        study_id: 'study test',
+        fhir_id: 'study test',
+        study_code: 'study test',
+        study_name: 'study test',
+        external_id: 'study test',
+        experimental_strategy: [],
+        family_count: 4,
+        participant_count: 4,
+        biospecimen_count: 4,
+        data_category: [],
+        family_data: false,
+        controlled_access: [],
+      },
+      score: 3,
+      sequencing_experiment: {
+        hits: {
+          edges: [
+            {
+              node: {
+                id: 'seqtest',
+                sequencing_experiment_id: 'seq test',
+                experiment_strategy: 'seq test',
+                center: 'seq test',
+                library_name: 'seq test',
+                library_prep: 'seq test',
+                library_selection: 'seq test',
+                library_strand: 'seq test',
+                platform: 'seq test',
+                instrument_model: 'seq test',
+                sequencing_center_id: 'seq test',
+              },
+            },
+            {
+              node: {
+                id: 'seqtest 2',
+                sequencing_experiment_id: 'seq test 2',
+                experiment_strategy: 'seq test 2',
+                center: 'seq test 2',
+                library_name: 'seq test 2',
+                library_prep: 'seq test 2',
+                library_selection: 'seq test 2',
+                library_strand: 'seq test 2',
+                platform: 'seq test 2',
+                instrument_model: 'seq test 2',
+                sequencing_center_id: 'seq test 2',
+              },
+            },
+          ],
+        },
+      },
+      size: 3,
+    };
+  });
+
+  test('sequencing experiment render should only disply first element', () => {
+    const defaultColumns = getDefaultColumns([], false, false);
+    const result = defaultColumns.filter(
+      (column) => column.key === 'sequencing_experiment.experiment_strategy',
+    );
+    let seqExp = null;
+    //@ts-ignore render has badly defined expected type
+    seqExp = result?.length > 0 ? result[0].render(fileEntity) : undefined;
+
+    expect(seqExp).toEqual('seq test');
+  });
+
+  test('sequencing experiment render should display - when no data available', () => {
+    const defaultColumns = getDefaultColumns([], false, false);
+    const result = defaultColumns.filter(
+      (column) => column.key === 'sequencing_experiment.experiment_strategy',
+    );
+    fileEntity.sequencing_experiment.hits.edges = [];
+
+    let seqExp = null;
+    //@ts-ignore render has badly defined expected type
+    seqExp = result?.length > 0 ? result[0].render(fileEntity) : undefined;
+
+    expect(seqExp).toEqual('-');
+  });
+});

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -55,7 +55,7 @@ interface OwnProps {
   sqon?: ISqonGroupFilter;
 }
 
-const getDefaultColumns = (
+export const getDefaultColumns = (
   fenceAcls: string[],
   isConnectedToCavatica: boolean,
   isConnectedToGen3: boolean,
@@ -148,11 +148,9 @@ const getDefaultColumns = (
     title: 'Experimental Strategy',
     sorter: { multiple: 1 },
     render: (record: IFileEntity) =>
-      record.sequencing_experiment
-        ? record.sequencing_experiment.hits?.edges
-            .map((edge) => edge.node.experiment_strategy)
-            .join(', ')
-        : TABLE_EMPTY_PLACE_HOLDER,
+      (record.sequencing_experiment &&
+        record.sequencing_experiment.hits?.edges.at(0)?.node.experiment_strategy) ||
+      TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'file_format',


### PR DESCRIPTION
# BUG | Only display 1 experimental strategy for a file

- closes #SKFP-702

## Description

The sequencing experiment which contains the field experimental strategy can be a list of documents, therefore multiple experimental strategies. This occurs when a VCF file is used to represent a jointGenotyping across family members for example. However, their experimental strategies should always be the same theoretically. Therefore, we will only display 1 experimental strategy for a file in the Data Exploration ta


## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="826" alt="experimental strategy before" src="https://github.com/kids-first/kf-portal-ui/assets/98903/1146aaa2-4eea-4ad3-a051-d30b7c08ecaa">

### After
<img width="875" alt="experimental strategy" src="https://github.com/kids-first/kf-portal-ui/assets/98903/7519a5dd-3a1f-4ea0-8962-2d070b4fb5cd">


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge 
