### PR TITLE
Fix/skfp 634

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -154,15 +154,15 @@ const defaultColumns: ProColumnType[] = [
       multiple: 1,
     },
     render: (record: IVariantEntity) => {
-      const participantNumber = record.participant_number || 0;
+      const participantNumber = record.participant_number_visible || 0;
       if (participantNumber <= 10) {
         return participantNumber;
       }
 
-      const participantIds = record.studies?.hits?.edges?.flatMap(
-        (study) => study.node.participant_ids,
+      const participantIds: string[] = record.studies?.hits?.edges?.flatMap(
+        (study) => study.node.participant_ids !== null ? study.node.participant_ids : []
       );
-
+      
       return (
         <Link
           to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}


### PR DESCRIPTION
# BUG | Participants count mismatch

- closes SKFP-634

## Description

https://d3b.atlassian.net/browse/SKFP-634

This is a partial fix.

Number of participants in the variant table, will only includes non-null ids.
When following the links of participant, the query in data exploration will contains all non null participants ids. (number will match)

But the results of the query can be different because of missing data.

- [ ] Code Approved
- [ ] QA Done

## Screenshot 

### After
![image](https://github.com/kids-first/kf-portal-ui/assets/98903/ab8508db-4355-4288-83d8-b25caf84bd21)

![image](https://github.com/kids-first/kf-portal-ui/assets/98903/7eebfa49-d5ff-4f95-baeb-a7efee421d7f)


## QA
@kstonge 
