### PR TITLE
feat(participant): SKFP-701 fix phenotypes

### DIFF
--- a/src/graphql/participants/actions.ts
+++ b/src/graphql/participants/actions.ts
@@ -1,3 +1,4 @@
+import { DocumentNode } from '@apollo/client';
 import {
   IQueryOperationsConfig,
   IQueryResults,
@@ -13,8 +14,6 @@ import {
   IDataFileResultTree,
   IParticipantEntity,
   IParticipantResultTree,
-  IUseParticipantEntityProps,
-  IUseParticipantEntityResults,
 } from './models';
 import {
   GET_DATA_FILE_AGG,
@@ -22,7 +21,6 @@ import {
   GET_PARTICIPANT_ENTITY,
   SEARCH_PARTICIPANT_QUERY,
 } from './queries';
-import { DocumentNode } from '@apollo/client';
 
 export const useParticipants = (
   variables?: IQueryVariable,

--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -1,5 +1,4 @@
 import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
-import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { IFileEntity } from 'graphql/files/models';
 import { IStudyEntity } from 'graphql/studies/models';
 
@@ -15,14 +14,6 @@ export interface IParticipantDiagnosis {
   diagnosis_category?: string;
   affected_status: boolean;
   diagnosis_id: string;
-}
-
-export interface IParticipantPhenotype {
-  id: string;
-  age_at_event_days: number;
-  fhir_id: string;
-  hpo_phenotype_observed: string;
-  is_observed: boolean;
 }
 
 export interface IParticipantMondo {
@@ -78,7 +69,6 @@ export interface IParticipantFamily {
   family_id: string;
   relations_to_proband: IArrangerResultsTree<IFamilyRelationToProband>;
 }
-
 
 export type ITableParticipantEntity = IParticipantEntity & {
   key: string;
@@ -219,4 +209,3 @@ export interface IDataFileResultTree {
   };
   loading: boolean;
 }
-

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -190,6 +190,9 @@ export const GET_PARTICIPANT_ENTITY = gql`
                     age_at_event_days
                     fhir_id
                     hpo_phenotype_observed
+                    hpo_phenotype_observed_text
+                    hpo_phenotype_not_observed
+                    hpo_phenotype_not_observed_text
                     observed
                     source_text
                   }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -550,8 +550,7 @@ const en = {
         },
         authorizedStudies: {
           title: 'Authorized Studies {count, plural, =0 {} other {(#)}}',
-          connectedNotice:
-            'You have access to the following Kids First controlled data.',
+          connectedNotice: 'You have access to the following Kids First controlled data.',
           disconnectedNotice:
             'To access controlled study files, connect to our data repository partners using your NIH credentials.',
           disconnect: 'Disconnect',
@@ -1414,9 +1413,12 @@ const en = {
       family_unit: 'Family Unit',
       hpo_term: 'HPO Term',
       hpo_term_tooltip: '# of participants with this exact HPO term',
+      interpretation: 'Interpretation',
       mondo_diagnosis: 'Diagnosis (MONDO)',
       mondo_term: 'MONDO Term',
       mondo_term_tooltip: '# of participants with this exact MONDO term',
+      not_observed: 'Not observed',
+      observed: 'Observed',
       other: 'Other',
       participant_id: 'Participant ID',
       phenotype: 'Phenotype',
@@ -1425,7 +1427,7 @@ const en = {
       profile: 'Profile',
       race: 'Race',
       sex: 'Sex',
-      source_text: 'Condition (Source Text)',
+      source_text: 'Phenotype (Source Text)',
       trio: 'Trio',
       trio_plus: ' Trio+',
       trisomy: 'T21: "Trisomy 21"',

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -17,7 +17,7 @@ import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/ut
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Button, Dropdown, Menu, Tooltip } from 'antd';
+import { Button, Dropdown, Menu } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useParticipants } from 'graphql/participants/actions';
 import {
@@ -55,7 +55,7 @@ import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { readableDistanceByDays } from 'utils/dates';
 import { formatQuerySortList, scrollToTop } from 'utils/helper';
-import { DYNAMIC_ROUTES, STATIC_ROUTES } from 'utils/routes';
+import { STATIC_ROUTES } from 'utils/routes';
 import { getProTableDictionary } from 'utils/translation';
 
 import styles from './index.module.scss';

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -2,6 +2,7 @@ import intl from 'react-intl-universal';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { Tag } from 'antd';
 import { IParticipantPhenotype } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
 import { extractPhenotypeTitleAndCode } from 'views/DataExploration/utils/helper';
@@ -15,7 +16,8 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
     key: 'hpo_phenotype_observed',
     title: intl.get('entities.participant.phenotype_hpo'),
     render: (phenotype: IParticipantPhenotype) => {
-      const phenotypeNames = phenotype?.hpo_phenotype_observed;
+      const phenotypeNames =
+        phenotype?.hpo_phenotype_observed || phenotype?.hpo_phenotype_not_observed;
       if (!phenotypeNames || phenotypeNames.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
@@ -47,28 +49,43 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
     title: intl.get('entities.participant.source_text'),
     render: (phenotype: IParticipantPhenotype) =>
       phenotype?.source_text ? phenotype.source_text : TABLE_EMPTY_PLACE_HOLDER,
+    width: '30%',
+  },
+  {
+    key: 'phenotypes_tagged.is_observed',
+    title: intl.get('entities.participant.interpretation'),
+    render: (phenotype: IParticipantPhenotype) => (
+      <Tag color={phenotype?.observed || phenotype.hpo_phenotype_observed ? 'green' : ''}>
+        {phenotype?.observed || phenotype.hpo_phenotype_observed
+          ? intl.get('entities.participant.observed')
+          : intl.get('entities.participant.not_observed')}
+      </Tag>
+    ),
+    width: '15%',
   },
   {
     key: 'age_at_event_days',
     title: intl.get('entities.participant.age'),
     tooltip: intl.get('entities.participant.age_tooltip_phenotype'),
-    render: (diagnosis: IParticipantPhenotype) =>
-      diagnosis.age_at_event_days ? (
-        <AgeCell ageInDays={diagnosis.age_at_event_days} />
+    render: (phenotype: IParticipantPhenotype) =>
+      phenotype.age_at_event_days ? (
+        <AgeCell ageInDays={phenotype.age_at_event_days} />
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),
+    width: '10%',
   },
   {
     key: 'hpo_term',
     title: intl.get('entities.participant.hpo_term'),
     tooltip: intl.get('entities.participant.hpo_term_tooltip'),
-    render: (diagnosis: IParticipantPhenotype) =>
-      diagnosis?.hpo_phenotype_observed ? (
-        <HpoParticipantCount phenotype={diagnosis.hpo_phenotype_observed} />
+    render: (phenotype: IParticipantPhenotype) =>
+      phenotype?.hpo_phenotype_observed ? (
+        <HpoParticipantCount phenotype={phenotype.hpo_phenotype_observed} />
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),
+    width: '10%',
   },
 ];
 

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -18,7 +18,7 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
     render: (phenotype: IParticipantPhenotype) => {
       const phenotypeNames =
         phenotype?.hpo_phenotype_observed || phenotype?.hpo_phenotype_not_observed;
-      if (!phenotypeNames || phenotypeNames.length === 0) {
+      if (!phenotypeNames) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
       return (


### PR DESCRIPTION
#[FEAT] Fix phenotype table in participant entity

- [SKFP-701](https://d3b.atlassian.net/browse/SKFP-701)

## Description

Les phenotypes non observés perdent leur nom dans la page participant entity.
Ajout de la colonne interpretation.
Fix style, largeur de colonnes.

Maquette [ici](https://www.figma.com/file/baxEfYnqjk3d87iQAPEz8S/Pages-Entit%C3%A9s?node-id=223%3A17889&mode=dev)

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1527" alt="Capture d’écran, le 2023-09-19 à 15 00 30" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/f192e60f-7727-4b5d-a58e-48aa70abe456">

### After
<img width="1426" alt="Capture d’écran, le 2023-09-19 à 14 53 25" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b670f8ca-f004-4f66-b171-64839b732bb1">
<img width="1527" alt="Capture d’écran, le 2023-09-19 à 14 53 47" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/de60fa1c-e324-497a-beca-95a3637b6911">


## QA

Steps to validate
Url (storybook, ...)
...


[SKFP-701]: https://d3b.atlassian.net/browse/SKFP-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ