### PR TITLE
fix(participant): SKFP-650 use pheno.is_observed

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -107,7 +107,7 @@ export interface IParticipantPhenotype {
   hpo_phenotype_observed_text: string;
   hpo_phenotype_not_observed: string;
   hpo_phenotype_not_observed_text: string;
-  observed: boolean;
+  is_observed: boolean;
 }
 
 export interface IParticipantBiospecimen {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -201,8 +201,7 @@ export const GET_PARTICIPANT_ENTITY = gql`
                     hpo_phenotype_observed_text
                     hpo_phenotype_not_observed
                     hpo_phenotype_not_observed_text
-                    # TODO FIX to is_observed graphql broken
-                    observed
+                    is_observed
                     source_text
                   }
                 }

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -51,13 +51,11 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
     width: '30%',
   },
   {
-    key: 'observed',
+    key: 'is_observed',
     title: intl.get('entities.participant.interpretation'),
     render: (phenotype: IParticipantPhenotype) => (
-      // TODO when field is_observed ready: <Tag color={phenotype?.is_observed ? 'green' : ''}>
-      // graphql broken
-      <Tag color={phenotype?.observed ? 'green' : ''}>
-        {phenotype?.observed
+      <Tag color={phenotype?.is_observed ? 'green' : ''}>
+        {phenotype?.is_observed
           ? intl.get('entities.participant.observed')
           : intl.get('entities.participant.not_observed')}
       </Tag>


### PR DESCRIPTION
###[FIX] Phenotype interpretation must used is_observed

[SKFP-650](https://d3b.atlassian.net/browse/SKFP-650)

## Description

Fix interpretation column in phenotype value from participant entity page to use `phenotype.is_observed`.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1536" alt="Capture d’écran, le 2023-09-22 à 11 06 27" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/9d895e9d-4364-4266-80a0-807a84af52a5">

### After
<img width="1536" alt="Capture d’écran, le 2023-09-22 à 11 08 11" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/833b4858-0abf-4d63-83c8-48952f5d5be0">



[SKFP-650]: https://d3b.atlassian.net/browse/SKFP-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ