### PR TITLE
fix(data explo): SKFP-688 dash in empty cell

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -19,8 +19,8 @@ const filesFacets = {
 const en = {
   ...translations,
   date: {
-    yearsDaysFormat:
-      '{years, plural, =0 {} =1 {# <span style="font-size: 12px">year</span>} other {# <span style="font-size: 12px">years</span>}} {days, plural, =0 {} =1 {# <span style="font-size: 12px">day</span>} other {# <span style="font-size: 12px">days</span>}}',
+    years: '{years, plural, =0 {} =1 {year} other {years}}',
+    days: '{days, plural, =0 {} =1 {day} other {days}}',
   },
   global: {
     viewInDataExploration: 'View in data exploration',

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -30,6 +30,7 @@ import {
   DEFAULT_QUERY_CONFIG,
   SCROLL_WRAPPER_ID,
 } from 'views/DataExploration/utils/constant';
+import AgeCell from 'views/ParticipantEntity/AgeCell';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { ReportType } from 'services/api/reports/models';
@@ -37,7 +38,6 @@ import { SetType } from 'services/api/savedSet/models';
 import { fetchReport, fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
-import { readableDistanceByDays } from 'utils/dates';
 import { formatQuerySortList, scrollToTop } from 'utils/helper';
 import { STATIC_ROUTES } from 'utils/routes';
 import { getProTableDictionary } from 'utils/translation';
@@ -112,9 +112,11 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     tooltip: 'Age at Biospecimen Collection',
     dataIndex: 'age_at_biospecimen_collection',
     render: (age_at_biospecimen_collection) =>
-      age_at_biospecimen_collection
-        ? readableDistanceByDays(age_at_biospecimen_collection)
-        : TABLE_EMPTY_PLACE_HOLDER,
+      age_at_biospecimen_collection ? (
+        <AgeCell ageInDays={age_at_biospecimen_collection} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'diagnosis_mondo',

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -109,7 +109,7 @@ const defaultColumns: ProColumnType[] = [
       multiple: 1,
     },
     className: styles.studyIdCell,
-    render: (isProband: boolean) => (isProband ? `true` : `false`), //|| TABLE_EMPTY_PLACE_HOLDER,
+    render: (isProband: boolean) => (isProband ? `true` : `false`),
   },
   {
     key: 'sex',
@@ -118,7 +118,12 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
-    render: (sex: string) => <ColorTag type={ColorTagType.Gender} value={capitalize(sex)} />,
+    render: (sex: string) =>
+      sex ? (
+        <ColorTag type={ColorTagType.Gender} value={capitalize(sex)} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'diagnosis_category',
@@ -170,7 +175,8 @@ const defaultColumns: ProColumnType[] = [
     className: styles.phenotypeCell,
     render: (phenotype: IArrangerResultsTree<IParticipantPhenotype>) => {
       const phenotypeNames = phenotype?.hits?.edges.map((p) => p.node.hpo_phenotype_observed);
-      if (!phenotypeNames || phenotypeNames.length === 0) {
+      const hasPhenotypeName = phenotypeNames?.filter((name) => name);
+      if (!phenotypeNames || hasPhenotypeName.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
       return (
@@ -373,17 +379,6 @@ const defaultColumns: ProColumnType[] = [
     },
   },
   {
-    key: 'clinical_status',
-    title: 'Clinical Status',
-    dataIndex: 'diagnosis',
-    defaultHidden: true,
-    sorter: {
-      multiple: 1,
-    },
-    render: (diagnosis: IArrangerResultsTree<IParticipantDiagnosis>) =>
-      diagnosis?.hits?.edges?.map((dn) => dn.node.affected_status) || TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
     key: 'disease_related',
     title: 'Disease Related',
     dataIndex: 'outcomes',
@@ -401,8 +396,11 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
-    render: (outcomes: IArrangerResultsTree<IParticipantOutcomes>) =>
-      outcomes?.hits?.edges?.map((o) => o.node.vital_status) || TABLE_EMPTY_PLACE_HOLDER,
+    render: (outcomes: IArrangerResultsTree<IParticipantOutcomes>) => {
+      const vitalStatus = outcomes?.hits?.edges?.filter((o) => o.node.vital_status);
+      if (!vitalStatus.length) return TABLE_EMPTY_PLACE_HOLDER;
+      return outcomes?.hits?.edges?.map((o) => o.node.vital_status);
+    },
   },
   {
     key: 'phenotypes_hpo_not_observed',

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -109,7 +109,7 @@ const defaultColumns: ProColumnType[] = [
       multiple: 1,
     },
     className: styles.studyIdCell,
-    render: (isProband: boolean) => (isProband ? `true` : `false`),
+    render: (isProband: boolean) => (!!isProband).toString(),
   },
   {
     key: 'sex',
@@ -175,8 +175,8 @@ const defaultColumns: ProColumnType[] = [
     className: styles.phenotypeCell,
     render: (phenotype: IArrangerResultsTree<IParticipantPhenotype>) => {
       const phenotypeNames = phenotype?.hits?.edges.map((p) => p.node.hpo_phenotype_observed);
-      const hasPhenotypeName = phenotypeNames?.filter((name) => name);
-      if (!phenotypeNames || hasPhenotypeName.length === 0) {
+      const hasPhenotypeName = !!phenotypeNames?.filter((name) => name).length;
+      if (!phenotypeNames || !hasPhenotypeName) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
       return (
@@ -397,9 +397,9 @@ const defaultColumns: ProColumnType[] = [
       multiple: 1,
     },
     render: (outcomes: IArrangerResultsTree<IParticipantOutcomes>) => {
-      const vitalStatus = outcomes?.hits?.edges?.filter((o) => o.node.vital_status);
-      if (!vitalStatus.length) return TABLE_EMPTY_PLACE_HOLDER;
-      return outcomes?.hits?.edges?.map((o) => o.node.vital_status);
+      const hasVitalStatus = outcomes?.hits?.edges?.some((o) => o.node.vital_status);
+      if (!hasVitalStatus) return TABLE_EMPTY_PLACE_HOLDER;
+      return [...new Set(outcomes?.hits?.edges?.map((o) => o.node.vital_status))];
     },
   },
   {


### PR DESCRIPTION
###[BUG] Display dash in empty cells

## Description

[SKFP-688](https://d3b.atlassian.net/browse/SKFP-688)

Cells fixed : 
- Data explo => participant => sex, vital status, Observed Phenotype (HPO)
- Data explo => biospecimen => age

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
cell empty 
### After
<img width="1438" alt="Capture d’écran, le 2023-09-25 à 13 20 03" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b3e25ce2-07dc-4182-a497-cea730e8a39d">

<img width="1438" alt="Capture d’écran, le 2023-09-25 à 13 18 17" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/371e048d-243c-4598-aa24-073ffaabd84f">



[SKFP-688]: https://d3b.atlassian.net/browse/SKFP-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ