### PR TITLE
fix(variant): SKFP-757 align participant cell in frequency

### DIFF
--- a/src/views/VariantEntity/index.module.scss
+++ b/src/views/VariantEntity/index.module.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.frequencyParticipantLink {
+  padding: 0;
+}

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -70,6 +70,7 @@ export const getFrequenciesItems = (): ProColumnType[] => [
                 value: row.participant_ids || [],
               });
             }}
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(row.participant_number || 0)}
           </Button>

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -137,6 +137,7 @@ export const getFrequenciesTableSummaryColumns = (
                 value: (studies || []).map((s) => s.participant_ids || []).flat(),
               });
             }}
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(variant?.participant_number || 0)}
           </Button>

--- a/src/views/VariantEntity2/index.module.scss
+++ b/src/views/VariantEntity2/index.module.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.frequencyParticipantLink {
+  padding: 0;
+}

--- a/src/views/VariantEntity2/utils/frequencies.tsx
+++ b/src/views/VariantEntity2/utils/frequencies.tsx
@@ -85,6 +85,7 @@ export const getFrequenciesItems = (): ProColumnType[] => [
                 setAsActive: true,
               })
             }
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(row.total?.pc || 0)}
           </Button>
@@ -149,6 +150,7 @@ export const getFrequenciesTableSummaryColumns = (
                 setAsActive: true,
               })
             }
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(totalNbOfParticipants)}
           </Button>


### PR DESCRIPTION
### [BUG] Variant entity, frequency table align participant cell

## Description

[SKFP-757](https://d3b.atlassian.net/browse/SKFP-757)
Align participant cell with link compare to the other participant cells, same for total line, in variant entity and variant 2 entity.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="710" alt="Capture d’écran, le 2023-09-25 à 15 09 36" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/997622ad-a4db-4d99-84fc-650162c4ea92">

### After
Variant 1
<img width="696" alt="Capture d’écran, le 2023-09-25 à 15 06 58" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/f3516445-b165-4cd0-a855-3467189f65c9">

Variant 2
<img width="710" alt="Capture d’écran, le 2023-09-25 à 15 07 21" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/d6208862-a76a-4869-86a7-33bedf0b0ea6">


[SKFP-757]: https://d3b.atlassian.net/browse/SKFP-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ