### PR TITLE
feat(variant 2): SKFP-772 variant facet and column names

### DIFF
--- a/src/components/uiKit/FilterList/CustomFilterSelector.tsx
+++ b/src/components/uiKit/FilterList/CustomFilterSelector.tsx
@@ -1,14 +1,16 @@
+import { useEffect } from 'react';
 import FilterSelector, {
   FilterSelectorProps,
 } from '@ferlab/ui/core/components/filters/FilterSelector';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
-import { Spin } from 'antd';
-import { useEffect } from 'react';
-import useGetAggregations from 'hooks/graphql/useGetAggregations';
-import { AGGREGATION_QUERY } from 'graphql/queries';
-import { TCustomFilterMapper } from '.';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
+import { Spin } from 'antd';
+import { AGGREGATION_QUERY } from 'graphql/queries';
+
+import useGetAggregations from 'hooks/graphql/useGetAggregations';
+
+import { TCustomFilterMapper } from '.';
 
 type OwnProps = FilterSelectorProps & {
   index: string;

--- a/src/components/uiKit/FilterList/index.tsx
+++ b/src/components/uiKit/FilterList/index.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
-import { Button, Layout, Space, Spin, Typography } from 'antd';
-import CustomFilterContainer from './CustomFilterContainer';
 import intl from 'react-intl-universal';
-import { FilterGroup, FilterInfo } from './types';
 import { ISqonGroupFilter, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
+import { Button, Layout, Space, Spin, Typography } from 'antd';
 import cx from 'classnames';
+import { isEmpty } from 'lodash';
 
 import styles from 'components/uiKit/FilterList/Filters.module.scss';
-import { isEmpty } from 'lodash';
-import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
+
+import CustomFilterContainer from './CustomFilterContainer';
+import { FilterGroup, FilterInfo } from './types';
 
 export type TCustomFilterMapper = (filters: ISqonGroupFilter) => ISyntheticSqon;
 
@@ -31,7 +32,7 @@ const isAllFacetOpen = (filterInfo: FilterInfo) => {
 };
 
 const concatAllFacets = (filterInfo: FilterInfo) => {
-  let allFacets: any[] = [];
+  const allFacets: any[] = [];
   filterInfo.groups.forEach(({ facets }) => allFacets.push(...facets));
   return allFacets;
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -765,6 +765,11 @@ const en = {
       },
       title: 'Variants Exploration',
       table: {
+        mostDeleteriousConsequence: {
+          title: 'Most Deleterious Consequence',
+          tooltip: 'Functional consequences of genetic variations annotated using VEP',
+        },
+        // TODO remove when new variant ETL will be used
         consequences: {
           title: 'Consequences',
           tooltip: 'Functional consequences of genetic variations annotated using VEP',
@@ -1130,6 +1135,8 @@ const en = {
     },
     studies: {
       study_code: 'Study Code',
+      zygosity: 'Zygosity',
+      transmission: 'Transmission',
     },
     is_proband: 'Proband',
     study_id: 'Study Code',
@@ -1212,6 +1219,28 @@ const en = {
       },
     },
     genes: {
+      consequences: {
+        consequence: 'Consequence',
+        vep_impact: 'VEP',
+        predictions: {
+          cadd_score: 'CADD (Raw)',
+          cadd_phred: 'CADD (Phred)',
+          dann_score: 'DANN',
+          fathmm_pred: 'FATHMM',
+          lrt_pred: 'LRT',
+          polyphen2_hvar_pred: 'PolyPhen-2 HVAR',
+          revel_score: 'REVEL',
+          sift_pred: 'SIFT',
+        },
+      },
+      biotype: 'Gene Type',
+      gnomad: {
+        pli: 'gnomAD pLI',
+        loeuf: 'gnomAD LOEUF',
+      },
+      spliceai: {
+        ds: 'SpliceAI',
+      },
       hpo: {
         hpo_term_label: 'HPO',
       },
@@ -1230,6 +1259,28 @@ const en = {
     },
     clinvar: {
       clin_sig: 'ClinVar',
+    },
+    external_frequencies: {
+      gnomad_genomes_2_1_1: {
+        af: 'gnomAD Genome 2.1.1',
+      },
+      gnomad_genomes_3: {
+        af: 'gnomAD Genome 3.1.2',
+      },
+      gnomad_exomes_2_1_1: {
+        af: 'gnomAD Exome 2.1.1',
+      },
+      topmed_bravo: {
+        af: 'TopMed',
+      },
+      thousand_genomes: {
+        af: '1000 Genomes',
+      },
+    },
+    internal_frequencies: {
+      total: {
+        af: 'KF Allele Frequency',
+      },
     },
     frequencies: {
       internal: {

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -254,6 +254,8 @@ export const getFacetsDictionary = () => ({
   },
   studies: {
     study_code: 'Study Code',
+    zygosity: 'Zygosity',
+    transmission: 'Transmission',
   },
   start: 'Position',
   acl: 'ACL',
@@ -302,6 +304,28 @@ export const getFacetsDictionary = () => ({
     },
   },
   genes: {
+    consequences: {
+      consequence: 'Consequence',
+      vep_impact: 'VEP',
+      predictions: {
+        cadd_score: 'CADD (Raw)',
+        cadd_phred: 'CADD (Phred)',
+        dann_score: 'DANN',
+        fathmm_pred: 'FATHMM',
+        lrt_pred: 'LRT',
+        polyphen2_hvar_pred: 'PolyPhen-2 HVAR',
+        revel_score: 'REVEL',
+        sift_pred: 'SIFT',
+      },
+    },
+    biotype: 'Gene Type',
+    gnomad: {
+      pli: 'gnomAD pLI',
+      loeuf: 'gnomAD LOEUF',
+    },
+    spliceai: {
+      ds: 'SpliceAI',
+    },
     hpo: {
       hpo_term_label: 'HPO',
     },
@@ -316,6 +340,28 @@ export const getFacetsDictionary = () => ({
     },
     cosmic: {
       tumour_types_germline: 'COSMIC',
+    },
+  },
+  external_frequencies: {
+    gnomad_genomes_2_1_1: {
+      af: 'gnomAD Genome 2.1.1',
+    },
+    gnomad_genomes_3: {
+      af: 'gnomAD Genome 3.1.2',
+    },
+    gnomad_exomes_2_1_1: {
+      af: 'gnomAD Exome 2.1.1',
+    },
+    topmed_bravo: {
+      af: 'TopMed',
+    },
+    thousand_genomes: {
+      af: '1000 Genomes',
+    },
+  },
+  internal_frequencies: {
+    total: {
+      af: 'KF Allele Frequency',
     },
   },
   frequencies: {

--- a/src/views/Variants2/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants2/components/PageContent/VariantsTable/index.tsx
@@ -107,9 +107,9 @@ const defaultColumns: ProColumnType[] = [
   },
   {
     key: 'consequences',
-    title: intl.get('screen.variants.table.consequences.title'),
+    title: intl.get('screen.variants.table.mostDeleteriousConsequence.title'),
     dataIndex: 'genes',
-    tooltip: intl.get('screen.variants.table.consequences.tooltip'),
+    tooltip: intl.get('screen.variants.table.mostDeleteriousConsequence.tooltip'),
     render: (genes: IArrangerResultsTree<IGeneEntity>) => {
       const geneWithPickedConsequence = genes?.hits?.edges?.find((e) =>
         (e.node.consequences || [])?.hits?.edges?.some((e) => e.node?.picked),


### PR DESCRIPTION
### [FEATURE] Variant 2 review all facet names and consequence column

## Description

[SKFP-772](https://d3b.atlassian.net/browse/SKFP-772)

- Variant 2 facet name in sidebar menu and in query builder
- Consequence column name in result table

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 13 41" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/8a685db8-42b3-425c-b3ca-4546056cc40f">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 13 33" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/fba2e291-2ce1-4bd8-b71b-ae90ed015bb1">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 13 26" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/f445d72f-99f7-4150-a662-0eef8fa45890">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 13 16" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/bba3e3d0-ea85-47b7-a7da-7e7918549fcf">

### After
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 12 08" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/7f17e8b1-2d8f-4616-9c7d-cc39ab49f8bc">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 11 39" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/a2b2d628-2427-42fb-b6fa-0c2c8ac9f5f4">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 12 00" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/3028f4db-6084-4b36-a83d-de47d563a2cd">
<img width="314" alt="Capture d’écran, le 2023-09-25 à 17 11 50" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b7d2af30-1b29-4660-aa66-9fa958e82a16">


[SKFP-772]: https://d3b.atlassian.net/browse/SKFP-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ