### PR TITLE
fix(participant): SKFP-650 fix QA comments

### DIFF
--- a/src/graphql/biospecimens/models.ts
+++ b/src/graphql/biospecimens/models.ts
@@ -41,4 +41,5 @@ export interface IBiospecimenEntity {
   tissue_type_source_text: string;
   source_text_tumor_location: string;
   dbgap_consent_code: string;
+  consent_type: string;
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1184,6 +1184,7 @@ const en = {
 
     //Other
     collection_sample_type: 'Collection Sample Type',
+    collection_sample_id: 'Collection ID',
 
     //Variants
     variant_class: 'Variant Type',
@@ -1395,6 +1396,7 @@ const en = {
       biospecimen_storage: 'Biospecimen Storage',
       collection_id: 'Collection ID',
       collection_sample_type: 'Collection Sample Type',
+      consent_type: 'Consent Type',
       container_id: 'Container ID',
       count: '{count, plural, =0 {Biospecimen} =1 {Biospecimen} other {Biospecimens}}',
       dbgap_consent_code: 'Consent Code (dbGaP)',

--- a/src/views/ParticipantEntity/SummaryHeader/index.module.scss
+++ b/src/views/ParticipantEntity/SummaryHeader/index.module.scss
@@ -48,6 +48,6 @@
 
 .text {
   line-height: 22px;
-  color: $gray-7;
+  color: $body-2;
   font-size: 14px;
 }

--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -88,6 +88,13 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
       biospecimen?.dbgap_consent_code || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
+    key: 'consent_type',
+    title: intl.get('entities.biospecimen.consent_type'),
+    defaultHidden: true,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.consent_type || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     key: 'volume',
     title: intl.get('entities.biospecimen.volume'),
     render: (biospecimen: IBiospecimenEntity) => biospecimen?.volume || TABLE_EMPTY_PLACE_HOLDER,


### PR DESCRIPTION
### [BUG] Fix QA comments in Participant Entity

## Description

Ticket [SKFP-650](https://d3b.atlassian.net/browse/SKFP-650)

- La couleur du Statistic Title dans les bouton du Summary devraient être body-2 selon le UI-Kit
- Il manque la colonne « Consent Type » du tableau Biospecimen
- L’étiquette de la pilule au redirect de Collection ID devrait être « Collection Sample ID » 

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before

### After
<img width="1500" alt="Capture d’écran, le 2023-09-26 à 08 27 46" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/31c15b53-39e5-48f4-b659-5905d0aea172">
<img width="1500" alt="Capture d’écran, le 2023-09-26 à 08 28 03" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/8c5c30fd-6b90-4afa-af4c-90fb8d7cc23f">
<img width="618" alt="Capture d’écran, le 2023-09-26 à 08 28 42" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/994f73c4-2c8d-49bd-a2e2-59955ee3cf45">


[SKFP-650]: https://d3b.atlassian.net/browse/SKFP-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ