### PR TITLE
fix: SKFP-779 remove sub text in file manifest modal

### DIFF
--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.module.scss
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.module.scss
@@ -9,12 +9,6 @@
   width: 740px !important;
 }
 
-.subText {
-  font-size: 12px;
-  line-height: 20px;
-  color: $gray-7
-}
-
 .table {
     margin-top: 30px;
 }

--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
@@ -65,7 +65,6 @@ const DownloadFileManifestModal = ({
         className={styles.modal}
       >
         <p>{intl.getHTML('api.report.fileManifest.text')}</p>
-        <p className={styles.subText}>{intl.get('api.report.fileManifest.subText')}</p>
         <Checkbox checked={isFamilyChecked} onChange={() => setIsFamilyChecked(!isFamilyChecked)}>
           {intl.get('api.report.fileManifest.textCheckbox')}
         </Checkbox>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -198,7 +198,6 @@ const en = {
         okText: 'Download',
         cancel: 'Cancel',
         text: `Download a manifest of the selected files which can be used for bulk downloading using Cavatica’s <a target="_blank" href="https://docs.cavatica.org/docs/import-from-a-drs-server" style="text-decoration: underline;">Import from an GA4GH Data Repository Service (DRS)</a>. This manifest also includes additional information, including the participant and samples associated with these files.`,
-        subText: 'In development and will be available soon.',
         textCheckbox: `Include data files of the same type for the participants' related family members for this selection.`,
         summary: 'Summary',
       },


### PR DESCRIPTION
[Data Exploration & Entity ] File manifest fixes

- closes #SKFP-779

## Description

remove the “In development and will be available soon”. line

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="761" alt="Capture d’écran, le 2023-09-26 à 19 28 33" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/b9002da1-6866-4d8a-a322-dd945c5fdd54">

### After
<img width="774" alt="Capture d’écran, le 2023-09-26 à 19 27 53" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/f6e905c5-793a-442a-846c-7e513b817c5c">


## QA

Go to Data Exploration > File tab > Select some files and click on Manifest button
