### PR TITLE
feat(variant2): SKFP-783 multiple fixes

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -813,6 +813,7 @@ const en = {
         cytoband: 'Cytoband',
         referenceGenome: 'Reference Genome',
         studies: 'Studies',
+        studiesTooltip: 'Frequency of the variant across KF studies',
         participants: 'Participants',
         participantsTooltip:
           'Due to participant confidentiality, redirect to the Data Exploration page if the number of affected participants across Kids First cohorts ≥ 10',
@@ -820,6 +821,7 @@ const en = {
         omim: 'OMIM',
         clinVar: 'ClinVar',
         gnomadGenome311: 'gnomAD Genome (v3.1.1)',
+        gnomadGenome312: 'gnomAD Genome (v3.1.2)',
         dbSNP: 'dbSNP',
       },
       consequences: {

--- a/src/views/VariantEntity2/SummaryHeader/index.module.scss
+++ b/src/views/VariantEntity2/SummaryHeader/index.module.scss
@@ -38,7 +38,7 @@
 
 .icon,
 .entityCount {
-  color: $gray-9;
+  color: $geekblue-7;
 }
 
 .icon {
@@ -54,7 +54,7 @@
 }
 
 .text {
-  color: $gray-7;
+  color: $body-2;
   line-height: 32px;
   margin-top: 4px;
 }

--- a/src/views/VariantEntity2/index.tsx
+++ b/src/views/VariantEntity2/index.tsx
@@ -102,7 +102,7 @@ export default function VariantEntity() {
           columns={getFrequenciesItems()}
           data={variantStudies}
           title={intl.get('screen.variants.frequencies.frequency')}
-          header={intl.get('screen.variants.frequencies.includeStudies')}
+          header={intl.get('screen.variants.frequencies.kfStudies')}
           loading={loading}
           summaryColumns={getFrequenciesTableSummaryColumns(data, variantStudies)}
         />

--- a/src/views/VariantEntity2/utils/summary.tsx
+++ b/src/views/VariantEntity2/utils/summary.tsx
@@ -1,147 +1,163 @@
 import intl from 'react-intl-universal';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { IEntitySummaryColumns } from '@ferlab/ui/core/pages/EntityPage/EntitySummary';
-import { numberWithCommas, toExponentialNotation } from '@ferlab/ui/core/utils/numberUtils';
+import {
+  formatQuotientToExponentialOrElse,
+  numberWithCommas,
+  toExponentialNotation,
+} from '@ferlab/ui/core/utils/numberUtils';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+import { Tooltip } from 'antd';
 import { IVariantEntity } from 'graphql/variants2/models';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 
 import styles from '../index.module.scss';
 
-export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns[] => [
-  {
-    column: {
-      lg: 12,
-      md: 24,
-      xs: 24,
+export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns[] => {
+  const totalNbOfParticipants = variant?.internal_frequencies?.total?.pc || 0;
+  return [
+    {
+      column: {
+        lg: 12,
+        md: 24,
+        xs: 24,
+      },
+      rows: [
+        {
+          title: '',
+          data: [
+            {
+              label: intl.get('screen.variants.summary.variant'),
+              value: variant?.hgvsg || TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.type'),
+              value: variant?.variant_class || TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.cytoband'),
+              value: variant?.genes?.hits?.edges[0]
+                ? variant.genes.hits.edges[0].node.location
+                : TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.referenceGenome'),
+              value: variant?.assembly_version || TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.genes'),
+              value: variant?.genes?.hits?.edges?.length
+                ? variant.genes.hits.edges.map((gene) => {
+                    if (!gene?.node?.symbol) {
+                      return TABLE_EMPTY_PLACE_HOLDER;
+                    }
+                    return (
+                      <ExternalLink
+                        key={gene.node.symbol}
+                        className={styles.geneExternalLink}
+                        href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
+                      >
+                        {gene.node.symbol}
+                      </ExternalLink>
+                    );
+                  })
+                : TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.omim'),
+              value: variant?.genes?.hits?.edges?.length
+                ? variant.genes.hits.edges.map((gene) => {
+                    if (!gene?.node?.omim_gene_id) {
+                      return TABLE_EMPTY_PLACE_HOLDER;
+                    }
+                    return (
+                      <ExternalLink
+                        key={gene.node.omim_gene_id}
+                        className={styles.geneExternalLink}
+                        href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
+                      >
+                        {gene.node.omim_gene_id}
+                      </ExternalLink>
+                    );
+                  })
+                : TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.clinVar'),
+              value:
+                removeUnderscoreAndCapitalize(
+                  variant?.clinvar?.clin_sig.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+                ) || TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: intl.get('screen.variants.summary.participants'),
+              value: variant?.internal_frequencies?.total?.pc
+                ? numberWithCommas(variant.internal_frequencies.total.pc)
+                : TABLE_EMPTY_PLACE_HOLDER,
+            },
+          ],
+        },
+      ],
     },
-    rows: [
-      {
-        title: '',
-        data: [
-          {
-            label: intl.get('screen.variants.summary.variant'),
-            value: variant?.hgvsg || TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.type'),
-            value: variant?.variant_class || TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.cytoband'),
-            value: variant?.genes?.hits?.edges[0]
-              ? variant.genes.hits.edges[0].node.location
-              : TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.referenceGenome'),
-            value: variant?.assembly_version || TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.genes'),
-            value: variant?.genes?.hits?.edges?.length
-              ? variant.genes.hits.edges.map((gene) => {
-                  if (!gene?.node?.symbol) {
-                    return;
-                  }
-                  return (
-                    <ExternalLink
-                      key={gene.node.symbol}
-                      className={styles.geneExternalLink}
-                      href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
-                    >
-                      {gene.node.symbol}
-                    </ExternalLink>
-                  );
-                })
-              : TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.omim'),
-            value: variant?.genes?.hits?.edges?.length
-              ? variant.genes.hits.edges.map((gene) => {
-                  if (!gene?.node?.omim_gene_id) {
-                    return;
-                  }
-                  return (
-                    <ExternalLink
-                      key={gene.node.omim_gene_id}
-                      className={styles.geneExternalLink}
-                      href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
-                    >
-                      {gene.node.omim_gene_id}
-                    </ExternalLink>
-                  );
-                })
-              : TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.clinVar'),
-            value:
-              removeUnderscoreAndCapitalize(
-                variant?.clinvar?.clin_sig.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
-              ) || TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.participants'),
-            value: variant?.internal_frequencies?.total?.pc
-              ? numberWithCommas(variant.internal_frequencies.total.pc)
-              : TABLE_EMPTY_PLACE_HOLDER,
-          },
-        ],
+    {
+      column: {
+        lg: 12,
+        md: 24,
+        xs: 24,
       },
-    ],
-  },
-  {
-    column: {
-      lg: 12,
-      md: 24,
-      xs: 24,
+      rows: [
+        {
+          title: 'Frequencies',
+          data: [
+            {
+              label: intl.get('screen.variants.summary.gnomadGenome312'),
+              value:
+                toExponentialNotation(variant?.external_frequencies?.gnomad_genomes_3?.af) ||
+                TABLE_EMPTY_PLACE_HOLDER,
+            },
+            {
+              label: (
+                <Tooltip title={intl.get('screen.variants.summary.studiesTooltip')}>
+                  {intl.get('screen.variants.summary.studies')}
+                </Tooltip>
+              ),
+              value: formatQuotientToExponentialOrElse(
+                totalNbOfParticipants,
+                variant?.internal_frequencies?.total?.pn || NaN,
+                TABLE_EMPTY_PLACE_HOLDER,
+              ),
+            },
+          ],
+        },
+        {
+          title: 'External Reference',
+          data: [
+            {
+              label: intl.get('screen.variants.summary.clinVar'),
+              value: variant?.clinvar?.clinvar_id ? (
+                <ExternalLink
+                  href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variant.clinvar.clinvar_id}`}
+                >
+                  {variant?.clinvar?.clinvar_id}
+                </ExternalLink>
+              ) : (
+                TABLE_EMPTY_PLACE_HOLDER
+              ),
+            },
+            {
+              label: intl.get('screen.variants.summary.dbSNP'),
+              value: variant?.rsnumber ? (
+                <ExternalLink href={`https://www.ncbi.nlm.nih.gov/snp/${variant?.rsnumber}`}>
+                  {variant?.rsnumber}
+                </ExternalLink>
+              ) : (
+                TABLE_EMPTY_PLACE_HOLDER
+              ),
+            },
+          ],
+        },
+      ],
     },
-    rows: [
-      {
-        title: 'Frequencies',
-        data: [
-          {
-            label: intl.get('screen.variants.summary.gnomadGenome3'),
-            value:
-              toExponentialNotation(variant?.external_frequencies?.gnomad_genomes_3?.af) ||
-              TABLE_EMPTY_PLACE_HOLDER,
-          },
-          {
-            label: intl.get('screen.variants.summary.studies'),
-            value: variant?.studies?.hits?.edges?.length || TABLE_EMPTY_PLACE_HOLDER,
-          },
-        ],
-      },
-      {
-        title: 'External Reference',
-        data: [
-          {
-            label: intl.get('screen.variants.summary.clinVar'),
-            value: variant?.clinvar?.clinvar_id ? (
-              <ExternalLink
-                href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variant.clinvar.clinvar_id}`}
-              >
-                {variant?.clinvar?.clinvar_id}
-              </ExternalLink>
-            ) : (
-              TABLE_EMPTY_PLACE_HOLDER
-            ),
-          },
-          {
-            label: intl.get('screen.variants.summary.dbSNP'),
-            value: variant?.rsnumber ? (
-              <ExternalLink href={`https://www.ncbi.nlm.nih.gov/snp/${variant?.rsnumber}`}>
-                {variant?.rsnumber}
-              </ExternalLink>
-            ) : (
-              TABLE_EMPTY_PLACE_HOLDER
-            ),
-          },
-        ],
-      },
-    ],
-  },
-];
+  ];
+};

--- a/src/views/VariantEntity2/utils/summary.tsx
+++ b/src/views/VariantEntity2/utils/summary.tsx
@@ -85,10 +85,9 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
             },
             {
               label: intl.get('screen.variants.summary.clinVar'),
-              value:
-                removeUnderscoreAndCapitalize(
-                  variant?.clinvar?.clin_sig.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
-                ) || TABLE_EMPTY_PLACE_HOLDER,
+              value: variant?.clinvar?.clin_sig
+                ? removeUnderscoreAndCapitalize(variant?.clinvar?.clin_sig.join(', '))
+                : TABLE_EMPTY_PLACE_HOLDER,
             },
             {
               label: intl.get('screen.variants.summary.participants'),


### PR DESCRIPTION
#[FEATURE] Variant2 entity multiple fixes

## Description

[SKFP-783](https://d3b.atlassian.net/browse/SKFP-783)

- stat colors
- Summary / Frequency => gnomad label
- Summary / Frequency => add tooltip on label and update value
- Summary / Frequency => fix OMIM value
- Frequency subsection label

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1520" alt="Capture d’écran, le 2023-09-28 à 11 42 39" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/4a4102ea-4958-45da-94cc-678e10b5dd77">
<img width="1520" alt="Capture d’écran, le 2023-09-28 à 11 42 28" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/ca6e172f-878c-4ddc-9465-f9ccfdfdf5f7">

### After
<img width="1520" alt="Capture d’écran, le 2023-09-28 à 11 35 50" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/7cd12d1e-94d5-43c6-982b-e4c5540e1f99">


- Avec OMIM 

<img width="1520" alt="Capture d’écran, le 2023-09-28 à 11 35 16" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/d90c293e-7ce4-47bf-94bc-be92ff1f68ee">


- Sans OMIM 

<img width="1520" alt="Capture d’écran, le 2023-09-28 à 11 34 56" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/a0b68865-7b24-493c-ab30-a982e387b751">



[SKFP-783]: https://d3b.atlassian.net/browse/SKFP-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ