### PR TITLE
fix: SKFP-788 fix members filters and pagination

### DIFF
--- a/src/views/Community/index.tsx
+++ b/src/views/Community/index.tsx
@@ -68,15 +68,36 @@ const CommunityPage = () => {
     sqon: resolveSqon(search, roleFilter, interestsFilter),
   });
 
+  const onSearchFilterChange = (search: string) => {
+    if (search.length > 0) {
+      setQueryConfig(DEFAULT_QUERY_CONFIG);
+    }
+    setSearch(search);
+  };
+
+  const onRoleFilterChange = (roles: string[]) => {
+    if (roles.length > 0) {
+      setQueryConfig(DEFAULT_QUERY_CONFIG);
+    }
+    setRoleFilter(roles);
+  };
+
+  const onInterestsFilterChange = (interests: string[]) => {
+    if (interests.length > 0) {
+      setQueryConfig(DEFAULT_QUERY_CONFIG);
+    }
+    setInterestsFilter(interests);
+  };
+
   return (
     <Space direction="vertical" size={24} className={styles.communityWrapper}>
       <Title className={styles.title} level={4}>
         {intl.get('screen.community.title')}
       </Title>
       <FiltersBox
-        onSearchFilterChange={setSearch}
-        onRoleFilterChange={setRoleFilter}
-        onInterestsFilterChange={setInterestsFilter}
+        onSearchFilterChange={onSearchFilterChange}
+        onRoleFilterChange={onRoleFilterChange}
+        onInterestsFilterChange={onInterestsFilterChange}
         hasFilters={roleFilter.length > 0 || interestsFilter.length > 0}
       />
       <Space className={styles.usersListWrapper} size={24} direction="vertical">
@@ -111,6 +132,7 @@ const CommunityPage = () => {
           className={styles.membersList}
           pagination={{
             total: total,
+            current: queryConfig.pageIndex,
             pageSize: queryConfig.size,
             onChange: (page) => {
               setQueryConfig({


### PR DESCRIPTION
#[BUG] [Community] Le filtre ne fonctionne pas dans les pages > 1

- closes SKFP-788

## Description

When filtering members on page > 1, it results nothing

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1411" alt="Capture d’écran, le 2023-09-28 à 12 18 40" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/f3cbce72-45f0-42c6-9247-590f3e9a1a35">

### After

<img width="1611" alt="Capture d’écran, le 2023-09-28 à 12 19 21" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/27f36cd4-78b2-45f3-a12c-f0d6171ce42b">

## QA

Go to Community
Go to the second page
Enter a filter in search or role or interest

You should see members that match the filter

## Mention

@ QA, Design ...
