### PR TITLE
fix: SKFP-786 add scroll on saved filters and saved sets cards in dashboard

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -17,6 +17,7 @@
 
   :global(.ant-tabs-content) {
     height: 100%;
+    overflow: auto;
   }
 
   :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -19,6 +19,7 @@
 
   :global(.ant-tabs-content) {
     height: 100%;
+    overflow: auto;
   }
 
   :global(.ant-tabs-tab) {


### PR DESCRIPTION
#[BUG] [Dashboard] Ajouter un scroll dans le widget des Saved Filters et Saved Sets

- closes SKFP-786

## Description

Add scroll on saved filters and saved sets cards in dashboard

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1917" alt="Capture d’écran, le 2023-09-28 à 12 43 33" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/10b6083a-975c-40b3-bb7e-fe999b5e7b8e">

### After
<img width="549" alt="Capture d’écran, le 2023-09-28 à 12 45 15" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/6709b39e-f6a4-4e86-8703-78fc296d4036">

<img width="587" alt="Capture d’écran, le 2023-09-28 à 12 46 15" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/62097f84-0916-43c5-85cf-46a4df005df0">

## QA

Make sure to have at least 5 saved sets and 5 saved filters
Go on dashboard

You should see scroll in Saved filters and Saved sets card

## Mention

@ QA, Design ...
