### PR TITLE
fix(file): SKFP-750 fix redirect biospecimen

### DIFF
--- a/src/views/FileEntity/SummaryHeader/index.tsx
+++ b/src/views/FileEntity/SummaryHeader/index.tsx
@@ -73,7 +73,25 @@ const SummaryHeader = ({ file }: OwnProps) => {
           {intl.get('entities.file.summary.participants', { count: participantCount })}
         </span>
       </Link>
-      <Link to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS} className={styles.link}>
+      <Link
+        to={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
+        className={styles.link}
+        onClick={() =>
+          addQuery({
+            queryBuilderId: DATA_EXPLORATION_QB_ID,
+            query: generateQuery({
+              newFilters: [
+                generateValueFilter({
+                  field: 'file_id',
+                  value: file ? [file.file_id] : [],
+                  index: INDEXES.FILE,
+                }),
+              ],
+            }),
+            setAsActive: true,
+          })
+        }
+      >
         <BiospecimenIcon className={styles.icon} />
         <span className={styles.entityCount}>{biospecimenCount}</span>
         <span className={styles.text}>


### PR DESCRIPTION
### [BUG] Fix Biospecimen redirect in File Entity

## Description

[SKFP-750](https://d3b.atlassian.net/browse/SKFP-750)
In file entity, summary section biospecimen stat must redirect to data explo, bio tab with the file id in the QB.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before

### After
https://github.com/kids-first/kf-portal-ui/assets/133775440/9c7118b3-6c88-41c5-b45d-5fbf0c316d59




[SKFP-750]: https://d3b.atlassian.net/browse/SKFP-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ