### PR TITLE
fix(dataexplo): SKFP-801 fix bio upload ids

### DIFF
--- a/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
@@ -63,10 +63,11 @@ const BiospecimenUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'biospecimen_facet_ids.biospecimen_fhir_id_2',
-        value: match.map((value) => value.key),
+        value: match.map((value) => value.value!),
         index: INDEXES.BIOSPECIMEN,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+        isUploadedList: true,
       })
     }
   />

--- a/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
@@ -1,5 +1,6 @@
 import intl from 'react-intl-universal';
 import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { MatchTableItem } from '@ferlab/ui/core/components/UploadIds/types';
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
@@ -59,11 +60,14 @@ const BiospecimenUploadIds = ({ queryBuilderId }: OwnProps) => (
         }));
       });
     }}
-    onUpload={(match) =>
+    onUpload={(matches: MatchTableItem[]) =>
       updateActiveQueryField({
         queryBuilderId,
         field: 'biospecimen_facet_ids.biospecimen_fhir_id_2',
-        value: match.map((value) => value.value!),
+        value: matches.reduce((filtered: string[], o) => {
+          if (o.value) filtered.push(o.value);
+          return filtered;
+        }, []),
         index: INDEXES.BIOSPECIMEN,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
@@ -12,6 +12,7 @@ import { INDEXES } from 'graphql/constants';
 import { ArrangerApi } from 'services/api/arranger';
 
 import EntityUploadIds from './EntityUploadIds';
+import { extractUploadValues } from './utils';
 
 interface OwnProps {
   queryBuilderId: string;
@@ -64,10 +65,7 @@ const BiospecimenUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'biospecimen_facet_ids.biospecimen_fhir_id_2',
-        value: matches.reduce((filtered: string[], o) => {
-          if (o.value) filtered.push(o.value);
-          return filtered;
-        }, []),
+        value: extractUploadValues(matches, 'value'),
         index: INDEXES.BIOSPECIMEN,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
@@ -12,6 +12,7 @@ import { CHECK_FILE_MATCH } from 'graphql/files/queries';
 import { ArrangerApi } from 'services/api/arranger';
 
 import EntityUploadIds from './EntityUploadIds';
+import { extractUploadValues } from './utils';
 
 interface OwnProps {
   queryBuilderId: string;
@@ -62,10 +63,7 @@ const FileUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'file_facet_ids.file_fhir_id_2',
-        value: matches.reduce((filtered: string[], o) => {
-          if (o.value) filtered.push(o.value);
-          return filtered;
-        }, []),
+        value: extractUploadValues(matches, 'value'),
         index: INDEXES.FILE,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/FileUploadIds.tsx
@@ -62,7 +62,10 @@ const FileUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'file_facet_ids.file_fhir_id_2',
-        value: matches.map((match) => match.value!),
+        value: matches.reduce((filtered: string[], o) => {
+          if (o.value) filtered.push(o.value);
+          return filtered;
+        }, []),
         index: INDEXES.FILE,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -12,6 +12,7 @@ import { CHECK_PARTICIPANT_MATCH } from 'graphql/participants/queries';
 import { ArrangerApi } from 'services/api/arranger';
 
 import EntityUploadIds from './EntityUploadIds';
+import { extractUploadValues } from './utils';
 
 interface OwnProps {
   queryBuilderId: string;
@@ -64,10 +65,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'participant_facet_ids.participant_fhir_id_2',
-        value: matches.reduce((filtered: string[], o) => {
-          if (o.value) filtered.push(o.value);
-          return filtered;
-        }, []),
+        value: extractUploadValues(matches, 'value'),
         index: INDEXES.PARTICIPANT,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -64,7 +64,10 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
       updateActiveQueryField({
         queryBuilderId,
         field: 'participant_facet_ids.participant_fhir_id_2',
-        value: matches.map((match) => match.value!),
+        value: matches.reduce((filtered: string[], o) => {
+          if (o.value) filtered.push(o.value);
+          return filtered;
+        }, []),
         index: INDEXES.PARTICIPANT,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,

--- a/src/views/DataExploration/components/UploadIds/utils.tsx
+++ b/src/views/DataExploration/components/UploadIds/utils.tsx
@@ -1,0 +1,7 @@
+import { MatchTableItem } from '@ferlab/ui/core/components/UploadIds/types';
+
+export const extractUploadValues = (arr: MatchTableItem[], key: any): string[] =>
+  arr.reduce((filtered: string[], o: any) => {
+    if (o[key]) filtered.push(o[key]);
+    return filtered;
+  }, []);


### PR DESCRIPTION
### [BUG] Data exploration: biospecimen upload ids

## Description

[SKFP-801](https://d3b.atlassian.net/browse/SKFP-801)
Biospecimen upload ids need to work and add the ids list to QB.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
No filter added before in the QB.

### After
https://github.com/kids-first/kf-portal-ui/assets/133775440/feed18e3-9796-4655-a3a8-66fc391d71f8


[SKFP-801]: https://d3b.atlassian.net/browse/SKFP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ