### PR TITLE
fix: SKFP-779 fix manifest button in file entity page and small ui fixes

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1344,7 +1344,6 @@ const en = {
       summary: 'Summary',
     },
     file: {
-      manifest: 'Manifest',
       fileAuthorization: 'File Authorization',
       fileReadMore: 'applying for data access.',
       locked:

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -418,18 +418,18 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
               selectedKeys={selectedKeys}
               key="file-set-management"
             />,
+            <DownloadFileManifestModal
+              key="download-file-manifest"
+              sqon={getCurrentSqon()}
+              isDisabled={!selectedKeys.length && !selectedAllResults}
+              hasTooManyFiles={hasTooManyFiles}
+            />,
             <CavaticaAnalyzeButton
               disabled={selectedKeys.length === 0 && !selectedAllResults}
               type="primary"
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}
               key="file-cavatica-upload"
-            />,
-            <DownloadFileManifestModal
-              key="download-file-manifest"
-              sqon={getCurrentSqon()}
-              isDisabled={!selectedKeys.length && !selectedAllResults}
-              hasTooManyFiles={hasTooManyFiles}
             />,
           ],
         }}


### PR DESCRIPTION
#[BUG] [Data Exploration & Entity ] File manifest fixes

- closes SKFP-779

## Description

- Manifest button in file entity page does nothing
- Add icon download in Manifest button in file entity page and make it default
- Make cavatica button primary in file entity page
- Switch Manifest and cavatica buttons in data exploration so cavatica is the most on the right

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1115" alt="Capture d’écran, le 2023-09-28 à 16 54 30" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/4f6202ee-c13d-4c98-b025-51524e8958a9">
<img width="1171" alt="Capture d’écran, le 2023-09-28 à 16 54 38" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/6e4d0286-f87e-4a7b-a815-ce6f0fc1ca5c">

### After
<img width="1651" alt="Capture d’écran, le 2023-09-28 à 16 55 51" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/6acb1c1c-cd86-4f27-b55c-b412b0fef39f">

<img width="1688" alt="Capture d’écran, le 2023-09-28 à 16 56 03" src="https://github.com/kids-first/kf-portal-ui/assets/82821620/037e645e-37d4-4ab2-a128-5f251b7f56d2">

## QA

In Data Exploration > Files tab
Cavatica button should be on the right

In File Entity Page
Manifest button should be default with download icon and should one the manifest modal for the current file
Cavatica button should be primary

## Mention

@ QA, Design ...
