### PR TITLE
fix: SKFP-779 withFamily param is not passed to the backend

### DIFF
--- a/src/services/api/reports/index.ts
+++ b/src/services/api/reports/index.ts
@@ -64,6 +64,7 @@ const generateReport = (config: ReportConfig) => {
       sqon: reportSqon,
       projectId: arrangerProjectId,
       filename: `kf_${config.fileName || config.name}_${makeFilenameDatePart(new Date())}`,
+      withFamily: config.withFamily,
     },
     headers: headers(),
   });


### PR DESCRIPTION
#[BUG] [Manifest] withFamily param is not passed to the backend

closes SKFP-779

Description
withFamily param is not passed to the backend

QA
Select a file and check the checkbox to include family datas and download the manifest
