### PR TITLE
fix(variantexplo): SKFP-808 remove upload ids

### DIFF
--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -3,9 +3,6 @@ import { UserOutlined } from '@ant-design/icons';
 import SidebarMenu, { ISidebarMenuItem } from '@ferlab/ui/core/components/SidebarMenu';
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
 import { INDEXES } from 'graphql/constants';
-import GenesUploadIds from './components/GeneUploadIds';
-import VariantGeneSearch from './components/VariantGeneSearch';
-import { VARIANT_REPO_QB_ID } from './utils/constants';
 
 import DiseaseIcon from 'components/Icons/DiseaseIcon';
 import FrequencyIcon from 'components/Icons/FrequencyIcon';
@@ -16,7 +13,10 @@ import { FilterInfo } from 'components/uiKit/FilterList/types';
 import useGetExtendedMappings from 'hooks/graphql/useGetExtendedMappings';
 import { SuggestionType } from 'services/api/arranger/models';
 
+import GenesUploadIds from './components/GeneUploadIds';
 import PageContent from './components/PageContent';
+import VariantGeneSearch from './components/VariantGeneSearch';
+import { VARIANT_REPO_QB_ID } from './utils/constants';
 import { SCROLL_WRAPPER_ID } from './utils/constants';
 
 import styles from './index.module.scss';
@@ -54,7 +54,6 @@ const filterGroups: {
         type={SuggestionType.VARIANTS}
         queryBuilderId={VARIANT_REPO_QB_ID}
       />,
-      <GenesUploadIds key="genes_upload_ids" queryBuilderId={VARIANT_REPO_QB_ID} />
     ],
     groups: [
       {


### PR DESCRIPTION
### [BUG] Variants: remove upload ids

## Description

[SKFP-808](https://d3b.atlassian.net/browse/SKFP-808)
In variants exploration, variants facets : remove upload ids.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="573" alt="Capture d’écran, le 2023-09-29 à 11 44 27" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/d869823c-b828-445d-a11c-3569d0dc97f7">

### After
<img width="573" alt="Capture d’écran, le 2023-09-29 à 11 44 06" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/8550194f-2695-4393-9cfa-f1d5bd318d36">


[SKFP-808]: https://d3b.atlassian.net/browse/SKFP-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ