### PR TITLE
fix(dataexplo): SKFP-810 remove sample id link

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -54,14 +54,7 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     key: 'sample_id',
     title: 'Sample ID',
     sorter: { multiple: 1 },
-    render: (record: IBiospecimenEntity) =>
-      record?.sample_id && record.participant?.participant_id ? (
-        <Link to={goToParticipantEntityPage(record.participant.participant_id)}>
-          {record.sample_id}
-        </Link>
-      ) : (
-        TABLE_EMPTY_PLACE_HOLDER
-      ),
+    render: (record: IBiospecimenEntity) => record?.sample_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'study.study_code',


### PR DESCRIPTION
### [BUG] Data exploration / bio tab remove sample ID link

## Description

[SKFP-810](https://d3b.atlassian.net/browse/SKFP-810)

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="642" alt="Capture d’écran, le 2023-09-29 à 11 55 18" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/7238f17c-00c7-4574-87d6-0b686db4f822">

### After
<img width="821" alt="Capture d’écran, le 2023-09-29 à 11 53 11" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/7ffe5676-e4c8-46db-8b0e-e2e2a47802e4">


[SKFP-810]: https://d3b.atlassian.net/browse/SKFP-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ