### PR TITLE
fix: skfp-819 dont display years when 0

### DIFF
--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,5 +1,3 @@
-import intl from 'react-intl-universal';
-
 // @see https://sciencenotes.org/how-to-convert-days-to-years/
 const LEAP_YEARS = 365.2425;
 

--- a/src/views/ParticipantEntity/AgeCell/index.tsx
+++ b/src/views/ParticipantEntity/AgeCell/index.tsx
@@ -15,9 +15,10 @@ const AgeCell = ({ ageInDays }: OwnProps) => {
   }
 
   const { years, days } = readableDistanceByDays(ageInDays);
+
   return (
     <>
-      {`${years} `}
+      {years === 0 ? '' : `${years} `}
       <span className={styles.timeUnitText}>{intl.get('date.years', { years })}</span>
       {` ${days} `}
       <span className={styles.timeUnitText}>{intl.get('date.days', { days })}</span>{' '}


### PR DESCRIPTION
#BUG | 0 year

- closes https://d3b.atlassian.net/browse/SKFP-819

## Description

Issue: the years in age should not be shown as 0 when the age can only be captured in days.
## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done

## Screenshot 
### After

![image](https://github.com/kids-first/kf-portal-ui/assets/98903/94a33d90-efeb-4a0e-9bc2-c42d44db6e02)

![image](https://github.com/kids-first/kf-portal-ui/assets/98903/7572abf6-b399-482c-8b52-c4a4b929007f)

