### PR TITLE
fix(typo): SKFP-816 fix typos

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -780,7 +780,7 @@ const en = {
         clinvar: 'ClinVar',
         gnomAD: {
           title: 'gnomAD',
-          tooltip: 'gnomAD 3.1.1 Allele Frequency',
+          tooltip: 'gnomAD v3.1.2 Allele Frequency',
         },
         type: 'Type',
         variant_class: 'Variant class',
@@ -791,11 +791,11 @@ const en = {
         variant: 'Variant',
         homozygotes: {
           title: 'Homo.',
-          tooltip: '# of Homozygotes',
+          tooltip: '# of homozygotes',
         },
         alt: {
           title: 'ALT',
-          tooltip: '# of Alternative alleles',
+          tooltip: '# of alternative alleles',
         },
         frequence: {
           title: 'Freq.',
@@ -1199,6 +1199,7 @@ const en = {
     source_text: 'Histological Diagnosis (Source Text)',
     source_text_tumor_location: 'Tumor Location (Source Text)',
     tissue_type_source_text: 'Tissue Type (Source Text)',
+    sample_id: 'Sample ID',
 
     // File
     files: filesFacets,
@@ -1322,6 +1323,7 @@ const en = {
       },
     },
     // Studies
+    search_text: 'Study Code',
     domain: 'Domain',
     population: 'Population',
     donors: {

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -417,18 +417,6 @@ export const getFacetsDictionary = () => ({
     },
   },
   tooltips: {
-    consequences: {
-      vep_impact: 'Ensembl Variant Effect Predictor',
-      predictions: {
-        cadd_rankscore: 'Combined Annotation Dependent Depletion',
-        dann_rankscore: 'Deleterious Annotation of genetic variants using Neural Networks',
-        fathmm_pred: 'Functional Analysis Through Hidden Markov Models',
-        lrt_pred: 'Likelihood Ratio Test',
-        polyphen2_hvar_pred: 'Polymorphism Phenotyping v2 HumVar',
-        revel_rankscore: 'Rare Exome Variant Ensemble Learner',
-        sift_pred: 'Sorting Intolerant From Tolerant',
-      },
-    },
     genes: {
       hpo: {
         hpo_term_label: 'Human Phenotype Ontology',
@@ -444,6 +432,19 @@ export const getFacetsDictionary = () => ({
       },
       cosmic: {
         tumour_types_germline: 'Catalogue Of Somatic Mutations In Cancer',
+      },
+      consequences: {
+        vep_impact: 'Ensembl Variant Effect Predictor',
+        predictions: {
+          cadd_score: 'Combined Annotation Dependent Depletion',
+          cadd_phred: 'Combined Annotation Dependent Depletion PHRED',
+          dann_score: 'Deleterious Annotation of genetic variants using Neural Networks',
+          fathmm_pred: 'Functional Analysis Through Hidden Markov Models',
+          lrt_pred: 'Likelihood Ratio Test',
+          polyphen2_hvar_pred: 'Polymorphism Phenotyping v2 HumVar',
+          revel_score: 'Rare Exome Variant Ensemble Learner',
+          sift_pred: 'Sorting Intolerant From Tolerant',
+        },
       },
     },
   },

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -89,6 +89,7 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
                   to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
                   title="Data Exploration page"
                 />
+                {'.'}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/index.tsx
@@ -1,13 +1,14 @@
 import { TSortableItems } from '@ferlab/ui/core/layout/SortableGrid/SortableItem';
-import AuthorizedStudies from './AuthorizedStudies';
 import cx from 'classnames';
-import SavedFilters from './SavedFilters';
+
+import AuthorizedStudies from './AuthorizedStudies';
+import CaringForChildrenWithCovid from './CaringForChildrenWithCovid';
 import Cavatica from './Cavatica';
 import Notebook from './Notebook';
+import SavedFilters from './SavedFilters';
+import SavedSets from './SavedSets';
 
 import styles from './index.module.scss';
-import SavedSets from './SavedSets';
-import CaringForChildrenWithCovid from './CaringForChildrenWithCovid';
 
 export interface DashboardCardProps {
   id: string;

--- a/src/views/DataExploration/components/ParticipantSearch.tsx
+++ b/src/views/DataExploration/components/ParticipantSearch.tsx
@@ -1,12 +1,13 @@
 import { UserOutlined } from '@ant-design/icons';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
-import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
-import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
-import SelectItem from 'components/uiKit/select/SelectItem';
 import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { PARTICIPANT_SEARCH_BY_ID_QUERY } from 'graphql/participants/queries';
+
+import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
+import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
+import SelectItem from 'components/uiKit/select/SelectItem';
 
 const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
   const { activeQuery } = useQueryBuilderState(queryBuilderId);
@@ -20,8 +21,8 @@ const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
       emptyDescription="No participants found"
       query={PARTICIPANT_SEARCH_BY_ID_QUERY}
       sqon={activeQuery as ISqonGroupFilter}
-      optionsFormatter={(options, matchRegex, search) => {
-        return options.map((option) => ({
+      optionsFormatter={(options, matchRegex, search) =>
+        options.map((option) => ({
           label: (
             <SelectItem
               icon={<UserOutlined />}
@@ -29,8 +30,8 @@ const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
             />
           ),
           value: option.participant_id,
-        }));
-      }}
+        }))
+      }
       title="Search by participant ID"
     />
   );

--- a/src/views/ParticipantEntity/utils/getProfileItems.tsx
+++ b/src/views/ParticipantEntity/utils/getProfileItems.tsx
@@ -4,6 +4,8 @@ import { Tag } from 'antd';
 import { IParticipantEntity, Sex } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
 
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+
 const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsItem[] => [
   {
     label: intl.get('entities.participant.race'),
@@ -11,7 +13,7 @@ const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsI
   },
   {
     label: intl.get('entities.participant.ethnicity'),
-    value: participant?.ethnicity,
+    value: participant?.ethnicity || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.participant.sex'),
@@ -31,7 +33,9 @@ const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsI
   },
   {
     label: intl.get('entities.participant.vital_status'),
-    value: [...new Set(participant?.outcomes?.hits?.edges?.map((o) => o.node.vital_status))],
+    value: participant?.outcomes?.hits?.edges?.map((o) => o.node.vital_status).length
+      ? [...new Set(participant?.outcomes?.hits?.edges?.map((o) => o.node.vital_status))]
+      : TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -32,9 +32,8 @@ const enum DataCategory {
   IMMUNE_MAP = 'Immune-Map',
 }
 
-const hasDataCategory = (dataCategory: string[], category: DataCategory) => 
+const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
   dataCategory && dataCategory.includes(`${category}s`) ? <CheckOutlined /> : undefined;
-
 
 const filterInfo: FilterInfo = {
   customSearches: [<StudySearch key={1} queryBuilderId={STUDIES_REPO_QB_ID} />],
@@ -73,7 +72,8 @@ const columns: ProColumnType<any>[] = [
     key: 'domain',
     title: 'Domain',
     dataIndex: 'domain',
-    render: (domain: string) => intl.get(`facets.options.domain.${domain}`, domain)  || domain || TABLE_EMPTY_PLACE_HOLDER,
+    render: (domain: string) =>
+      intl.get(`facets.options.domain.${domain}`, domain) || domain || TABLE_EMPTY_PLACE_HOLDER,
     width: 182,
   },
   {

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -257,7 +257,10 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
-    render: (ac: string) => ac || TABLE_EMPTY_PLACE_HOLDER,
+    render: (ac: string) =>
+      ac && typeof Number(ac) === 'number'
+        ? numberWithCommas(Number(ac))
+        : TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     title: intl.get('screen.variants.table.homozygotes.title'),

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -11,17 +11,6 @@ import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
 import { Space, Typography } from 'antd';
 import copy from 'copy-to-clipboard';
-import { useVariant } from '../../../../graphql/variants/actions';
-import { IVariantResultTree } from '../../../../graphql/variants/models';
-import { GET_VARIANT_COUNT } from '../../../../graphql/variants/queries';
-import {
-  DEFAULT_OFFSET,
-  DEFAULT_PAGE_INDEX,
-  DEFAULT_PAGE_SIZE,
-  DEFAULT_QUERY_CONFIG,
-  DEFAULT_SORT_QUERY,
-  VARIANT_REPO_QB_ID,
-} from '../../utils/constants';
 
 import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
@@ -41,6 +30,18 @@ import { useUser } from 'store/user';
 import { combineExtendedMappings } from 'utils/fieldMapper';
 import { getCurrentUrl } from 'utils/helper';
 import { getQueryBuilderDictionary } from 'utils/translation';
+
+import { useVariant } from '../../../../graphql/variants/actions';
+import { IVariantResultTree } from '../../../../graphql/variants/models';
+import { GET_VARIANT_COUNT } from '../../../../graphql/variants/queries';
+import {
+  DEFAULT_OFFSET,
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_QUERY_CONFIG,
+  DEFAULT_SORT_QUERY,
+  VARIANT_REPO_QB_ID,
+} from '../../utils/constants';
 
 import VariantsTable from './VariantsTable';
 


### PR DESCRIPTION
### [BUG] Fix typos

## Description

[SKFP-816](https://d3b.atlassian.net/browse/SKFP-816)

- Saved filter tooltip in dashboard
- Search by study in studies page
- file facet name from bio table files column link
- participant entity empty vital status
- All facet tooltips from pathogenecity
- gnomad alt et homo tooltip columns in variants page
- comma in alt number variants page

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
See in the ticket.
### After
<img width="365" alt="Capture d’écran, le 2023-10-05 à 15 20 56" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b87a65f8-7fe3-42e0-b010-bc6c7a7329fa">
<img width="680" alt="Capture d’écran, le 2023-10-05 à 15 21 18" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/c8fab869-7301-4b11-b0f9-b7c023855053">
<img width="261" alt="Capture d’écran, le 2023-10-05 à 15 22 10" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/35e4190e-34b1-459e-b0
<img width="656" alt="Capture d’écran, le 2023-10-05 à 15 22 34" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/29c44562-cb08-4435-a4b3-3b2c3c8d66bc">
eb-378b5ee0ed1a">
<img width="363" alt="Capture d’écran, le 2023-10-05 à 15 22 56" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/cc27b6b7-d39b-4f1a-a71b-c7509c8425f3">
<img width="336" alt="Capture d’écran, le 2023-10-05 à 15 23 13" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/1424d411-27f9-49c6-a9dd-83177f80d61c">
<img width="251" alt="Capture d’écran, le 2023-10-05 à 15 23 35" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/062badc0-f83e-4a38-929d-8bd6a8f092df">

