### PR TITLE
fix(variant): SKFP-804 fix protein coding display

### DIFF
--- a/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+
 import { IGeneEntity } from '../../../graphql/variants/models';
 
 import styles from '@ferlab/ui/core/pages/EntityPage/EntityGeneConsequence/EntityGeneConsequenceSubtitle/index.module.scss';
@@ -51,21 +52,21 @@ const EntityGeneConsequenceSubtitle = ({
       <span className={styles.separator}>|</span>
       {removeUnderscoreAndCapitalize(gene?.node?.biotype)}
     </span>
-    {gene?.node?.spliceai?.ds && (
+    {gene?.node?.spliceai?.ds != null && (
       <span>
         <span className={styles.separator}>|</span>
         <span className={styles.bold}>{dictionary.spliceai}:</span>
         <span>{gene.node.spliceai.ds}</span>
       </span>
     )}
-    {gene?.node?.gnomad?.pli && (
+    {gene?.node?.gnomad?.pli != null && (
       <span>
         <span className={styles.separator}>|</span>
         <span className={styles.bold}>{dictionary.gnomad_pli}:</span>
         <span>{gene.node.gnomad.pli}</span>
       </span>
     )}
-    {gene?.node?.gnomad?.loeuf && (
+    {gene?.node?.gnomad?.loeuf != null && (
       <span>
         <span className={styles.separator}>|</span>
         <span className={styles.bold}>{dictionary.gnomad_loeuf}:</span>


### PR DESCRIPTION
### [BUG] Variant entity, fix protein coding value display

## Description

[SKFP-804](https://d3b.atlassian.net/browse/SKFP-804)
If the value is 0 it's the real value, we want to display it. If the value is not defined we received null/undefined.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
spliceAi value 0
<img width="707" alt="Capture d’écran, le 2023-10-05 à 15 30 20" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/9b6b4502-1edf-4543-821e-abe4094c5547">
gnomad pli value 0
<img width="760" alt="Capture d’écran, le 2023-10-05 à 15 32 06" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/74973801-6926-409c-8223-d2859886d503">
We don't have an example for gnomad loeuf with 0 value.

### After
<img width="731" alt="Capture d’écran, le 2023-10-06 à 10 12 24" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/41707910-04c4-458a-8ab0-69a737db59c4">


[SKFP-804]: https://d3b.atlassian.net/browse/SKFP-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ