### PR TITLE
fix(graph): SKFP-799 studies graph legend

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
@@ -75,11 +75,12 @@ const StudiesGraphCard = () => {
           legends={[
             {
               anchor: 'bottom',
-              translateX: 0,
+              translateX: -310,
               translateY: 92,
               direction: 'column',
               itemWidth: 100,
-              itemHeight: 18,
+              itemHeight: 15,
+              itemsSpacing: 2,
             },
           ]}
         />


### PR DESCRIPTION
### [BUG] Studies graph legend overlap chart pie

## Description

[SKFP-799](https://d3b.atlassian.net/browse/SKFP-799)
Move the legend so that it is no longer above the graph.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="798" alt="Capture d’écran, le 2023-10-06 à 12 25 17" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/dfca1a76-e981-4717-b91e-023daaab547a">

### After
<img width="798" alt="Capture d’écran, le 2023-10-06 à 12 24 26" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/cfa2e28c-1c30-461f-90c4-74d0d0575645">


[SKFP-799]: https://d3b.atlassian.net/browse/SKFP-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ