### PR TITLE
fix(variants): SKFP-825 typo tooltip

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -148,7 +148,7 @@
   "global.search.genes.emptyText": "No gene found",
   "global.search.genes.placeholder": "e.g. BRAF, ENSG00000157764",
   "global.search.genes.title": "Search by gene",
-  "global.search.genes.tooltip": "Enter a Gene Symbol, Gene Alias ​​or Ensemble ID",
+  "global.search.genes.tooltip": "Enter a Gene Symbol, Gene Alias ​​or Ensembl ID",
   "global.search.variants.emptyText": "No variant found",
   "global.search.variants.placeholder": "e.g. 10-100063679-C-T, rs341",
   "global.search.variants.title": "Search by variant",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -37,7 +37,7 @@ const en = {
         emptyText: 'No gene found',
         placeholder: 'e.g. BRAF, ENSG00000157764',
         title: 'Search by gene',
-        tooltip: 'Enter a Gene Symbol, Gene Alias ​​or Ensemble ID',
+        tooltip: 'Enter a Gene Symbol, Gene Alias ​​or Ensembl ID',
       },
       variants: {
         emptyText: 'No variant found',


### PR DESCRIPTION
### [BUG] Variant explo : typo in search gene tooltip

## Description

[SKFP-825](https://d3b.atlassian.net/browse/SKFP-825)

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="633" alt="Capture d’écran, le 2023-10-10 à 14 54 38" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/a4a191ac-3ee1-4137-a31d-0480eceb1b0b">


### After
<img width="633" alt="Capture d’écran, le 2023-10-10 à 14 54 10" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/0dc2f3c5-80ae-4ba8-a91b-9ac61d412557">



[SKFP-825]: https://d3b.atlassian.net/browse/SKFP-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ