### PR TITLE
fix(participant): SKFP-816 vital status display

### DIFF
--- a/src/views/ParticipantEntity/utils/getProfileItems.tsx
+++ b/src/views/ParticipantEntity/utils/getProfileItems.tsx
@@ -33,8 +33,16 @@ const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsI
   },
   {
     label: intl.get('entities.participant.vital_status'),
-    value: participant?.outcomes?.hits?.edges?.map((o) => o.node.vital_status).length
-      ? [...new Set(participant?.outcomes?.hits?.edges?.map((o) => o.node.vital_status))]
+    value: participant?.outcomes?.hits?.edges
+      ?.map((o) => o.node.vital_status)
+      .filter((vitalStatus) => vitalStatus).length
+      ? [
+          ...new Set(
+            participant?.outcomes?.hits?.edges
+              ?.map((o) => o.node.vital_status)
+              .filter((vitalStatus) => vitalStatus),
+          ),
+        ]
       : TABLE_EMPTY_PLACE_HOLDER,
   },
 ];


### PR DESCRIPTION
### [BUG] Display vital status or a dash

## Description

[SKFP-816](https://d3b.atlassian.net/browse/SKFP-816)
Remove null value from vital status list.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="662" alt="Capture d’écran, le 2023-10-11 à 15 27 01" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/971ad7c0-be40-4dbf-9e0a-cef4d430aac4">

### After
<img width="662" alt="Capture d’écran, le 2023-10-11 à 15 27 08" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/360b0899-8bca-47df-861c-8bd2bbd1761b">
