### PR TITLE
feat(studies): SKFP-767 filter without footer

### DIFF
--- a/src/components/uiKit/FilterList/CustomFilterContainer.tsx
+++ b/src/components/uiKit/FilterList/CustomFilterContainer.tsx
@@ -26,6 +26,7 @@ type OwnProps = {
   headerTooltip?: boolean;
   noDataInputOption?: boolean;
   intervalDecimal?: number;
+  filterWithFooter?: boolean;
 };
 
 const CustomFilterContainer = ({
@@ -40,6 +41,7 @@ const CustomFilterContainer = ({
   headerTooltip,
   noDataInputOption,
   intervalDecimal,
+  filterWithFooter = true,
 }: OwnProps) => {
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -70,7 +72,7 @@ const CustomFilterContainer = ({
     extendedMapping: found,
     aggregation: aggregations,
     rangeTypes: [],
-    filterFooter: true,
+    filterFooter: filterWithFooter,
     headerTooltip,
     dictionary: getFacetsDictionary(),
     noDataInputOption,

--- a/src/components/uiKit/FilterList/index.tsx
+++ b/src/components/uiKit/FilterList/index.tsx
@@ -19,6 +19,7 @@ type OwnProps = {
   queryBuilderId: string;
   extendedMappingResults: IExtendedMappingResults;
   filterInfo: FilterInfo;
+  filterWithFooter?: boolean;
   filterMapper?: TCustomFilterMapper;
 };
 
@@ -42,6 +43,7 @@ const FilterList = ({
   queryBuilderId,
   extendedMappingResults,
   filterInfo,
+  filterWithFooter = true,
   filterMapper,
 }: OwnProps) => {
   const [filtersOpen, setFiltersOpen] = useState<boolean | undefined>(isAllFacetOpen(filterInfo));
@@ -92,6 +94,7 @@ const FilterList = ({
                       ? group.intervalDecimal[facet]
                       : undefined
                   }
+                  filterWithFooter={filterWithFooter}
                 />
               ) : (
                 <div key={i + ii} className={cx(styles.customFilterWrapper, styles.filter)}>

--- a/src/views/Studies/components/SideBarFacet/index.tsx
+++ b/src/views/Studies/components/SideBarFacet/index.tsx
@@ -18,9 +18,15 @@ type OwnProps = {
   className?: string;
   extendedMappingResults: IExtendedMappingResults;
   filterInfo: FilterInfo;
+  filterWithFooter?: boolean;
 };
 
-const SideBarFacet = ({ className, extendedMappingResults, filterInfo }: OwnProps) => {
+const SideBarFacet = ({
+  className,
+  extendedMappingResults,
+  filterInfo,
+  filterWithFooter,
+}: OwnProps) => {
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const { loading } = extendedMappingResults;
 
@@ -48,6 +54,7 @@ const SideBarFacet = ({ className, extendedMappingResults, filterInfo }: OwnProp
               queryBuilderId={STUDIES_REPO_QB_ID}
               extendedMappingResults={extendedMappingResults}
               filterInfo={filterInfo}
+              filterWithFooter={filterWithFooter}
             />
           </div>
         )}

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -191,7 +191,11 @@ const Studies = () => {
 
   return (
     <div className={styles.studiesPage}>
-      <SideBarFacet extendedMappingResults={studiesMappingResults} filterInfo={filterInfo} />
+      <SideBarFacet
+        extendedMappingResults={studiesMappingResults}
+        filterInfo={filterInfo}
+        filterWithFooter={false}
+      />
       <ScrollContent id={SCROLL_WRAPPER_ID} className={styles.scrollContent}>
         <PageContent defaultColumns={columns} extendedMappingResults={studiesMappingResults} />
       </ScrollContent>


### PR DESCRIPTION
#[FEATURE] Remove apply and clear button in filters

## Description

[SKFP-767](https://d3b.atlassian.net/browse/SKFP-767)

Acceptance Criterias

Remove buttons in the facets to(CLEAR, Apply). As soon as there is a value that is selected, it will automatically be added to the query builder.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="915" alt="Capture d’écran, le 2023-11-01 à 08 48 31" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/bcfa407e-2ab2-4a77-af77-01b051861aa9">

### After
<img width="915" alt="Capture d’écran, le 2023-11-01 à 08 47 02" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/c55b3c3c-8f89-40a5-a6ca-6b8d1e396e0f">


[SKFP-767]: https://d3b.atlassian.net/browse/SKFP-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ