### PR TITLE
fix(variant): SKFP-850 fix NO_GENE case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.14.0",
+        "@ferlab/ui": "^7.14.2",
         "@loadable/component": "^5.15.2",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -2757,9 +2757,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.0.tgz",
-      "integrity": "sha512-VwLz/ISxEFeaA9xoNjdm3ryYWsmqqxCUd/M8NSGNKQQBg+9exeMlJFE4tO+9kMxMN4Ea3pHKX63FC9aMOJq4Pg==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.2.tgz",
+      "integrity": "sha512-QQxqxuQe25zfWPfywdhyKbfhIF2TwwBUz9io4s1ksES+PJrESUfGgcCfySykhQNZ9J/OR6PjGPpmKMiVMZcKXA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -35053,9 +35053,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.0.tgz",
-      "integrity": "sha512-VwLz/ISxEFeaA9xoNjdm3ryYWsmqqxCUd/M8NSGNKQQBg+9exeMlJFE4tO+9kMxMN4Ea3pHKX63FC9aMOJq4Pg==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.2.tgz",
+      "integrity": "sha512-QQxqxuQe25zfWPfywdhyKbfhIF2TwwBUz9io4s1ksES+PJrESUfGgcCfySykhQNZ9J/OR6PjGPpmKMiVMZcKXA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.14.0",
+    "@ferlab/ui": "^7.14.2",
     "@loadable/component": "^5.15.2",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -88,7 +88,7 @@ const PageContent = ({
   participantMapping,
   tabId = TAB_IDS.SUMMARY,
 }: OwnProps) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<any>();
   const history = useHistory();
   const { savedSets } = useSavedSet();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =

--- a/src/views/VariantEntity/FerlabComponent/EntityGeneConsequence.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityGeneConsequence.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { NO_GENE } from '@ferlab/ui/core/components/Consequences/Cell';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
 import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { EntityExpandableTableMultiple } from '@ferlab/ui/core/pages/EntityPage';
+
 import { IGeneEntity } from '../../../graphql/variants/models';
 
 import EntityGeneConsequenceSubtitle from './EntityGeneConsequenceSubtitle';
@@ -38,22 +40,24 @@ export const EntityGeneConsequences = ({
     id={id}
     loading={loading}
     tables={
-      genes?.map((gene) => ({
-        columns,
-        data: hydrateResults(gene?.node?.consequences?.hits?.edges || []),
-        subTitle: (
-          <EntityGeneConsequenceSubtitle
-            gene={gene}
-            dictionary={{
-              gene: 'Gene',
-              omim: 'Omim',
-              spliceai: 'SpliceAI',
-              gnomad_pli: 'gnomAD pLI',
-              gnomad_loeuf: 'gnomAD LOEUF',
-            }}
-          />
-        ),
-      })) || []
+      genes
+        ?.filter((gene) => gene.node.symbol !== NO_GENE)
+        .map((gene) => ({
+          columns,
+          data: hydrateResults(gene?.node?.consequences?.hits?.edges || []),
+          subTitle: (
+            <EntityGeneConsequenceSubtitle
+              gene={gene}
+              dictionary={{
+                gene: 'Gene',
+                omim: 'Omim',
+                spliceai: 'SpliceAI',
+                gnomad_pli: 'gnomAD pLI',
+                gnomad_loeuf: 'gnomAD LOEUF',
+              }}
+            />
+          ),
+        })) || []
     }
     title={title}
   />

--- a/src/views/VariantEntity/FerlabComponent/Pathogenecity.utils.tsx
+++ b/src/views/VariantEntity/FerlabComponent/Pathogenecity.utils.tsx
@@ -6,6 +6,7 @@ import {
 } from '@ferlab/ui/core/pages/EntityPage/type';
 import { groupRowsBySource } from '@ferlab/ui/core/pages/EntityPage/utils/pathogenicity';
 import { toKebabCase } from '@ferlab/ui/core/utils/stringUtils';
+
 import {
   IGeneCosmic,
   IGeneDdd,
@@ -92,7 +93,7 @@ export const makeUnGroupedDataRows = (genes: IArrangerEdge<IGeneEntity>[]) => {
   }
 
   return genes.map((gene) => {
-    const rowOrphanet = orphanetFromEdges(gene, gene.node.orphanet.hits.edges || []);
+    const rowOrphanet = orphanetFromEdges(gene, gene.node.orphanet?.hits?.edges || []);
     const rowOmim = omimFromEdges(gene, keepOnlyOmimWithId(gene.node.omim?.hits?.edges || []));
     const rowCosmic = cosmicFromEdges(gene, gene.node.cosmic?.hits?.edges || []);
     const rowHpo = hpoFromEdges(gene, gene.node.hpo?.hits?.edges || []);

--- a/src/views/VariantEntity/utils/consequences.tsx
+++ b/src/views/VariantEntity/utils/consequences.tsx
@@ -13,11 +13,12 @@ import {
 } from '@ferlab/ui/core/pages/EntityPage/utils/consequences';
 import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
 import { Space, Tooltip, Typography } from 'antd';
-import { IConsequenceEntity, Impact } from '../../../graphql/variants/models';
 import { capitalize } from 'lodash';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { getEntityConsequenceDictionary } from 'utils/translation';
+
+import { IConsequenceEntity, Impact } from '../../../graphql/variants/models';
 const { Text } = Typography;
 
 import { getPredictionScore } from '../FerlabComponent/Consequences.utils';

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -1,4 +1,5 @@
 import intl from 'react-intl-universal';
+import { NO_GENE } from '@ferlab/ui/core/components/Consequences/Cell';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { IEntitySummaryColumns } from '@ferlab/ui/core/pages/EntityPage/EntitySummary';
 import {
@@ -49,22 +50,24 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
             },
             {
               label: intl.get('screen.variants.summary.genes'),
-              value: variant?.genes?.hits?.edges?.length
-                ? variant.genes.hits.edges.map((gene) => {
-                    if (!gene?.node?.symbol) {
-                      return;
-                    }
-                    return (
-                      <ExternalLink
-                        key={gene.node.symbol}
-                        className={styles.geneExternalLink}
-                        href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
-                      >
-                        {gene.node.symbol}
-                      </ExternalLink>
-                    );
-                  })
-                : TABLE_EMPTY_PLACE_HOLDER,
+              value:
+                variant?.genes?.hits?.edges?.length &&
+                variant.genes.hits.edges.filter((gene) => gene?.node?.symbol !== NO_GENE).length
+                  ? variant.genes.hits.edges.map((gene) => {
+                      if (!gene?.node?.symbol) {
+                        return;
+                      }
+                      return (
+                        <ExternalLink
+                          key={gene.node.symbol}
+                          className={styles.geneExternalLink}
+                          href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
+                        >
+                          {gene.node.symbol}
+                        </ExternalLink>
+                      );
+                    })
+                  : TABLE_EMPTY_PLACE_HOLDER,
             },
             {
               label: intl.get('screen.variants.summary.omim'),

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -56,7 +56,7 @@ const addTagToFilter = (filter: ISavedFilter) => ({
 });
 
 const PageContent = ({ variantMapping }: OwnProps) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<any>();
   const { userInfo } = useUser();
   const { savedSets } = useSavedSet();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =


### PR DESCRIPTION
# BUG 

- closes #[850](https://d3b.atlassian.net/browse/SKFP-850)

## Description

> Salut! Dans le tableau du Variant Exploration, on ne veut pas afficher “NO GENE”. On va simplement retirer le “NO GENE” mais garder le restant de l’information qu’on a dans la cellule du Most Deleterious Consequence (ex. le point gris “intergenic”)
> 
> ![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/13710ebc-4568-46aa-8b3b-20e173f90c17)
> 
> Dans la page Variant entity section Consequence:
> 
> Si dans le tableau Gene Consequence, la seule conséquence est “intergenic”, afficher le message “No data available” comme c’est fait les autres sections comme Pathogenicity.
> 
> Si dans le tableau Gene Consequence, il y a une conséquence “intergenic” et d’autres conséquence autre que “intergenic”, simplement pas afficher la conséquence “intergenic” mais toujours montrer les autres conséquences 

J'ai aussi ajouté le cas pour le gene summary ou on affichait NO_GENE. Je retourne - a la place.

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/5cf5c0a0-b5c4-4af6-a9b8-8672047aed48)
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/e6d84c4d-39c0-45e5-b1b9-0f52c999bd08)


### After
![Screenshot from 2023-11-06 14-36-40](https://github.com/kids-first/kf-portal-ui/assets/65532894/e278ee36-f865-4b8d-bd55-3ec25d893ffa)
![Screenshot from 2023-11-06 14-37-01](https://github.com/kids-first/kf-portal-ui/assets/65532894/4c69ad23-195f-498d-ba19-250e916908f2)
![Screenshot from 2023-11-06 14-37-12](https://github.com/kids-first/kf-portal-ui/assets/65532894/7293e35f-5995-4015-94af-a399c5ca64fb)
![Screenshot from 2023-11-06 14-38-05](https://github.com/kids-first/kf-portal-ui/assets/65532894/5d507a7d-bb63-4b88-a8f8-ee0b34e0ed4d)

