### PR TITLE
fix(files): SKFP-815 export TSV with platform col

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -238,7 +238,7 @@ export const getDefaultColumns = (
     sorter: { multiple: 1 },
   },
   {
-    key: 'platform',
+    key: 'sequencing_experiment.platform',
     title: 'Platform',
     defaultHidden: true,
     sorter: { multiple: 1 },


### PR DESCRIPTION
#[BUG] Files export TSV is missing platform column

## Description

[SKFP-815](https://d3b.atlassian.net/browse/SKFP-815)

Acceptance Criterias
When I export files data with platform column I want to see it in the TSV export file.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
Column not displayed

### After
<img width="1274" alt="Capture d’écran, le 2023-11-20 à 10 22 21" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b9211d3f-6acc-4d58-8203-82a9eae1a426">



[SKFP-815]: https://d3b.atlassian.net/browse/SKFP-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ