### PR TITLE
fix(query): SKFP-855 fix redirect from variant

### DIFF
--- a/src/views/VariantEntity/SummaryHeader/index.tsx
+++ b/src/views/VariantEntity/SummaryHeader/index.tsx
@@ -48,7 +48,7 @@ const SummaryHeader = ({ variant }: OwnProps) => {
                 generateValueFilter({
                   field: 'study.study_code',
                   value: studyCodes,
-                  index: '',
+                  index: INDEXES.PARTICIPANT,
                 }),
               ],
             }),


### PR DESCRIPTION
#[BUG] Query pill dropdown not working (error 500)

## Description

[SKFP-855](https://d3b.atlassian.net/browse/SKFP-855)

Acceptance Criterias
When we are redirect to data exploration from variant entity by the studies link, the value filter generated produce a 500 error on value click to display the dropdown.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
https://github.com/kids-first/kf-portal-ui/assets/133775440/0cd7c8d6-e777-4c0f-b56c-6589d69357d6

### After
https://github.com/kids-first/kf-portal-ui/assets/133775440/d34d29c7-ed87-4562-8bd4-daa20ad3a855

[SKFP-855]: https://d3b.atlassian.net/browse/SKFP-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ