### PR TITLE
fix(tag): SKFP-911 color link on hover

### DIFF
--- a/src/style/themes/kids-first/antd/tags.less
+++ b/src/style/themes/kids-first/antd/tags.less
@@ -77,3 +77,10 @@
     background-color: @purple-2;
   }
 }
+
+.ant-tag a {
+  color: inherit;
+}
+.ant-tag a:hover {
+  color: inherit;
+}


### PR DESCRIPTION
# [BUG] Fix color link in a tag on hover

[SKFP-911](https://d3b.atlassian.net/browse/SKFP-911)

## Description

Acceptance Criterias

- The link text color within tags should not change.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
https://github.com/kids-first/kf-portal-ui/assets/133775440/190f4058-d65e-4980-8389-ba848f28752e

### After
https://github.com/kids-first/kf-portal-ui/assets/133775440/2cfb0f91-dba5-4ca1-955e-c33cc1f1109c


[SKFP-911]: https://d3b.atlassian.net/browse/SKFP-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ