### PR TITLE
fix(widget): SKFP-918 auth studies style and count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.16.0",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.19.2",
+        "@ferlab/ui": "^7.19.3",
         "@loadable/component": "^5.15.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@react-keycloak/core": "^3.2.0",
@@ -2926,9 +2926,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.19.2.tgz",
-      "integrity": "sha512-SCJzjblYqB8mnDcSokQmfo3G9sBr/VS9IoNP3o0HLwMrWObwqaswjLTTh2/MuLmYRXVZ4ReCnM9WS9boFHAzsQ==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.19.3.tgz",
+      "integrity": "sha512-fTj+SZVSeXuNLbQvsY+SfdP2yUi6As97kSMAw+UGwg6SV/LIGtk1TmB/qAO8jma19S8ry7uvXxufN92AMSaQ3Q==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -36539,9 +36539,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.19.2.tgz",
-      "integrity": "sha512-SCJzjblYqB8mnDcSokQmfo3G9sBr/VS9IoNP3o0HLwMrWObwqaswjLTTh2/MuLmYRXVZ4ReCnM9WS9boFHAzsQ==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.19.3.tgz",
+      "integrity": "sha512-fTj+SZVSeXuNLbQvsY+SfdP2yUi6As97kSMAw+UGwg6SV/LIGtk1TmB/qAO8jma19S8ry7uvXxufN92AMSaQ3Q==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "^7.16.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.19.2",
+    "@ferlab/ui": "^7.19.3",
     "@loadable/component": "^5.15.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@react-keycloak/core": "^3.2.0",

--- a/src/store/fences/slice.ts
+++ b/src/store/fences/slice.ts
@@ -98,6 +98,7 @@ const fencesSlice = createSlice({
     builder.addCase(fenceDisconnection.fulfilled, (state, action) => {
       state[action.meta.arg].status = FENCE_AUHTENTIFICATION_STATUS.disconnected;
       state[action.meta.arg].loading = false;
+      state.authorizedStudies.studies = [];
     });
     builder.addCase(fenceDisconnection.rejected, (state, action) => {
       state[action.meta.arg].status = FENCE_AUHTENTIFICATION_STATUS.disconnected;


### PR DESCRIPTION
# [BUG] Fix Authorized Studies style and count

[SKFP-918](https://d3b.atlassian.net/browse/SKFP-918)

## Description

Acceptance Criterias

- incorrect stats count in study item. We want (authorized_controlled_files_count + total_uncontrolled_files_count) of total_files_count
- Number of study items in the header sticks after fence disconnection. To reproduce, connect with success to a fence, make sure a number is displayed in the header, disconnect the fence, the list of item will empty itself but the count will remain.
- Wording between header and list cut sometimes.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
Small screen
<img width="577" alt="Capture d’écran, le 2024-01-16 à 11 58 50" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/ff0b9003-96f7-470f-b931-3f11cb2038bf">

### After
Small screen
<img width="687" alt="Capture d’écran, le 2024-01-16 à 16 07 21" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/a7c1184b-8e9c-4223-9138-48a0dcffa563">

<img width="687" alt="Capture d’écran, le 2024-01-16 à 16 07 30" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/1ee6cad7-0067-4241-99bd-6cb65daab2c9">

Big screen
![Capture d’écran, le 2024-01-16 à 16 08 52](https://github.com/kids-first/kf-portal-ui/assets/133775440/b94bf721-f8b7-4dd2-8b87-5b48f3cb1791)


[SKFP-918]: https://d3b.atlassian.net/browse/SKFP-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ