### PR TITLE
fix(usersnap): SKFP-914 usersnap not loaded

### DIFF
--- a/src/services/initUsersnap.ts
+++ b/src/services/initUsersnap.ts
@@ -1,4 +1,4 @@
-import EnvVariables from "helpers/EnvVariables";
+import EnvVariables from 'helpers/EnvVariables';
 
 declare global {
   interface Window {
@@ -7,7 +7,7 @@ declare global {
 }
 
 export const initUserSnap = () => {
-  const apiKey = EnvVariables.configFor("USER_SNAP_API_KEY");
+  const apiKey = EnvVariables.configFor('USER_SNAP_API_KEY');
 
   if (!apiKey) {
     return;
@@ -17,8 +17,19 @@ export const initUserSnap = () => {
     api.init();
   };
 
-  const script = document.createElement("script");
-  script.async = true;
-  script.src = `https://widget.usersnap.com/load/${apiKey}?onload=onUsersnapCXLoad`;
-  document.head.append(script);
+  fetch(`https://widget.usersnap.com/load/${apiKey}?onload=onUsersnapCXLoad`, {
+    body: null,
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'omit',
+  })
+    .then(() => {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = `https://widget.usersnap.com/load/${apiKey}?onload=onUsersnapCXLoad`;
+      document.head.append(script);
+    })
+    .catch((error: any) => {
+      console.log(error.message);
+    });
 };


### PR DESCRIPTION
# [BUG] Safari - usersnap not loaded crash portal

[SKFP-914](https://d3b.atlassian.net/browse/SKFP-914)

## Description

Acceptance Criterias

- if usersnap widget is not loaded the portal must open like in chrome.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design


[SKFP-914]: https://d3b.atlassian.net/browse/SKFP-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ