### PR TITLE
fix(cavatica): SKFP-895 should update list when a new project is created

### DIFF
--- a/src/store/passport/slice.ts
+++ b/src/store/passport/slice.ts
@@ -116,6 +116,7 @@ const passportSlice = createSlice({
     });
     builder.addCase(createCavaticaProjet.fulfilled, (state, action) => {
       state.cavatica.projects.loading = false;
+      state.cavatica.projects.data.push(action.payload.newProject);
     });
     builder.addCase(createCavaticaProjet.rejected, (state, action) => {
       state.cavatica.projects.loading = false;


### PR DESCRIPTION
# BUG 

- closes #895

## Description
https://d3b.atlassian.net/browse/SKFP-895

List wasn't updating when creating a new project

Snapshot use a mock, so the same data is returned (needed to test on a local dev env)

https://github.com/kids-first/kf-portal-ui/assets/65532894/153bbf98-9ddb-49fd-a32f-4414c11de6e4

