### PR TITLE
fix(table): SKFP-926 fixed column color

### DIFF
--- a/src/style/themes/kids-first/antd/tables.less
+++ b/src/style/themes/kids-first/antd/tables.less
@@ -62,3 +62,13 @@
     }
   }
 }
+
+.ant-table-tbody > tr:nth-child(even):not(.ant-table-row-selected) td {
+  background-color: #f8fafc;
+}
+.ant-table-tbody > tr:nth-child(even):not(.ant-table-row-selected) td.ant-table-column-sort {
+  background-color: #f1f5f9;
+}
+.ant-table-tbody > tr:nth-child(even):not(.ant-table-row-selected):hover td {
+  background-color: #f1f5f9;
+}


### PR DESCRIPTION
# [BUG] Fix alternated color on fixed column lines

SKFP-926

## Description

Acceptance Criterias
In fixed columns, line colors must be alternated. (sorted or not, selected or not)

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="554" alt="Capture d’écran, le 2024-01-29 à 11 14 33" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/443f04f0-329e-4f5c-805b-1b6a097cae97">

### After
<img width="554" alt="Capture d’écran, le 2024-01-29 à 11 15 30" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/22d1b436-7bc6-4591-8cd7-c4c7109c5bce">
