### PR TITLE
fix(variants): SKFP-936 CADD value

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -384,8 +384,8 @@ const getDefaultColumns = (queryBuilderId: string, noData: boolean = false): Pro
       const pickedConsequence = geneWithPickedConsequence.consequences?.hits?.edges?.find(
         (c) => c.node.picked,
       );
-      return pickedConsequence?.node?.predictions?.cadd_score
-        ? pickedConsequence.node.predictions.cadd_score
+      return pickedConsequence?.node?.predictions?.cadd_phred
+        ? pickedConsequence.node.predictions.cadd_phred
         : TABLE_EMPTY_PLACE_HOLDER;
     },
     width: 90,


### PR DESCRIPTION
# [BUG] Display the CADD phred value in table

## Description

[SKFP-936](https://d3b.atlassian.net/browse/SKFP-936)
Acceptance Criterias
- display CADD phred instead of CADD raw in CADD column

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="177" alt="Capture d’écran, le 2024-02-02 à 10 29 10" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/bf428fb3-7195-4f58-8132-0409ed114e8e">

### After
<img width="177" alt="Capture d’écran, le 2024-02-02 à 10 28 11" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/b3c74ef3-39f6-4497-8313-0ff32ada71ef">


[SKFP-936]: https://d3b.atlassian.net/browse/SKFP-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ