### PR TITLE
fix(user): SKFP-915 user config lost

### DIFF
--- a/src/store/user/slice.ts
+++ b/src/store/user/slice.ts
@@ -72,9 +72,9 @@ const userSlice = createSlice({
         config: action.payload,
       },
     }));
-    builder.addCase(updateUserConfig.rejected, (state, action) => ({
+    builder.addCase(updateUserConfig.rejected, (state) => ({
       ...state,
-      error: action.payload,
+      isLoading: false,
     }));
 
     // Delete User


### PR DESCRIPTION
# [BUG] User config update saved only one page config

## Description

[SKFP-915](https://d3b.atlassian.net/browse/SKFP-915)

Acceptance Criterias
- When a user changes columns config he wants it's saved for an other visit.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
See video in ticket.

### After
https://github.com/kids-first/kf-portal-ui/assets/133775440/3e86471d-0450-4396-be6e-f10adcb42aa7



[SKFP-915]: https://d3b.atlassian.net/browse/SKFP-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ