### PR TITLE
feat(studies): SKFP-927 Add sort to fields in Study Page

### DIFF
--- a/src/views/Studies/components/PageContent/index.tsx
+++ b/src/views/Studies/components/PageContent/index.tsx
@@ -5,9 +5,11 @@ import { ReadOutlined } from '@ant-design/icons';
 import { TExtendedMapping } from '@ferlab/ui/core/components/filters/types';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
 import QueryBuilder from '@ferlab/ui/core/components/QueryBuilder';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { isEmptySqon, resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { Space, Typography } from 'antd';
@@ -52,6 +54,12 @@ const PageContent = ({
     first: PAGE_SIZE,
     offset: PAGE_SIZE * (queryConfig.pageIndex - 1),
     sqon: resolvedSqon,
+    sort: tieBreaker({
+      sort: queryConfig.sort,
+      defaultSort: [],
+      field: 'study_id',
+      order: queryConfig.operations?.previous ? SortDirection.Desc : SortDirection.Asc,
+    }),
   });
 
   useEffect(() => {
@@ -114,11 +122,12 @@ const PageContent = ({
             initialColumnState={userInfo?.config.study?.tables?.study?.columns}
             wrapperClassName={styles.tableWrapper}
             loading={loading}
+            showSorterTooltip={false}
             bordered
-            onChange={({ current, pageSize }, _, sorter) => {
+            onChange={(_pagination, _filter, sorter) => {
               setQueryConfig({
-                pageIndex: current!,
-                size: pageSize!,
+                pageIndex: DEFAULT_PAGE_INDEX,
+                size: queryConfig.size!,
                 sort: formatQuerySortList(sorter),
               });
             }}

--- a/src/views/Studies/components/PageContent/index.tsx
+++ b/src/views/Studies/components/PageContent/index.tsx
@@ -27,7 +27,12 @@ import { formatQuerySortList } from 'utils/helper';
 import { getProTableDictionary } from 'utils/translation';
 import { getQueryBuilderDictionary } from 'utils/translation';
 
-import { DEFAULT_PAGE_INDEX, DEFAULT_QUERY_CONFIG, STUDIES_REPO_QB_ID } from '../../utils/constant';
+import {
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_QUERY_CONFIG,
+  DEFAULT_STUDY_QUERY_SORT,
+  STUDIES_REPO_QB_ID,
+} from '../../utils/constant';
 
 import styles from './index.module.scss';
 
@@ -47,7 +52,10 @@ const PageContent = ({
   const dispatch = useDispatch();
   const { userInfo } = useUser();
   const { queryList, activeQuery } = useQueryBuilderState(STUDIES_REPO_QB_ID);
-  const [queryConfig, setQueryConfig] = useState(DEFAULT_QUERY_CONFIG);
+  const [queryConfig, setQueryConfig] = useState({
+    ...DEFAULT_QUERY_CONFIG,
+    sort: DEFAULT_STUDY_QUERY_SORT,
+  });
   const resolvedSqon = resolveSyntheticSqon(queryList, activeQuery);
 
   const { loading, total, data } = useStudies({
@@ -56,8 +64,8 @@ const PageContent = ({
     sqon: resolvedSqon,
     sort: tieBreaker({
       sort: queryConfig.sort,
-      defaultSort: [],
-      field: 'study_id',
+      defaultSort: DEFAULT_STUDY_QUERY_SORT,
+      field: 'study_code',
       order: queryConfig.operations?.previous ? SortDirection.Desc : SortDirection.Asc,
     }),
   });

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -49,6 +49,7 @@ const columns: ProColumnType<any>[] = [
   {
     key: 'study_code',
     title: 'Code',
+    sorter: { multiple: 1 },
     render: (record: IStudyEntity) =>
       record?.website ? (
         <ExternalLink href={record.website}>{record.study_code}</ExternalLink>
@@ -58,6 +59,7 @@ const columns: ProColumnType<any>[] = [
   },
   {
     key: 'study_name',
+    sorter: { multiple: 1 },
     title: 'Name',
     dataIndex: 'study_name',
     width: 500,
@@ -80,6 +82,7 @@ const columns: ProColumnType<any>[] = [
     key: 'external_id',
     title: 'dbGaP',
     dataIndex: 'external_id',
+    sorter: { multiple: 1 },
     render: (externalId: string) =>
       externalId ? (
         <ExternalLink
@@ -94,6 +97,7 @@ const columns: ProColumnType<any>[] = [
   {
     key: 'participant_count',
     title: 'Participants',
+    sorter: { multiple: 1 },
     render: (record: IStudyEntity) => {
       const participantCount = record.participant_count;
 
@@ -126,6 +130,7 @@ const columns: ProColumnType<any>[] = [
   {
     key: 'biospecimen_count',
     title: 'Biospecimens',
+    sorter: { multiple: 1 },
     render: (record: IStudyEntity) => {
       const biospecimenCount = record.biospecimen_count;
 
@@ -159,6 +164,7 @@ const columns: ProColumnType<any>[] = [
     key: 'family_count',
     title: 'Families',
     dataIndex: 'family_count',
+    sorter: { multiple: 1 },
     render: (family_count: number) =>
       family_count ? numberWithCommas(family_count) : TABLE_EMPTY_PLACE_HOLDER,
   },

--- a/src/views/Studies/utils/constant.ts
+++ b/src/views/Studies/utils/constant.ts
@@ -1,4 +1,5 @@
-import { IQueryConfig } from '@ferlab/ui/core/graphql/types';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { IQueryConfig, ISort } from '@ferlab/ui/core/graphql/types';
 
 export const STUDIES_REPO_QB_ID = 'studies-repo-key';
 
@@ -13,6 +14,10 @@ export const DEFAULT_PAGING_CONFIG = {
   index: DEFAULT_PAGE_INDEX,
   size: DEFAULT_PAGE_SIZE,
 };
+
+export const DEFAULT_STUDY_QUERY_SORT = [
+  { field: 'study_code', order: SortDirection.Asc },
+] as ISort[];
 
 export const DEFAULT_QUERY_CONFIG: IQueryConfig = {
   pageIndex: DEFAULT_PAGE_INDEX,


### PR DESCRIPTION
# FEAT: Add sort to fields in Study Page

- closes [#SKFP-927](https://d3b.atlassian.net/jira/software/c/projects/SKFP/boards/82?selectedIssue=SKFP-927)

## Description

Goal: add the sort funcitonality on the following fields in the study page table of results:

- Study code
- Study Name
- dbGaP
- Participants
- Families
- Biospecimens
