### PR TITLE
feat(cavatica): SKFP-956 add sorter when starting cavatica analyse

### DIFF
--- a/src/components/Cavatica/AnalyzeButton/index.tsx
+++ b/src/components/Cavatica/AnalyzeButton/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@ferlab/ui/core/components/Widgets/Cavatica/type';
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { ISort } from '@ferlab/ui/core/graphql/types';
 import { CAVATICA_FILE_BATCH_SIZE } from 'views/DataExploration/utils/constant';
 
 import { trackCavaticaAction } from 'services/analytics';
@@ -29,6 +30,7 @@ import { SUPPORT_EMAIL } from 'store/report/thunks';
 interface OwnProps {
   fileIds: string[];
   sqon?: ISqonGroupFilter;
+  sort?: ISort[];
   type?: 'default' | 'primary';
   disabled?: boolean;
   index: string;
@@ -37,6 +39,7 @@ interface OwnProps {
 const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
   fileIds,
   sqon,
+  sort = [],
   type = 'default',
   disabled = false,
   index,
@@ -52,6 +55,7 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
             op: BooleanOperators.and,
             content: [],
           },
+          sort,
           fileIds,
         }),
       ),

--- a/src/store/passport/metadata.ts
+++ b/src/store/passport/metadata.ts
@@ -1,0 +1,119 @@
+import { IFileEntity, IFileStudyEntity } from 'graphql/files/models';
+import { toNodes } from 'graphql/utils/helpers';
+
+import { keepOnly } from 'utils/helper';
+
+import { makeUniqueWords as unique } from '../../helpers';
+
+const joinUniquely = (l: string[]) => unique(l).join(',');
+
+const extractFileMetaData = (file: IFileEntity) => ({
+  fhir_document_reference: file.fhir_document_reference,
+  file_id: file.file_id,
+  external_file_id: file.external_id,
+  file_name: file.file_name,
+  data_category: file.data_category,
+  data_type: file.data_type,
+  file_format: file.file_format,
+  repository: file.repository,
+  acl: joinUniquely(file.acl),
+  access_url: file.access_urls,
+});
+
+const extractParticipantMetaData = (participants: any[]) => {
+  const diagnosis = participants.flatMap((participant) => toNodes(participant.diagnosis));
+  const outcomes = participants.flatMap((participant) => toNodes(participant.outcomes));
+  const phenotype = participants.flatMap((participant) => toNodes(participant.phenotype));
+  const relation = participants.flatMap((participant) =>
+    participant.family ? toNodes(participant.family.relations_to_proband) : '',
+  );
+
+  return {
+    case_id: joinUniquely(participants.map((x) => x.participant_id)),
+    external_participant_ids: joinUniquely(participants.map((x) => x.external_id)),
+    proband: joinUniquely(participants.map((x) => `${x.participant_id}: ${x.is_proband}`)),
+    ethnicity: joinUniquely(participants.map((x) => x.ethnicity)),
+    gender: joinUniquely(participants.map((x) => x.sex)),
+    race: joinUniquely(participants.map((x) => x.race)),
+    age_at_participant_diagnosis: joinUniquely(diagnosis.map((d) => d.age_at_event_days)),
+    age_at_vital_status: joinUniquely(outcomes.map((o) => o.age_at_event_days.value)),
+    age_at_observed_phenotype: joinUniquely(phenotype.map((p) => p.age_at_event_days)),
+    diagnosis_mondo: joinUniquely(diagnosis.map((d) => d.mondo_id_diagnosis)),
+    diagnosis_ncit: joinUniquely(diagnosis.map((d) => d.ncit_id_diagnosis)),
+    diagnosis_source_text: joinUniquely(diagnosis.map((d) => d.source_text)),
+    family_id: joinUniquely(participants.map((x) => x.families_id)),
+    family_composition: joinUniquely(participants.map((x) => x.family_type)),
+    family_role: joinUniquely(relation.map((r) => r.role)),
+    observed_phenotype_hpo: joinUniquely(phenotype.map((p) => p.hpo_phenotype_observed)),
+    not_observed_phenotype_hpo: joinUniquely(phenotype.map((p) => p.hpo_phenotype_not_observed)),
+    observed_phenotype_source_text: joinUniquely(
+      phenotype.map((p) => p.hpo_phenotype_observed_text),
+    ),
+    vital_status: joinUniquely(outcomes.map((o) => o.vital_status)),
+  };
+};
+
+const extractBioSpecimenMetaData = (biospecimens: any[]) => {
+  const diagnoses = biospecimens.flatMap((x) => toNodes(x.diagnoses));
+  return {
+    sample_id: joinUniquely(biospecimens.map((x) => x.sample_id)),
+    sample_type: joinUniquely(biospecimens.map((x) => x.sample_type)),
+    external_sample_id: joinUniquely(biospecimens.map((x) => x.external_sample_id)),
+    collection_sample_type: joinUniquely(biospecimens.map((x) => x.collection_sample_type)),
+    age_at_biospecimen_collection: joinUniquely(
+      biospecimens.map((x) => x.age_at_biospecimen_collection),
+    ),
+    age_at_histological_diagnosis: joinUniquely(diagnoses.map((d) => d.age_at_event.value)),
+    tumor_descriptor: joinUniquely(diagnoses.map((d) => d.source_text_tumor_descriptor)),
+    method_of_sample_procurement: joinUniquely(
+      biospecimens.map((d) => d.collection_method_of_sample_procurement),
+    ),
+    tumor_location: joinUniquely(diagnoses.map((d) => d.source_text_tumor_location)),
+    histological_diagnosis_source_text: joinUniquely(diagnoses.map((d) => d.source_text)),
+    histological_diagnosis_ncit: joinUniquely(diagnoses.map((d) => d.diagnosis_ncit)),
+    histological_diagnosis_mondo: joinUniquely(diagnoses.map((d) => d.diagnosis_mondo)),
+    dbgap_consent_code: joinUniquely(biospecimens.map((x) => x.dbgap_consent_code)),
+    consent_type: joinUniquely(biospecimens.map((x) => x.consent_type)),
+    anatomical_site_source_text: joinUniquely(biospecimens.map((x) => x.collection_anatomy_site)),
+  };
+};
+
+const extractSequentialExperimentMetaData = (sequentialExperiments: any[]) => ({
+  experimental_strategy: joinUniquely(sequentialExperiments.map((x) => x.experiment_strategy)),
+  platform: joinUniquely(sequentialExperiments.map((x) => x.platform)),
+  instrument_model: joinUniquely(sequentialExperiments.map((x) => x.instrument_model)),
+  library_strand: joinUniquely(sequentialExperiments.map((x) => x.library_strand)),
+  is_paired_end: joinUniquely(sequentialExperiments.map((x) => x.is_paired_end)),
+});
+
+const extractStudyMetaData = (study: IFileStudyEntity) => ({
+  investigation: study.study_code,
+  study_name: study.study_name,
+  study_program: study.program,
+  study_domain: study.domain,
+});
+
+export const extractMetadata = (file: IFileEntity) => {
+  if (!file || !Object.keys(file).length) {
+    return {};
+  }
+
+  const sequentialExperiments = toNodes(file.sequencing_experiment);
+  const participants = toNodes(file.participants);
+  const biospecimens = participants.flatMap((participant) => toNodes(participant.biospecimens));
+
+  const fileMetaData = extractFileMetaData(file);
+  const participantsMetaData = extractParticipantMetaData(participants);
+  const biospecimensMetaData = extractBioSpecimenMetaData(biospecimens);
+  const sequentialExperimentsMetaData = extractSequentialExperimentMetaData(sequentialExperiments);
+  const studyMetaData = extractStudyMetaData(file.study);
+
+  return keepOnly({
+    ...fileMetaData,
+    ...participantsMetaData,
+    ...biospecimensMetaData,
+    ...sequentialExperimentsMetaData,
+    ...studyMetaData,
+    reference_genome: null,
+  });
+};

--- a/src/store/passport/thunks.test.ts
+++ b/src/store/passport/thunks.test.ts
@@ -1,7 +1,7 @@
 import { IFileEntity } from 'graphql/files/models';
 import { FamilyType, Sex } from 'graphql/participants/models';
 
-import { extractMetadata } from './thunks';
+import { extractMetadata } from './metadata';
 
 describe(`${extractMetadata.name}()`, () => {
   test('should handle edge case', () => {

--- a/src/store/passport/thunks.ts
+++ b/src/store/passport/thunks.ts
@@ -12,11 +12,11 @@ import {
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { termToSqon } from '@ferlab/ui/core/data/sqon/utils';
+import { ISort } from '@ferlab/ui/core/graphql/types';
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { IFileEntity, IFileResultTree, IFileStudyEntity } from 'graphql/files/models';
+import { IFileEntity, IFileResultTree } from 'graphql/files/models';
 import { SEARCH_FILES_QUERY } from 'graphql/files/queries';
 import { hydrateResults } from 'graphql/models';
-import { toNodes } from 'graphql/utils/helpers';
 import EnvironmentVariables from 'helpers/EnvVariables';
 import { isEmpty } from 'lodash';
 import { CAVATICA_FILE_BATCH_SIZE } from 'views/DataExploration/utils/constant';
@@ -35,9 +35,9 @@ import { globalActions } from 'store/global';
 import { RootState } from 'store/types';
 import { handleThunkApiReponse } from 'store/utils';
 import { userHasAccessToFile } from 'utils/dataFiles';
-import { chunkIt, keepOnly } from 'utils/helper';
+import { chunkIt } from 'utils/helper';
 
-import { makeUniqueWords as unique } from '../../helpers';
+import { extractMetadata } from './metadata';
 
 const USER_BASE_URL = EnvironmentVariables.configFor('CAVATICA_USER_BASE_URL');
 const TEN_MINUTES_IN_MS = 1000 * 60 * 10;
@@ -218,6 +218,7 @@ export const beginCavaticaAnalyse = createAsyncThunk<
   },
   {
     sqon: ISqonGroupFilter;
+    sort: ISort[];
     fileIds: string[];
   },
   { rejectValue: string; state: RootState }
@@ -255,6 +256,7 @@ export const beginCavaticaAnalyse = createAsyncThunk<
     query: SEARCH_FILES_QUERY.loc?.source.body,
     variables: {
       sqon,
+      sort: args.sort,
       first: CAVATICA_FILE_BATCH_SIZE,
     },
   });
@@ -287,119 +289,6 @@ export const beginCavaticaAnalyse = createAsyncThunk<
     },
   });
 });
-
-const joinUniquely = (l: string[]) => unique(l).join(',');
-
-const extractFileMetaData = (file: IFileEntity) => ({
-  fhir_document_reference: file.fhir_document_reference,
-  file_id: file.file_id,
-  external_file_id: file.external_id,
-  file_name: file.file_name,
-  data_category: file.data_category,
-  data_type: file.data_type,
-  file_format: file.file_format,
-  repository: file.repository,
-  acl: joinUniquely(file.acl),
-  access_url: file.access_urls,
-});
-
-const extractParticipantMetaData = (participants: any[]) => {
-  const diagnosis = participants.flatMap((participant) => toNodes(participant.diagnosis));
-  const outcomes = participants.flatMap((participant) => toNodes(participant.outcomes));
-  const phenotype = participants.flatMap((participant) => toNodes(participant.phenotype));
-  const relation = participants.flatMap((participant) =>
-    participant.family ? toNodes(participant.family.relations_to_proband) : '',
-  );
-
-  return {
-    case_id: joinUniquely(participants.map((x) => x.participant_id)),
-    external_participant_ids: joinUniquely(participants.map((x) => x.external_id)),
-    proband: joinUniquely(participants.map((x) => `${x.participant_id}: ${x.is_proband}`)),
-    ethnicity: joinUniquely(participants.map((x) => x.ethnicity)),
-    gender: joinUniquely(participants.map((x) => x.sex)),
-    race: joinUniquely(participants.map((x) => x.race)),
-    age_at_participant_diagnosis: joinUniquely(diagnosis.map((d) => d.age_at_event_days)),
-    age_at_vital_status: joinUniquely(outcomes.map((o) => o.age_at_event_days.value)),
-    age_at_observed_phenotype: joinUniquely(phenotype.map((p) => p.age_at_event_days)),
-    diagnosis_mondo: joinUniquely(diagnosis.map((d) => d.mondo_id_diagnosis)),
-    diagnosis_ncit: joinUniquely(diagnosis.map((d) => d.ncit_id_diagnosis)),
-    diagnosis_source_text: joinUniquely(diagnosis.map((d) => d.source_text)),
-    family_id: joinUniquely(participants.map((x) => x.families_id)),
-    family_composition: joinUniquely(participants.map((x) => x.family_type)),
-    family_role: joinUniquely(relation.map((r) => r.role)),
-    observed_phenotype_hpo: joinUniquely(phenotype.map((p) => p.hpo_phenotype_observed)),
-    not_observed_phenotype_hpo: joinUniquely(phenotype.map((p) => p.hpo_phenotype_not_observed)),
-    observed_phenotype_source_text: joinUniquely(
-      phenotype.map((p) => p.hpo_phenotype_observed_text),
-    ),
-    vital_status: joinUniquely(outcomes.map((o) => o.vital_status)),
-  };
-};
-
-const extractBioSpecimenMetaData = (biospecimens: any[]) => {
-  const diagnoses = biospecimens.flatMap((x) => toNodes(x.diagnoses));
-  return {
-    sample_id: joinUniquely(biospecimens.map((x) => x.sample_id)),
-    sample_type: joinUniquely(biospecimens.map((x) => x.sample_type)),
-    external_sample_id: joinUniquely(biospecimens.map((x) => x.external_sample_id)),
-    collection_sample_type: joinUniquely(biospecimens.map((x) => x.collection_sample_type)),
-    age_at_biospecimen_collection: joinUniquely(
-      biospecimens.map((x) => x.age_at_biospecimen_collection),
-    ),
-    age_at_histological_diagnosis: joinUniquely(diagnoses.map((d) => d.age_at_event.value)),
-    tumor_descriptor: joinUniquely(diagnoses.map((d) => d.source_text_tumor_descriptor)),
-    method_of_sample_procurement: joinUniquely(
-      biospecimens.map((d) => d.collection_method_of_sample_procurement),
-    ),
-    tumor_location: joinUniquely(diagnoses.map((d) => d.source_text_tumor_location)),
-    histological_diagnosis_source_text: joinUniquely(diagnoses.map((d) => d.source_text)),
-    histological_diagnosis_ncit: joinUniquely(diagnoses.map((d) => d.diagnosis_ncit)),
-    histological_diagnosis_mondo: joinUniquely(diagnoses.map((d) => d.diagnosis_mondo)),
-    dbgap_consent_code: joinUniquely(biospecimens.map((x) => x.dbgap_consent_code)),
-    consent_type: joinUniquely(biospecimens.map((x) => x.consent_type)),
-    anatomical_site_source_text: joinUniquely(biospecimens.map((x) => x.collection_anatomy_site)),
-  };
-};
-const extractSequentialExperimentMetaData = (sequentialExperiments: any[]) => ({
-  experimental_strategy: joinUniquely(sequentialExperiments.map((x) => x.experiment_strategy)),
-  platform: joinUniquely(sequentialExperiments.map((x) => x.platform)),
-  instrument_model: joinUniquely(sequentialExperiments.map((x) => x.instrument_model)),
-  library_strand: joinUniquely(sequentialExperiments.map((x) => x.library_strand)),
-  is_paired_end: joinUniquely(sequentialExperiments.map((x) => x.is_paired_end)),
-});
-
-const extractStudyMetaData = (study: IFileStudyEntity) => ({
-  investigation: study.study_code,
-  study_name: study.study_name,
-  study_program: study.program,
-  study_domain: study.domain,
-});
-
-export const extractMetadata = (file: IFileEntity) => {
-  if (!file || !Object.keys(file).length) {
-    return {};
-  }
-
-  const sequentialExperiments = toNodes(file.sequencing_experiment);
-  const participants = toNodes(file.participants);
-  const biospecimens = participants.flatMap((participant) => toNodes(participant.biospecimens));
-
-  const fileMetaData = extractFileMetaData(file);
-  const participantsMetaData = extractParticipantMetaData(participants);
-  const biospecimensMetaData = extractBioSpecimenMetaData(biospecimens);
-  const sequentialExperimentsMetaData = extractSequentialExperimentMetaData(sequentialExperiments);
-  const studyMetaData = extractStudyMetaData(file.study);
-
-  return keepOnly({
-    ...fileMetaData,
-    ...participantsMetaData,
-    ...biospecimensMetaData,
-    ...sequentialExperimentsMetaData,
-    ...studyMetaData,
-    reference_genome: null,
-  });
-};
-
 export const startBulkImportJob = createAsyncThunk<
   any,
   ICavaticaTreeNode,

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -438,6 +438,7 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
               type="primary"
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}
+              sort={queryConfig.sort ?? DEFAULT_FILE_QUERY_SORT}
               key="file-cavatica-upload"
               index={INDEXES.FILE}
             />,


### PR DESCRIPTION
# FEATURE

- closes #[956](https://d3b.atlassian.net/browse/SKFP-956)

## Description

Lors du bulk import, il faudrait utiliser le même sorter que dans le tableau où on à fait selectAll quand on fetch les ids de fichiers. Car vue que plusieurs requêtes sont envoyé, on n’est pas sûr de recevoir les données dans le même ordre


## Screenshot 

![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/7dec6671-1a46-4c5a-abfa-b8cc2a095cbd)


