### PR TITLE
feat(variant): SKFP-901 add consequence section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.16.0",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.5.3",
+        "@ferlab/ui": "^9.6.0",
         "@loadable/component": "^5.15.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@react-keycloak/core": "^3.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.5.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.5.3.tgz",
-      "integrity": "sha512-3eiYBbf6J6PRr5w/frL5+m8Ez+ywrCcFxW3HkwOW/dN2PrqScH6qHo94TVsqTr08LyLql8l65TBLLpsr48tJNQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.6.0.tgz",
+      "integrity": "sha512-w5Ga0dopYVNMML/DDwmt0eDg3ysr7hiLQ06MhCPgJYkLoaUisYnJJ11gleKBhLnEbar0REXYYS/2RqBRcmOkKw==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -36803,9 +36803,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "9.5.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.5.3.tgz",
-      "integrity": "sha512-3eiYBbf6J6PRr5w/frL5+m8Ez+ywrCcFxW3HkwOW/dN2PrqScH6qHo94TVsqTr08LyLql8l65TBLLpsr48tJNQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.6.0.tgz",
+      "integrity": "sha512-w5Ga0dopYVNMML/DDwmt0eDg3ysr7hiLQ06MhCPgJYkLoaUisYnJJ11gleKBhLnEbar0REXYYS/2RqBRcmOkKw==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "^7.16.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.5.3",
+    "@ferlab/ui": "^9.6.0",
     "@loadable/component": "^5.15.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@react-keycloak/core": "^3.2.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1004,6 +1004,7 @@ const en = {
         strand: 'Strand',
         vep: 'VEP',
         predictions: {
+          prediction: 'Prediction',
           predictions: 'Predictions',
           sift: 'Sift',
           polyphen2: 'Polyphen2',
@@ -1017,10 +1018,19 @@ const en = {
         refSeq: 'RefSeq',
         geneConsequence: 'Gene Consequence',
         gene: 'Gene',
+        geneType: 'Gene Type',
         omim: 'OMIM',
         hideTranscript: 'Show less',
         showTranscript: '{count, plural, =1 {# other transcript} other {# other transcripts}}',
         canonical: 'Canonical transcript',
+        gnomad: {
+          pli: 'pLI',
+          loeuf: 'LOEUF',
+        },
+        spliceAi: 'SpliceAI',
+        conservation: 'Conservation',
+        phyloP17Way: 'PhyloP17Way',
+        pickedTooltip: 'Gene with most deleterious consequence',
       },
       frequencies: {
         kfStudies: 'Kids First Studies',

--- a/src/views/VariantEntity2/index.module.scss
+++ b/src/views/VariantEntity2/index.module.scss
@@ -80,3 +80,28 @@
 .spliceAi {
   padding-right: 8px;
 }
+
+.pickedIcon {
+  padding-left: 8px;
+}
+
+.predictionLabel,
+.conservationLabel {
+  margin-right: 4px;
+}
+
+.canonicalIcon {
+  color: $canonical-icon-color;
+}
+
+.expandedTable {
+  :global(.ant-spin-nested-loading
+      .ant-spin-container
+      .ant-table
+      .ant-table-container
+      .ant-table-content) {
+    table > tbody > tr > td {
+      background-color: $gray-1;
+    }
+  }
+}

--- a/src/views/VariantEntity2/utils/consequence.tsx
+++ b/src/views/VariantEntity2/utils/consequence.tsx
@@ -105,7 +105,7 @@ export const getPredictionScore = (
     lrt: string;
     revel: string;
   },
-): any[][] =>
+): (string | number | null)[][] =>
   [
     [dictionary.sift, predictions?.sift_pred, predictions?.sift_score],
     [dictionary.polyphen2, predictions?.polyphen2_hvar_pred, predictions?.sift_score],

--- a/src/views/VariantEntity2/utils/consequence.tsx
+++ b/src/views/VariantEntity2/utils/consequence.tsx
@@ -1,0 +1,249 @@
+import { ReactNode } from 'react';
+import intl from 'react-intl-universal';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from '@ferlab/ui/core/common/constants';
+import { pickImpactBadge } from '@ferlab/ui/core/components/Consequences/Cell';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import CanonicalIcon from '@ferlab/ui/core/components/Icons/CanonicalIcon';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import StackLayout from '@ferlab/ui/core/layout/StackLayout';
+import {
+  INDEX_IMPACT_PREDICTION_FIELD,
+  INDEX_IMPACT_PREDICTION_SHORT_LABEL,
+  INDEX_IMPACT_SCORE,
+  getLongPredictionLabelIfKnown,
+} from '@ferlab/ui/core/pages/EntityPage/utils/consequences';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+
+import { CheckCircleFilled } from '@ant-design/icons';
+import { Space, Table, Tag, Tooltip, Typography } from 'antd';
+import { ColumnType } from 'antd/lib/table';
+import {
+  IConsequenceEntity,
+  IConservationsEntity,
+  IGeneEntity,
+  IPredictionEntity,
+} from 'graphql/variants/models';
+import { capitalize } from 'lodash';
+import { getEntityConsequenceDictionary } from 'utils/translation';
+
+import style from '../index.module.scss';
+
+const { Text } = Typography;
+
+export const getColumn = (geneSymbolOfPicked?: string): ProColumnType[] => [
+  {
+    key: 'symbol',
+    title: intl.get('screen.variants.consequences.gene'),
+    render: (gene: IGeneEntity) =>
+      gene.symbol ? (
+        <>
+          <ExternalLink href={`https://www.omim.org/entry/${gene.omim_gene_id}`}>
+            {gene.symbol}
+          </ExternalLink>
+          {gene.symbol === geneSymbolOfPicked && (
+            <Tooltip title={intl.get('screen.variants.consequences.pickedTooltip')}>
+              <CheckCircleFilled className={style.pickedIcon} />
+            </Tooltip>
+          )}
+        </>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+  {
+    key: 'biotype',
+    dataIndex: 'biotype',
+    title: intl.get('screen.variants.consequences.geneType'),
+    render: (biotype: string) =>
+      biotype ? removeUnderscoreAndCapitalize(biotype) : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'pli',
+    dataIndex: 'gnomad',
+    title: intl.get('screen.variants.consequences.gnomad.pli'),
+    render: (gnomad: { pli: number }) => gnomad?.pli || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'loeuf',
+    dataIndex: 'gnomad',
+    title: intl.get('screen.variants.consequences.gnomad.loeuf'),
+    render: (gnomad: { loeuf: string }) => gnomad?.loeuf || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'spliceai',
+    dataIndex: 'spliceai',
+    title: intl.get('screen.variants.consequences.spliceAi'),
+    render: (spliceAi: { ds: number; type: string[] }) =>
+      spliceAi?.ds ? (
+        <>
+          <span className={style.spliceAi}>{spliceAi.ds}</span>
+          {spliceAi.type.map((t: string, index: number) => {
+            return (
+              <Tooltip title={intl.get(`screen.variants.summary.details.spliceAiType.${t}`)}>
+                <Tag key={index}>{t}</Tag>
+              </Tooltip>
+            );
+          })}
+        </>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+];
+
+export const getPredictionScore = (
+  predictions: IPredictionEntity,
+  dictionary: {
+    sift: string;
+    polyphen2: string;
+    fathmm: string;
+    cadd: string;
+    dann: string;
+    lrt: string;
+    revel: string;
+  },
+): any[][] =>
+  [
+    [dictionary.sift, predictions?.sift_pred, predictions?.sift_score],
+    [dictionary.polyphen2, predictions?.polyphen2_hvar_pred, predictions?.sift_score],
+    [dictionary.fathmm, predictions?.fathmm_score],
+    [dictionary.cadd, null, predictions?.cadd_score],
+    [dictionary.dann, null, predictions?.dann_score],
+    [dictionary.lrt, predictions?.lrt_pred, predictions?.lrt_score],
+    [dictionary.revel, null, predictions?.revel_score],
+  ].filter(([, , score]) => score);
+
+export const getExpandedColumns = (): ColumnType<any>[] => [
+  {
+    key: 'aa_change',
+    dataIndex: 'aa_change',
+    title: (
+      <Tooltip title={intl.get('screen.variants.consequences.aaColumnTooltip')}>
+        {intl.get('screen.variants.consequences.aaColumn')}
+      </Tooltip>
+    ),
+    render: (aa_change: string) => aa_change || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'consequence',
+    title: intl.get('screen.variants.consequences.consequence'),
+    render: (consequence: IConsequenceEntity) => {
+      if (!consequence.consequence?.length) return TABLE_EMPTY_PLACE_HOLDER;
+      return (
+        <>
+          {pickImpactBadge(consequence.vep_impact)}
+          <span className={style.consequence}>
+            {removeUnderscoreAndCapitalize(consequence.consequence[0])}
+          </span>
+        </>
+      );
+    },
+  },
+  {
+    key: 'coding_dna_change',
+    dataIndex: 'coding_dna_change',
+    title: intl.get('screen.variants.consequences.cdnaChangeColumn'),
+    render: (coding_dna_change: string) => coding_dna_change || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'predictions',
+    dataIndex: 'predictions',
+    title: intl.get('screen.variants.consequences.predictions.prediction'),
+    render: (predictions: IPredictionEntity) => {
+      const impact = getPredictionScore(predictions, getEntityConsequenceDictionary().predictions);
+      if (!impact?.length) return TABLE_EMPTY_PLACE_HOLDER;
+      return (
+        <ExpandableCell
+          dataSource={impact}
+          dictionnary={{
+            'see.less': intl.get('see.less'),
+            'see.more': intl.get('see.more'),
+          }}
+          nOfElementsWhenCollapsed={2}
+          renderItem={(item: any, id) => {
+            const predictionField = item[INDEX_IMPACT_PREDICTION_FIELD];
+            const score = item[INDEX_IMPACT_SCORE];
+            const predictionShortLabel = item[INDEX_IMPACT_PREDICTION_SHORT_LABEL];
+            const predictionLongLabel = getLongPredictionLabelIfKnown(
+              predictionField,
+              predictionShortLabel,
+            );
+            const label = predictionLongLabel || predictionShortLabel;
+            const description = label ? `${capitalize(label)} - ${score}` : score;
+            return (
+              <StackLayout horizontal key={id}>
+                <Text className={style.predictionLabel}>{predictionField}:</Text>
+                <Text>{description}</Text>
+              </StackLayout>
+            );
+          }}
+        />
+      );
+    },
+  },
+  {
+    key: 'conservations',
+    dataIndex: 'conservations',
+    title: intl.get('screen.variants.consequences.conservation'),
+    render: (conservations: IConservationsEntity) =>
+      conservations?.phyloP17way_primate ? (
+        <StackLayout horizontal>
+          <Text className={style.conservationLabel}>
+            {intl.get('screen.variants.consequences.phyloP17Way')}:
+          </Text>
+          <Text>{conservations.phyloP17way_primate}</Text>
+        </StackLayout>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+  {
+    key: 'ensembl_transcript_id',
+    title: intl.get('screen.variants.consequences.transcript'),
+    render: (consequence: IConsequenceEntity) => {
+      const { ensembl_transcript_id, canonical } = consequence;
+      return (
+        <Space>
+          <ExternalLink href={`https://www.ensembl.org/id/${ensembl_transcript_id}`}>
+            {ensembl_transcript_id}
+          </ExternalLink>
+          {canonical && (
+            <Tooltip title={intl.get('screen.variants.consequences.canonical')}>
+              <div>
+                <CanonicalIcon className={style.canonicalIcon} height={14} width={14} />
+              </div>
+            </Tooltip>
+          )}
+        </Space>
+      );
+    },
+  },
+  {
+    title: intl.get('screen.variants.consequences.refSeq'),
+    dataIndex: 'refseq_mrna_id',
+    key: 'consequences',
+    render: (refseq_mrna_id: string) =>
+      refseq_mrna_id ? (
+        <ExternalLink href={`https://www.ncbi.nlm.nih.gov/nuccore/${refseq_mrna_id}?report=graph`}>
+          {refseq_mrna_id}
+        </ExternalLink>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+];
+
+export const expandedRowRender = (row: IGeneEntity): ReactNode => {
+  return (
+    <Table
+      className={style.expandedTable}
+      columns={getExpandedColumns()}
+      dataSource={hydrateResults(row.consequences?.hits?.edges || [])}
+      pagination={false}
+      bordered
+    />
+  );
+};


### PR DESCRIPTION
# [FEATURE] Add consequence section in variant entity v2

[SKFP-901](https://d3b.atlassian.net/browse/SKFP-901)

## Description

Acceptance Criterias
- Add consequence section

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before

### After

No data available 

<img width="1514" alt="Capture d’écran, le 2024-02-28 à 08 45 29" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/d5b96f97-c495-4be6-ad23-570c4e477594">

Not expanded

<img width="1514" alt="Capture d’écran, le 2024-02-28 à 08 45 49" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/928d75d3-4419-4614-a146-f581da5495b9">

Expanded

<img width="1524" alt="Capture d’écran, le 2024-02-28 à 14 45 59" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/4b60e5d9-ef5b-43c6-9a2b-794d1e21f41d">

[SKFP-901]: https://d3b.atlassian.net/browse/SKFP-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ