### PR TITLE
feat: SKFP-965 add search by Family ID in Participant Data Exploration

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -295,6 +295,7 @@ export const CHECK_PARTICIPANT_MATCH = gql`
             fhir_id
             participant_id
             external_id
+            families_id
             study {
               study_code
             }
@@ -312,6 +313,7 @@ export const PARTICIPANT_SEARCH_BY_ID_QUERY = gql`
           node {
             participant_id
             external_id
+            families_id
           }
         }
       }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -54,9 +54,9 @@ const en = {
       },
       participant: {
         emptyText: 'No participants found',
-        placeholder: 'e.g. PT_1BCRHQVF, HTP0001',
+        placeholder: 'e.g. PT_1BCRHQVF, HTP0001, FM_012SFG34',
         title: 'Search by Participant ID',
-        tooltip: 'Search by Participant ID or External Participant ID',
+        tooltip: 'Search by Participant ID, External Participant ID or Family ID',
       },
       biospecimen: {
         emptyText: 'No samples found',
@@ -389,12 +389,12 @@ const en = {
         match: 'Matched ({count})',
         unmatch: 'Unmatched ({count})',
         identifiers: {
-          participant: 'Participant ID, External Participant ID',
+          participant: 'Participant ID, External Participant ID, Family ID',
           biospecimen: 'Sample ID, External Sample ID',
           file: 'File ID',
         },
         placeholders: {
-          participant: 'e.g. PT_03Y3K025, HTP0001, 10214, HTP0001',
+          participant: 'e.g. PT_03Y3K025, HTP0001, 10214, FM_012SFG34',
           biospecimen: 'e.g. HTP0001B2_Whole blood, BS_011DYZ2J_DNA, 238981007, SSH3953290',
           file: 'e.g. GF_2JAYWYDX, GF_TP6PG8Z0',
         },

--- a/src/views/DataExploration/components/ParticipantSearch.tsx
+++ b/src/views/DataExploration/components/ParticipantSearch.tsx
@@ -17,7 +17,7 @@ const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
     <GlobalSearch<IParticipantEntity>
       queryBuilderId={queryBuilderId}
       field="participant_id"
-      searchFields={['participant_id', 'external_id']}
+      searchFields={['participant_id', 'external_id', 'families_id']}
       index={INDEXES.PARTICIPANT}
       placeholder={intl.get('global.search.participant.placeholder')}
       emptyDescription={intl.get('global.search.participant.emptyText')}

--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -32,7 +32,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
           offset: 0,
           sqon: generateQuery({
             operator: BooleanOperators.or,
-            newFilters: ['participant_id', 'external_id'].map((field) =>
+            newFilters: ['participant_id', 'external_id', 'families_id'].map((field) =>
               generateValueFilter({
                 field,
                 value: ids,
@@ -51,7 +51,8 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
         const matchedIds: string[] = ids.filter(
           (id: string) =>
             participant.participant_id.toLocaleLowerCase() === id.toLocaleLowerCase() ||
-            participant.external_id.toLocaleLowerCase() === id.toLocaleLowerCase(),
+            participant.external_id.toLocaleLowerCase() === id.toLocaleLowerCase() ||
+            participant.families_id.toLocaleLowerCase() === id.toLocaleLowerCase(),
         );
 
         return matchedIds.map((id, index) => ({


### PR DESCRIPTION
# FIX: add search by Family ID in Participant Data Exploration

- closes [#SKFP-965](https://d3b.atlassian.net/jira/software/c/projects/SKFP/boards/82?selectedIssue=SKFP-965)