### PR TITLE
feat(variant): SKFP-995 update refSeq display

### DIFF
--- a/src/views/VariantEntity2/utils/consequence.tsx
+++ b/src/views/VariantEntity2/utils/consequence.tsx
@@ -251,7 +251,7 @@ export const getExpandedColumns = (): ColumnType<any>[] => [
             'see.less': intl.get('see.less'),
             'see.more': intl.get('see.more'),
           }}
-          nOfElementsWhenCollapsed={2}
+          nOfElementsWhenCollapsed={1}
           renderItem={(item: string, id) => (
             <StackLayout horizontal key={id}>
               <ExternalLink href={`https://www.ncbi.nlm.nih.gov/nuccore/${item}?report=graph`}>

--- a/src/views/VariantEntity2/utils/consequence.tsx
+++ b/src/views/VariantEntity2/utils/consequence.tsx
@@ -241,14 +241,27 @@ export const getExpandedColumns = (): ColumnType<any>[] => [
     title: intl.get('screen.variants.consequences.refSeq'),
     dataIndex: 'refseq_mrna_id',
     key: 'consequences',
-    render: (refseq_mrna_id: string) =>
-      refseq_mrna_id ? (
-        <ExternalLink href={`https://www.ncbi.nlm.nih.gov/nuccore/${refseq_mrna_id}?report=graph`}>
-          {refseq_mrna_id}
-        </ExternalLink>
-      ) : (
-        TABLE_EMPTY_PLACE_HOLDER
-      ),
+    render: (refseq_mrna_id: string[]) => {
+      if (!refseq_mrna_id?.length) return TABLE_EMPTY_PLACE_HOLDER;
+      console.log('refseq_mrna_id', refseq_mrna_id);
+      return (
+        <ExpandableCell
+          dataSource={refseq_mrna_id}
+          dictionnary={{
+            'see.less': intl.get('see.less'),
+            'see.more': intl.get('see.more'),
+          }}
+          nOfElementsWhenCollapsed={2}
+          renderItem={(item: string, id) => (
+            <StackLayout horizontal key={id}>
+              <ExternalLink href={`https://www.ncbi.nlm.nih.gov/nuccore/${item}?report=graph`}>
+                {item}
+              </ExternalLink>
+            </StackLayout>
+          )}
+        />
+      );
+    },
   },
 ];
 

--- a/src/views/VariantEntity2/utils/consequence.tsx
+++ b/src/views/VariantEntity2/utils/consequence.tsx
@@ -243,7 +243,7 @@ export const getExpandedColumns = (): ColumnType<any>[] => [
     key: 'consequences',
     render: (refseq_mrna_id: string[]) => {
       if (!refseq_mrna_id?.length) return TABLE_EMPTY_PLACE_HOLDER;
-      console.log('refseq_mrna_id', refseq_mrna_id);
+
       return (
         <ExpandableCell
           dataSource={refseq_mrna_id}


### PR DESCRIPTION
# [FEATURE] Use ExpandableCell to display refseq

## Description

[SKFP-995](https://d3b.atlassian.net/browse/SKFP-995)

Acceptance Criterias

- Variant has multiple refseq, display them with see more component

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="1510" alt="Capture d’écran, le 2024-03-15 à 13 48 30" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/bb5893f5-a489-4f78-ab58-57c2982d7907">

### After
<img width="1521" alt="Capture d’écran, le 2024-03-15 à 13 58 33" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/d0aabd37-4ac3-4396-8d15-86394364a057">
<img width="1510" alt="Capture d’écran, le 2024-03-15 à 13 48 08" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/c14f188d-1100-4e76-a629-49c7dd18bd67">



[SKFP-995]: https://d3b.atlassian.net/browse/SKFP-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ