### PR TITLE
fix(files): SKFP-993 fix acls fetching for files authrorization

### DIFF
--- a/src/store/fences/selector.ts
+++ b/src/store/fences/selector.ts
@@ -20,11 +20,11 @@ export const fencesAtLeastOneAuthentificationConnectedSelector = (state: RootSta
   });
 
 export const fencesAllAclsSelector = (state: RootState) => {
-  const acls: string[] = [];
+  let acls: string[] = [];
   Object.keys(FENCE_NAMES).forEach((fenceKey) => {
     const key = fenceKey as FENCE_NAMES;
     if (state.fences[key].acl.length > 0) {
-      acls.concat(state.fences[key].acl);
+      acls = [...acls, ...state.fences[key].acl];
     }
   });
 


### PR DESCRIPTION
# BUG

- closes #[993](https://d3b.atlassian.net/browse/SKFP-993)

## Description

- Aller sur le dashboard
- Se connecter aux authorized studies
- Accéder a une étude via authorized widget
- Toutes les files sont lock alors qu'il devrait être unlock


## Screenshot 
### Before
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/a9556e59-4a98-43a6-8ce7-e69943c6c3c4)

### After
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/d242c296-ce3c-4b4f-b8f2-9dfa97bc5fc8)


