### PR TITLE
fix: SKFP-964 prevent double title in safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.16.0",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.8.1",
+        "@ferlab/ui": "^9.9.3",
         "@loadable/component": "^5.15.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@react-keycloak/core": "^3.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.8.1.tgz",
-      "integrity": "sha512-edcKxVYsg6xfwEvepaZDO9rl03WANHA4p6vHmcjAZbOaZoDZSdiGzkCqIhLYTxg9nfZ60pRLQhqyaPv7f20JaA==",
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.3.tgz",
+      "integrity": "sha512-ShIw96oJrHxO+CDYfqaM8aX8THVCYM2GcBStBdQD4db/F6OcveVNodmN1l9suJ72oxubk9eql5pYkplIp/i4aA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -36803,9 +36803,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.8.1.tgz",
-      "integrity": "sha512-edcKxVYsg6xfwEvepaZDO9rl03WANHA4p6vHmcjAZbOaZoDZSdiGzkCqIhLYTxg9nfZ60pRLQhqyaPv7f20JaA==",
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.3.tgz",
+      "integrity": "sha512-ShIw96oJrHxO+CDYfqaM8aX8THVCYM2GcBStBdQD4db/F6OcveVNodmN1l9suJ72oxubk9eql5pYkplIp/i4aA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "^7.16.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.8.1",
+    "@ferlab/ui": "^9.9.3",
     "@loadable/component": "^5.15.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@react-keycloak/core": "^3.2.0",


### PR DESCRIPTION
# FIX: prevent double title in safari

- closes [#SKFP-964](https://d3b.atlassian.net/browse/SKFP-964)

## Description

Weird bug in Safari only. Cant reproduce in Local since i'm not able to run mock auth studies with Safari.