### PR TITLE
fix(dashbard): SKFP-975 fix draggable card issue

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/index.tsx
@@ -20,7 +20,7 @@ export interface DashboardCardProps {
 // Its is used for user config
 export const dashboardCards: TSortableItems[] = [
   {
-    id: '7',
+    id: '1',
     xs: 24,
     md: 12,
     xxl: 8,
@@ -58,6 +58,6 @@ export const dashboardCards: TSortableItems[] = [
     md: 12,
     xxl: 8,
     className: cx(styles.cardColxxl6, styles.cardColxxl5),
-    component: <CaringForChildrenWithCovid id="6" className={styles.dashboardCard} />,
+    component: <CaringForChildrenWithCovid id="5" className={styles.dashboardCard} />,
   },
 ];


### PR DESCRIPTION
#BUG 

- closes #[975](https://d3b.atlassian.net/browse/SKFP-975)

## Description
Il n’est plus possible de déplacer le widget Authorized Studies

## Screenshot 


https://github.com/kids-first/kf-portal-ui/assets/65532894/048dd7fe-815f-48e9-ae10-655ac472a6f1


