### PR TITLE
feat(variant): SKFP-1013 no gene display in banner

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1787,6 +1787,7 @@ const en = {
           sequence_alteration: 'Sequence Alteration',
         },
       },
+      no_gene: 'No gene',
     },
   },
 };

--- a/src/views/VariantEntity/index.module.scss
+++ b/src/views/VariantEntity/index.module.scss
@@ -25,6 +25,14 @@
   color: $gray-8 !important;
 }
 
+.noGene {
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 28px;
+  padding-right: 8px;
+  color: $gray-7 !important;
+}
+
 .ensemblLink {
   padding: 0 2px;
 }

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -2,7 +2,7 @@ import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { TABLE_EMPTY_PLACE_HOLDER } from '@ferlab/ui/core/common/constants';
-import { pickImpactBadge } from '@ferlab/ui/core/components/Consequences/Cell';
+import { NO_GENE, pickImpactBadge } from '@ferlab/ui/core/components/Consequences/Cell';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import CanonicalIcon from '@ferlab/ui/core/components/Icons/CanonicalIcon';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
@@ -144,27 +144,38 @@ export const getSummaryItems = (variant?: IVariantEntity) => {
       {
         label: (
           <>
-            <ExternalLink
-              className={style.symbolLink}
-              href={
-                geneWithPickedConsequence.omim_gene_id
-                  ? `https://omim.org/entry/${geneWithPickedConsequence.omim_gene_id}`
-                  : `https://www.omim.org/search?index=entry&start=1&limit=10&sort=score+desc%2C+prefix_sort+desc&search=${geneWithPickedConsequence.symbol}`
-              }
-            >
-              <Text>{geneWithPickedConsequence.symbol}</Text>
-            </ExternalLink>
-            (
-            <ExternalLink
-              className={style.ensemblLink}
-              href={`https://www.ensembl.org/id/${pickedConsequence.node.ensembl_transcript_id}`}
-            >
-              {intl.get('screen.variants.summary.ensembl')}
-            </ExternalLink>
-            )
+            {geneWithPickedConsequence.symbol === NO_GENE ? (
+              <Text className={style.noGene}>{intl.get('entities.variant.no_gene')}</Text>
+            ) : (
+              <ExternalLink
+                className={style.symbolLink}
+                href={
+                  geneWithPickedConsequence.omim_gene_id
+                    ? `https://omim.org/entry/${geneWithPickedConsequence.omim_gene_id}`
+                    : `https://www.omim.org/search?index=entry&start=1&limit=10&sort=score+desc%2C+prefix_sort+desc&search=${geneWithPickedConsequence.symbol}`
+                }
+              >
+                <Text>{geneWithPickedConsequence.symbol}</Text>
+              </ExternalLink>
+            )}
+            {pickedConsequence.node.ensembl_transcript_id && (
+              <Text type="secondary">
+                (
+                <ExternalLink
+                  className={style.ensemblLink}
+                  href={`https://www.ensembl.org/id/${pickedConsequence.node.ensembl_transcript_id}`}
+                >
+                  {intl.get('screen.variants.summary.ensembl')}
+                </ExternalLink>
+                )
+              </Text>
+            )}
           </>
         ),
-        value: pickedConsequence.node.aa_change || TABLE_EMPTY_PLACE_HOLDER,
+        value:
+          geneWithPickedConsequence.symbol !== NO_GENE
+            ? pickedConsequence.node.aa_change || TABLE_EMPTY_PLACE_HOLDER
+            : '',
       },
       {
         label: intl.get('screen.variants.summary.consequence'),


### PR DESCRIPTION
# [FEATURE] Improve no gene display in variant entity

## Description

[SKFP-1013](https://d3b.atlassian.net/browse/SKFP-1013)

Acceptance Criterias
- If no ensembl_transcript_id remove the link
- If symbol = NO_GENE remove link and display “No gene”
- If NO_GENE remove - for aa_change

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
<img width="250" alt="Capture d’écran, le 2024-04-15 à 09 08 46" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/4e0c0459-37cf-4225-8ab8-eea403fcb63f">

### After
<img width="250" alt="Capture d’écran, le 2024-04-15 à 09 08 40" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/afd2e159-ec77-4386-bde5-485cb9731980">



[SKFP-1013]: https://d3b.atlassian.net/browse/SKFP-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ