### PR TITLE
fix(summary): SKFP-1016 fix padding empty

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/AgeAtDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/AgeAtDiagnosisGraphCard/index.tsx
@@ -156,7 +156,7 @@ const AgeAtDiagnosisGraphCard = () => {
       content={
         <>
           {isEmpty(ageAtDiagnosisresults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={ageAtDiagnosisresults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
@@ -93,7 +93,7 @@ const DataCategoryGraphCard = () => {
       content={
         <>
           {isEmpty(dataCategoryResults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={dataCategoryResults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
@@ -90,7 +90,7 @@ const DataTypeGraphCard = () => {
       content={
         <>
           {isEmpty(dataTypeResults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={dataTypeResults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
@@ -178,7 +178,7 @@ const DemographicsGraphCard = () => {
         <Row gutter={[12, 24]} className={styles.graphRowWrapper}>
           <Col sm={12} md={12} lg={6}>
             {isEmpty(sexData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.sexTitle')}
@@ -191,7 +191,7 @@ const DemographicsGraphCard = () => {
           </Col>
           <Col sm={12} md={12} lg={6}>
             {isEmpty(ethnicityData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.ethnicityTitle')}
@@ -204,7 +204,7 @@ const DemographicsGraphCard = () => {
           </Col>
           <Col sm={12} md={12} lg={6}>
             {isEmpty(raceData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.raceTitle')}
@@ -217,7 +217,7 @@ const DemographicsGraphCard = () => {
           </Col>
           <Col sm={12} md={12} lg={6}>
             {isEmpty(familyData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get(

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
@@ -90,7 +90,7 @@ const StudiesGraphCard = () => {
         <Row className={styles.graphRowWrapper}>
           <Col md={24}>
             {isEmpty(data) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" size="large" noPadding />
             ) : (
               <PieChart
                 data={data}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/GraphContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/GraphContent/index.tsx
@@ -98,6 +98,7 @@ const SunburstGraph = ({ field, previewMode = false, width = 335, height = 335 }
   if (!isLoading && (!treeData || treeData?.length === 0)) {
     return (
       <Empty
+        noPadding
         imageType="grid"
         size="large"
         description={intl.get(`screen.dataExploration.tabs.summary.${field}.empty`)}


### PR DESCRIPTION
#BUG | FEATURE | DOC] [TITLE]

- closes #[3242](https://d3b.atlassian.net/browse/SKFP-1016)

## Description
t seems like the No data does not scale for certain charts (Participant by Data Category and Participants by sample type). It should be centered like the other charts. 

## Screenshot 
![image](https://github.com/kids-first/kf-portal-ui/assets/65532894/9143a9e0-ab9e-49cf-8d26-0f3c192cb545)

