### PR TITLE
fix: SKFP-1021 add extra whitespace before support email in saved filters

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -665,9 +665,9 @@ const en = {
         },
         savedFilters: {
           errorCard: {
-            contactSupport: 'contact our support',
-            failedToFetch: 'Failed to fetch Saved Filters',
-            refresh: 'Please refresh and try again or',
+            failedToFetch: 'Failed to Fetch Saved Filters',
+            message:
+              'Please refresh and try again or <a href="{href}" style="color:inherit;text-decoration: underline;">contact our support</a>.',
           },
           title: 'Saved Filters',
           noSavedFilters:
@@ -682,9 +682,9 @@ const en = {
         },
         savedSets: {
           errorCard: {
-            contactSupport: 'contact our support',
             failedToFetch: 'Failed to fetch Saved Sets',
-            refresh: 'Please refresh and try again or',
+            message:
+              'Please refresh and try again or <a href="{href}" style="color:inherit;text-decoration: underline;">contact our support</a>.',
           },
           tabs: {
             biospecimens: 'Biospecimens',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -664,6 +664,11 @@ const en = {
           },
         },
         savedFilters: {
+          errorCard: {
+            contactSupport: 'contact our support',
+            failedToFetch: 'Failed to fetch Saved Filters',
+            refresh: 'Please refresh and try again or',
+          },
           title: 'Saved Filters',
           noSavedFilters:
             'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -42,12 +42,14 @@ const SavedFilterListWrapper = ({
     locale={{
       emptyText: fetchingError ? (
         <CardErrorPlaceholder
-          title={intl.get('screen.dashboard.cards.savedSets.errorCard.failedToFetch')}
+          title={intl.get('screen.dashboard.cards.savedFilters.errorCard.failedToFetch')}
           subTitle={
             <Text>
-              {intl.get('screen.dashboard.cards.savedSets.errorCard.refresh')}{' '}
+              {intl.get('screen.dashboard.cards.savedFilters.errorCard.refresh')}{' '}
               <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                <Text>{intl.get('screen.dashboard.cards.savedSets.errorCard.contactSupport')}</Text>
+                <Text>
+                  {intl.get('screen.dashboard.cards.savedFilters.errorCard.contactSupport')}
+                </Text>
               </ExternalLink>
               .
             </Text>

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -1,7 +1,6 @@
 import intl from 'react-intl-universal';
 import { FileSearchOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
-import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { List, Tabs, Typography } from 'antd';
 import cx from 'classnames';
@@ -45,13 +44,9 @@ const SavedFilterListWrapper = ({
           title={intl.get('screen.dashboard.cards.savedFilters.errorCard.failedToFetch')}
           subTitle={
             <Text>
-              {intl.get('screen.dashboard.cards.savedFilters.errorCard.refresh')}{' '}
-              <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                <Text>
-                  {intl.get('screen.dashboard.cards.savedFilters.errorCard.contactSupport')}
-                </Text>
-              </ExternalLink>
-              .
+              {intl.getHTML('screen.dashboard.cards.savedFilters.errorCard.message', {
+                href: `mailto:${SUPPORT_EMAIL}`,
+              })}
             </Text>
           }
         />

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -42,12 +42,12 @@ const SavedFilterListWrapper = ({
     locale={{
       emptyText: fetchingError ? (
         <CardErrorPlaceholder
-          title="Failed to Fetch Saved Filters"
+          title={intl.get('screen.dashboard.cards.savedSets.errorCard.failedToFetch')}
           subTitle={
             <Text>
-              Please refresh and try again or
+              {intl.get('screen.dashboard.cards.savedSets.errorCard.refresh')}{' '}
               <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                <Text>contact our support</Text>
+                <Text>{intl.get('screen.dashboard.cards.savedSets.errorCard.contactSupport')}</Text>
               </ExternalLink>
               .
             </Text>

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -2,7 +2,6 @@ import { ReactElement } from 'react';
 import intl from 'react-intl-universal';
 import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
-import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { List, Tabs, Typography } from 'antd';
 import cx from 'classnames';
@@ -42,11 +41,9 @@ const getItemList = (
           title={intl.get('screen.dashboard.cards.savedSets.errorCard.failedToFetch')}
           subTitle={
             <Text>
-              {intl.get('screen.dashboard.cards.savedSets.errorCard.refresh')}{' '}
-              <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                <Text>{intl.get('screen.dashboard.cards.savedSets.errorCard.contactSupport')}</Text>
-              </ExternalLink>
-              .
+              {intl.getHTML('screen.dashboard.cards.savedFilters.errorCard.message', {
+                href: `mailto:${SUPPORT_EMAIL}`,
+              })}
             </Text>
           }
         />


### PR DESCRIPTION
# FIX: add extra whitespace before support email in saved filters

- closes [#SKFP-1021](https://d3b.atlassian.net/browse/SKFP-1021)

## Description

![image](https://github.com/kids-first/kf-portal-ui/assets/156684667/00ded19e-f273-4d7c-af1b-d31b39371af4)


After:

![image](https://github.com/kids-first/kf-portal-ui/assets/156684667/5437b46b-c4aa-41ae-a7fe-9358853da6c8)
