### PR TITLE
feat(summary): SKFP-1026 add hpo and mondo graphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.16.0",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.15.3",
+        "@ferlab/ui": "^9.15.5",
         "@loadable/component": "^5.15.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@react-keycloak/core": "^3.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.15.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.3.tgz",
-      "integrity": "sha512-8pgcUSrWnN07xJy5KoESoSQd7LSLryMNfYI96wVj2l/i9dQwchmhPbbGbjPX65+t83pkie0bfnLhlAdtJr2evQ==",
+      "version": "9.15.5",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.5.tgz",
+      "integrity": "sha512-N9//nS/39CcO6skYhlk7lFkXZbIC18q64jGDqkS7FGxTYp+qe7A2c625ZgUh1Qss7K8zNXwurJ1ZILsZwMi1pg==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -36803,9 +36803,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "9.15.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.3.tgz",
-      "integrity": "sha512-8pgcUSrWnN07xJy5KoESoSQd7LSLryMNfYI96wVj2l/i9dQwchmhPbbGbjPX65+t83pkie0bfnLhlAdtJr2evQ==",
+      "version": "9.15.5",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.5.tgz",
+      "integrity": "sha512-N9//nS/39CcO6skYhlk7lFkXZbIC18q64jGDqkS7FGxTYp+qe7A2c625ZgUh1Qss7K8zNXwurJ1ZILsZwMi1pg==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "^7.16.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.15.3",
+    "@ferlab/ui": "^9.15.5",
     "@loadable/component": "^5.15.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@react-keycloak/core": "^3.2.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -298,7 +298,7 @@ const en = {
           newQueryBuilder: 'New filter',
           save: 'Save filter',
           saveChanges: 'Save changes',
-          saveDisabled: 'Add new query to save',
+          saveDisabled: 'Add a query to save',
           delete: 'Delete',
           duplicateQueryBuilder: 'Duplicate filter',
           share: 'Share (Copy url)',
@@ -1173,6 +1173,8 @@ const en = {
             dataCategoryTitle: 'Participants by Data Category',
             dataTypeTitle: 'Participants by Data Type',
             studiesTitle: 'Participants by Study',
+            mostFrequentPhenotypes: 'Most Frequent Phenotypes (HPO)',
+            mostFrequentDiagnoses: 'Most Frequent Diagnoses (MONDO)',
           },
           observed_phenotype: {
             cardTitle: 'Observed Phenotypes (HPO)',
@@ -1203,6 +1205,16 @@ const en = {
           },
           studies: {
             cardTitle: 'Studies',
+          },
+          mostFrequentDiagnoses: {
+            cardTitle: 'Most Frequent Diagnoses (MONDO)',
+            legendAxisLeft: 'Diagnoses (MONDO)',
+            legendAxisBottom: '# of participants',
+          },
+          mostFrequentPhenotypes: {
+            cardTitle: 'Most Frequent Phenotypes (HPO)',
+            legendAxisLeft: 'Phenotypes (HPO)',
+            legendAxisBottom: '# of participants',
           },
         },
         participants: {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from 'react';
+import intl from 'react-intl-universal';
+import BarChart from '@ferlab/ui/core/components/Charts/Bar';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ArrangerValues } from '@ferlab/ui/core/data/arranger/formatting';
+import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
+import { treeNodeToChartData } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
+import { INDEXES } from 'graphql/constants';
+import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
+import { isEmpty, uniqBy } from 'lodash';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { getFlattenTree, TreeNode } from 'views/DataExploration/utils/OntologyTree';
+import { PhenotypeStore } from 'views/DataExploration/utils/PhenotypeStore';
+
+import { truncateString } from 'utils/string';
+import { getResizableGridDictionary } from 'utils/translation';
+
+import { MOST_FREQUENT_DIAGNOSES_ID, UID } from '../utils/grid';
+
+const addToQuery = (field: string, key: string) =>
+  updateActiveQueryField({
+    queryBuilderId: DATA_EXPLORATION_QB_ID,
+    field: `${field}.name`,
+    value: [key.toLowerCase() === 'no data' ? ArrangerValues.missing : key],
+    index: INDEXES.PARTICIPANT,
+  });
+
+const excludes = [
+  'complete trisomy 21 (MONDO:0700030)',
+  'Down syndrome (MONDO:0008608)',
+  'mosaic translocation Down syndrome (MONDO:0700129)',
+  'mosaic trisomy 21 (MONDO:0700127)',
+  'partial segmental duplication (MONDO:0700130)',
+  'translocation Down syndrome (MONDO:0700128)',
+  'trisomy 21 (MONDO:0700126)',
+];
+
+const filterMondoData = (data: any[], key = 'label') => {
+  let result = data as any[];
+
+  // Exclude zero value
+  result = result.filter((item) => item.value > 0);
+
+  // Excludes some values
+  result = result.filter((item) => !excludes.includes((item as any)[key]));
+
+  // Unique
+  result = uniqBy(result, key);
+
+  // Total
+  result = result.slice(0, 10);
+
+  return result;
+};
+
+const MostFrequentDiagnosisGraphCard = () => {
+  const [mondo, setMondo] = useState<any[]>([]);
+  const [mondoLoading, setMondoLoading] = useState<boolean>(true);
+
+  const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
+
+  // TODO: we should change that after phenotype store refact
+  const phenotypeStore = useRef<PhenotypeStore | undefined>(new PhenotypeStore());
+
+  useEffect(() => {
+    setMondoLoading(true);
+    phenotypeStore.current?.fetch({ field: 'mondo', sqon }).then(() => {
+      setMondoLoading(false);
+      const flattenMondoTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+        (a, b) => {
+          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+            return -1;
+          }
+          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+            return 1;
+          }
+          return 0;
+        },
+      );
+      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)));
+    });
+  }, [JSON.stringify(sqon)]);
+
+  return (
+    <ResizableGridCard
+      gridUID={UID}
+      id={MOST_FREQUENT_DIAGNOSES_ID}
+      theme="shade"
+      loading={mondoLoading}
+      loadingType="spinner"
+      dictionary={getResizableGridDictionary()}
+      headerTitle={intl.get(
+        'screen.dataExploration.tabs.summary.availableData.mostFrequentDiagnoses',
+      )}
+      tsvSettings={{
+        contentMap: ['label', 'value'],
+        data: [mondo],
+        headers: ['Value', 'Count'],
+      }}
+      modalContent={
+        <BarChart
+          data={mondo}
+          axisLeft={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.mostFrequentDiagnoses.legendAxisLeft',
+            ),
+            legendPosition: 'middle',
+            legendOffset: -120,
+            format: (label: string) => {
+              const title = label
+                .replace(/\(MONDO:\d+\)/g, '')
+                .split('-')
+                .pop();
+              return truncateString(title ?? '', 15);
+            },
+          }}
+          tooltipLabel={(node: any) => node.data.label}
+          axisBottom={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.mostFrequentDiagnoses.legendAxisBottom',
+            ),
+            legendPosition: 'middle',
+            legendOffset: 35,
+          }}
+          layout="horizontal"
+          margin={{
+            bottom: 45,
+            left: 130,
+            right: 12,
+            top: 12,
+          }}
+        />
+      }
+      modalSettings={{
+        width: 800,
+        height: 300,
+      }}
+      content={
+        <>
+          {isEmpty(mondo) ? (
+            <Empty imageType="grid" size="large" noPadding />
+          ) : (
+            <BarChart
+              data={mondo}
+              axisLeft={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.mostFrequentDiagnoses.legendAxisLeft',
+                ),
+                legendPosition: 'middle',
+                legendOffset: -120,
+                format: (label: string) => {
+                  const title = label
+                    .replace(/\(MONDO:\d+\)/g, '')
+                    .split('-')
+                    .pop();
+                  return truncateString(title ?? '', 15);
+                },
+              }}
+              tooltipLabel={(node: any) => node.data.label}
+              axisBottom={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.mostFrequentDiagnoses.legendAxisBottom',
+                ),
+                legendPosition: 'middle',
+                legendOffset: 35,
+              }}
+              layout="horizontal"
+              onClick={(datum: any) => addToQuery('mondo', datum.data.label as string)}
+              margin={{
+                bottom: 45,
+                left: 130,
+                right: 12,
+                top: 12,
+              }}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export default MostFrequentDiagnosisGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from 'react';
+import intl from 'react-intl-universal';
+import BarChart from '@ferlab/ui/core/components/Charts/Bar';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ArrangerValues } from '@ferlab/ui/core/data/arranger/formatting';
+import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
+import { treeNodeToChartData } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
+import { INDEXES } from 'graphql/constants';
+import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
+import { isEmpty, uniqBy } from 'lodash';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { getFlattenTree, TreeNode } from 'views/DataExploration/utils/OntologyTree';
+import { PhenotypeStore } from 'views/DataExploration/utils/PhenotypeStore';
+
+import { truncateString } from 'utils/string';
+import { getResizableGridDictionary } from 'utils/translation';
+
+import { MOST_FREQUENT_PHENOTYPES_ID, UID } from '../utils/grid';
+
+const addToQuery = (field: string, key: string) =>
+  updateActiveQueryField({
+    queryBuilderId: DATA_EXPLORATION_QB_ID,
+    field: `${field}.name`,
+    value: [key.toLowerCase() === 'no data' ? ArrangerValues.missing : key],
+    index: INDEXES.PARTICIPANT,
+  });
+
+const filterPhenotypesData = (data: any[], key = 'label') => {
+  let result = data as any[];
+
+  // Exclude zero value
+  result = result.filter((item) => item.value > 0);
+
+  // Unique
+  result = uniqBy(result, key);
+
+  // Total
+  result = result.slice(0, 10);
+
+  return result;
+};
+
+const MostFrequentPhenotypesGraphCard = () => {
+  const [phenotypes, setPhenotypes] = useState<any>([]);
+  const [phenotypesLoading, setPhenotypesLoading] = useState<boolean>(true);
+
+  const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
+
+  // TODO: we should change that after phenotype store refact
+  const phenotypeStore = useRef<PhenotypeStore | undefined>(new PhenotypeStore());
+
+  useEffect(() => {
+    setPhenotypesLoading(true);
+    phenotypeStore.current?.fetch({ field: 'observed_phenotype', sqon }).then(() => {
+      setPhenotypesLoading(false);
+      const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+        (a, b) => {
+          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+            return -1;
+          }
+          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+            return 1;
+          }
+          return 0;
+        },
+      );
+      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)));
+    });
+  }, [JSON.stringify(sqon)]);
+
+  return (
+    <ResizableGridCard
+      gridUID={UID}
+      id={MOST_FREQUENT_PHENOTYPES_ID}
+      theme="shade"
+      loading={phenotypesLoading}
+      loadingType="spinner"
+      dictionary={getResizableGridDictionary()}
+      headerTitle={intl.get(
+        'screen.dataExploration.tabs.summary.availableData.mostFrequentPhenotypes',
+      )}
+      tsvSettings={{
+        contentMap: ['label', 'value'],
+        data: [phenotypes],
+        headers: ['Value', 'Count'],
+      }}
+      modalContent={
+        <BarChart
+          data={phenotypes}
+          axisLeft={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisLeft',
+            ),
+            legendPosition: 'middle',
+            legendOffset: -120,
+            format: (label: string) => {
+              const title = label
+                .replace(/\(HP:\d+\)/g, '')
+                .split('-')
+                .pop();
+              return truncateString(title ?? '', 15);
+            },
+          }}
+          tooltipLabel={(node: any) => node.data.label}
+          axisBottom={{
+            legend: 'coucou',
+            // legend: intl.get(
+            //   'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisBottom',
+            // ),
+            legendPosition: 'middle',
+            legendOffset: 35,
+          }}
+          layout="horizontal"
+          margin={{
+            bottom: 45,
+            left: 130,
+            right: 12,
+            top: 12,
+          }}
+        />
+      }
+      modalSettings={{
+        width: 800,
+        height: 300,
+      }}
+      content={
+        <>
+          {isEmpty(phenotypes) ? (
+            <Empty imageType="grid" size="large" noPadding />
+          ) : (
+            <BarChart
+              data={phenotypes}
+              axisLeft={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisLeft',
+                ),
+                legendPosition: 'middle',
+                legendOffset: -120,
+                format: (label: string) => {
+                  const title = label
+                    .replace(/\(HP:\d+\)/g, '')
+                    .split('-')
+                    .pop();
+                  return truncateString(title ?? '', 15);
+                },
+              }}
+              tooltipLabel={(node: any) => node.data.label}
+              axisBottom={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisBottom',
+                ),
+                legendPosition: 'middle',
+                legendOffset: 35,
+              }}
+              layout="horizontal"
+              onClick={(datum: any) => addToQuery('observed_phenotype', datum.data.label as string)}
+              margin={{
+                bottom: 45,
+                left: 130,
+                right: 12,
+                top: 12,
+              }}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export default MostFrequentPhenotypesGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -104,10 +104,9 @@ const MostFrequentPhenotypesGraphCard = () => {
           }}
           tooltipLabel={(node: any) => node.data.label}
           axisBottom={{
-            legend: 'coucou',
-            // legend: intl.get(
-            //   'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisBottom',
-            // ),
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.mostFrequentPhenotypes.legendAxisBottom',
+            ),
             legendPosition: 'middle',
             legendOffset: 35,
           }}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -14,12 +14,16 @@ import AgeAtDiagnosisGraphCard from '../AgeAtDiagnosisGraphCard';
 import DataCategoryGraphCard from '../DataCategoryGraphCard';
 import DataTypeGraphCard from '../DataTypeGraphCard';
 import DemographicsGraphCard from '../DemographicGraphCard';
+import MostFrequentDiagnosisGraphCard from '../MostFrequentDiagnosisGraphCard';
+import MostFrequentPhenotypesGraphCard from '../MostFrequentPhenotypesGraphCard';
 import StudiesGraphCard from '../StudiesGraphCard';
 import SunburstGraphCard from '../SunburstGraphCard';
 
 export const UID = 'summary';
 export const OBSERVED_PHENOTYPE_ID = 'observed_phenotype';
 export const MONDO_ID = 'mondo';
+export const MOST_FREQUENT_DIAGNOSES_ID = 'most_frequent_disagnoses';
+export const MOST_FREQUENT_PHENOTYPES_ID = 'most_frequent_phenotypes';
 export const DEMOGRAPHICS_GRAPH_CARD_ID = 'demographics-graph-card';
 export const AGE_AT_DIAGNOSIS_GRAPH_CARD_ID = 'age-at-diagnosis-graph-card';
 export const DATA_CATEGORY_GRAPH_CARD_ID = 'data-category-graph-card';
@@ -38,6 +42,92 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     id: MONDO_ID,
     component: <SunburstGraphCard id={MONDO_ID} field="mondo" />,
     ...mondoDefaultGridConfig,
+  },
+  {
+    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentPhenotypes.cardTitle'),
+    id: MOST_FREQUENT_PHENOTYPES_ID,
+    component: <MostFrequentPhenotypesGraphCard />,
+    base: {
+      h: 4,
+      minH: 3,
+      minW: 4,
+      w: 8,
+      x: 0,
+      y: 4,
+    },
+    lg: {
+      h: 4,
+      w: 8,
+      x: 0,
+      y: 4,
+    },
+    md: {
+      h: 4,
+      w: 6,
+      x: 0,
+      y: 4,
+    },
+    sm: {
+      h: 4,
+      w: 5,
+      x: 0,
+      y: 4,
+    },
+    xs: {
+      h: 6,
+      w: 6,
+      x: 0,
+      y: 12,
+    },
+    xxs: {
+      h: 6,
+      w: 4,
+      x: 0,
+      y: 12,
+    },
+  },
+  {
+    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentDiagnoses.cardTitle'),
+    id: MOST_FREQUENT_DIAGNOSES_ID,
+    component: <MostFrequentDiagnosisGraphCard />,
+    base: {
+      h: 4,
+      minH: 3,
+      minW: 4,
+      w: 8,
+      x: 8,
+      y: 4,
+    },
+    lg: {
+      h: 4,
+      w: 8,
+      x: 8,
+      y: 4,
+    },
+    md: {
+      h: 4,
+      w: 6,
+      x: 6,
+      y: 4,
+    },
+    sm: {
+      h: 4,
+      w: 5,
+      x: 5,
+      y: 4,
+    },
+    xs: {
+      h: 6,
+      w: 6,
+      x: 0,
+      y: 12,
+    },
+    xxs: {
+      h: 6,
+      w: 4,
+      x: 0,
+      y: 12,
+    },
   },
   {
     title: intl.get('screen.dataExploration.tabs.summary.demographic.cardTitle'),


### PR DESCRIPTION
# [FEATURE] Add HPO and Mondo graphs to summary view

## Description

[SKFP-1026](https://d3b.atlassian.net/browse/SKFP-1026)

Acceptance Criterias
- Add Most Frequent Phenotypes and Diagnosis graphs

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before

### After
<img width="1471" alt="Capture d’écran, le 2024-05-06 à 11 29 32" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/30ee1b03-65d2-42db-8e0d-4c2ba1cb95f4">

<img width="1471" alt="Capture d’écran, le 2024-05-06 à 11 29 19" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/11d88589-74eb-48f1-a728-ed4807e77a30">

<img width="1516" alt="Capture d’écran, le 2024-05-06 à 10 00 54" src="https://github.com/kids-first/kf-portal-ui/assets/133775440/5ead86c0-3a32-4efd-bde2-cd4e376f03e6">


[SKFP-1026]: https://d3b.atlassian.net/browse/SKFP-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ