### PR TITLE
fix(dashboard): SKFP-971 fix return after redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.16.0",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.15.5",
+        "@ferlab/ui": "^9.15.6",
         "@loadable/component": "^5.15.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@react-keycloak/core": "^3.2.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.15.5",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.5.tgz",
-      "integrity": "sha512-N9//nS/39CcO6skYhlk7lFkXZbIC18q64jGDqkS7FGxTYp+qe7A2c625ZgUh1Qss7K8zNXwurJ1ZILsZwMi1pg==",
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.6.tgz",
+      "integrity": "sha512-mPmwj1x+D2xuBAgUMa26SXyrjDFksvXZQzt23WzegahlyojZi8lslecK7w5NQpPF11QICoPIiRqvLXGBr6JHkA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -36803,9 +36803,9 @@
       "dev": true
     },
     "@ferlab/ui": {
-      "version": "9.15.5",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.5.tgz",
-      "integrity": "sha512-N9//nS/39CcO6skYhlk7lFkXZbIC18q64jGDqkS7FGxTYp+qe7A2c625ZgUh1Qss7K8zNXwurJ1ZILsZwMi1pg==",
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.15.6.tgz",
+      "integrity": "sha512-mPmwj1x+D2xuBAgUMa26SXyrjDFksvXZQzt23WzegahlyojZi8lslecK7w5NQpPF11QICoPIiRqvLXGBr6JHkA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/core": "^7.16.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.15.5",
+    "@ferlab/ui": "^9.15.6",
     "@loadable/component": "^5.15.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@react-keycloak/core": "^3.2.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -591,6 +591,12 @@ const en = {
         variantSearch: 'Variant Search',
       },
       cards: {
+        infoPopover: {
+          and: ' and ',
+          variantsLink: 'Variants Exploration',
+          dataExploLink: 'Data Exploration',
+          pages: ' pages.',
+        },
         error: {
           title: 'Connection error',
           disconnect: {
@@ -671,12 +677,11 @@ const en = {
           },
           title: 'Saved Filters',
           noSavedFilters:
-            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
+            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the ',
           lastSaved: 'Last saved: {date} ago',
           infoPopover: {
             content:
-              'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
-
+              'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the ',
             title: 'Managing Saved Filters',
           },
         },
@@ -694,11 +699,11 @@ const en = {
           },
           title: 'Saved Sets',
           noSavedSets:
-            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
+            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in the ',
           lastSaved: 'Last saved: {date} ago',
           infoPopover: {
             content:
-              'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. You can create saved sets at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
+              'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. You can create saved sets at the top of the table of results in the ',
             title: 'Managing Saved Sets',
           },
         },

--- a/src/style/themes/kids-first/antd/descriptions.less
+++ b/src/style/themes/kids-first/antd/descriptions.less
@@ -1,7 +1,18 @@
 .@{descriptions-prefix-cls} {
-    &-item-label {
-        &::after {
-            margin: 0 4px 0 0;
-        }
+  &-item-label {
+    &::after {
+      margin: 0 4px 0 0;
     }
+  }
+}
+
+// a (antd force text-decoration: none)
+.ant-typography a,
+.@{descriptions-prefix-cls} a {
+  text-decoration: underline;
+}
+
+.ant-typography a:hover,
+.@{descriptions-prefix-cls} a:hover {
+  text-decoration: none;
 }

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -1,4 +1,5 @@
 import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
 import { FileSearchOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
@@ -17,7 +18,6 @@ import { STATIC_ROUTES } from 'utils/routes';
 import SavedFiltersListItem from './ListItem';
 
 import styles from './index.module.scss';
-import { Link } from 'react-router-dom';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -54,15 +54,14 @@ const SavedFilterListWrapper = ({
       ) : (
         <Empty
           imageType="grid"
-          // @ts-ignore cuz the type description is a string
           description={
             <Text>
               {intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
-              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+              <Link to={STATIC_ROUTES.DATA_EXPLORATION}>
                 {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
               </Link>
               {intl.get('screen.dashboard.cards.infoPopover.and')}
-              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+              <Link to={STATIC_ROUTES.VARIANTS}>
                 {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
               </Link>
               {intl.get('screen.dashboard.cards.infoPopover.pages')}
@@ -96,11 +95,11 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
             content: (
               <Text>
                 {intl.get('screen.dashboard.cards.savedFilters.infoPopover.content')}
-                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                <Link to={STATIC_ROUTES.DATA_EXPLORATION}>
                   {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
                 </Link>
                 {intl.get('screen.dashboard.cards.infoPopover.and')}
-                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                <Link to={STATIC_ROUTES.VARIANTS}>
                   {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
                 </Link>
                 {intl.get('screen.dashboard.cards.infoPopover.pages')}

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -17,6 +17,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import SavedFiltersListItem from './ListItem';
 
 import styles from './index.module.scss';
+import { Link } from 'react-router-dom';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;
@@ -53,10 +54,20 @@ const SavedFilterListWrapper = ({
       ) : (
         <Empty
           imageType="grid"
-          description={intl.getHTML('screen.dashboard.cards.savedFilters.noSavedFilters', {
-            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-            variantsHref: STATIC_ROUTES.VARIANTS,
-          })}
+          // @ts-ignore cuz the type description is a string
+          description={
+            <Text>
+              {intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
+              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
+              </Link>
+              {intl.get('screen.dashboard.cards.infoPopover.and')}
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
+              </Link>
+              {intl.get('screen.dashboard.cards.infoPopover.pages')}
+            </Text>
+          }
           noPadding
         />
       ),
@@ -84,10 +95,15 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedFilters.infoPopover.title'),
             content: (
               <Text>
-                {intl.getHTML('screen.dashboard.cards.savedFilters.infoPopover.content', {
-                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-                  variantsHref: STATIC_ROUTES.VARIANTS,
-                })}
+                {intl.get('screen.dashboard.cards.savedFilters.infoPopover.content')}
+                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                  {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
+                </Link>
+                {intl.get('screen.dashboard.cards.infoPopover.and')}
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                  {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
+                </Link>
+                {intl.get('screen.dashboard.cards.infoPopover.pages')}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -20,6 +20,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import ListItem from './ListItem';
 
 import styles from './index.module.scss';
+import { Link } from 'react-router-dom';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;
@@ -50,10 +51,20 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.getHTML('screen.dashboard.cards.savedSets.noSavedSets', {
-            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-            variantsHref: STATIC_ROUTES.VARIANTS,
-          })}
+          // @ts-ignore cuz the type description is a string
+          description={
+            <Text>
+              {intl.get('screen.dashboard.cards.savedSets.noSavedSets')}
+              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
+              </Link>
+              {intl.get('screen.dashboard.cards.infoPopover.and')}
+              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
+              </Link>
+              {intl.get('screen.dashboard.cards.infoPopover.pages')}
+            </Text>
+          }
           noPadding
         />
       ),
@@ -81,10 +92,15 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             title: intl.get('screen.dashboard.cards.savedSets.infoPopover.title'),
             content: (
               <Text>
-                {intl.getHTML('screen.dashboard.cards.savedSets.infoPopover.content', {
-                  dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
-                  variantsHref: STATIC_ROUTES.VARIANTS,
-                })}
+                {intl.get('screen.dashboard.cards.savedSets.infoPopover.content')}
+                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                  {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
+                </Link>
+                {intl.get('screen.dashboard.cards.infoPopover.and')}
+                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                  {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
+                </Link>
+                {intl.get('screen.dashboard.cards.infoPopover.pages')}
               </Text>
             ),
           }}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
 import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
@@ -20,7 +21,6 @@ import { STATIC_ROUTES } from 'utils/routes';
 import ListItem from './ListItem';
 
 import styles from './index.module.scss';
-import { Link } from 'react-router-dom';
 
 const { Text } = Typography;
 const { TabPane } = Tabs;

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -51,15 +51,14 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          // @ts-ignore cuz the type description is a string
           description={
             <Text>
               {intl.get('screen.dashboard.cards.savedSets.noSavedSets')}
-              <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+              <Link to={STATIC_ROUTES.DATA_EXPLORATION}>
                 {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
               </Link>
               {intl.get('screen.dashboard.cards.infoPopover.and')}
-              <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+              <Link to={STATIC_ROUTES.VARIANTS}>
                 {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
               </Link>
               {intl.get('screen.dashboard.cards.infoPopover.pages')}
@@ -93,11 +92,11 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             content: (
               <Text>
                 {intl.get('screen.dashboard.cards.savedSets.infoPopover.content')}
-                <Link to={`${STATIC_ROUTES.DATA_EXPLORATION}`}>
+                <Link to={STATIC_ROUTES.DATA_EXPLORATION}>
                   {intl.get('screen.dashboard.cards.infoPopover.dataExploLink')}
                 </Link>
                 {intl.get('screen.dashboard.cards.infoPopover.and')}
-                <Link to={`${STATIC_ROUTES.VARIANTS}`}>
+                <Link to={STATIC_ROUTES.VARIANTS}>
                   {intl.get('screen.dashboard.cards.infoPopover.variantsLink')}
                 </Link>
                 {intl.get('screen.dashboard.cards.infoPopover.pages')}


### PR DESCRIPTION
# [BUG] Back after redirect from filter or set links

## Description

[SKFP-971](https://d3b.atlassian.net/browse/SKFP-971)

Acceptance Criterias
- back after set or filter redirect => use link instead of a element.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before

### After
From info popover

https://github.com/kids-first/kf-portal-ui/assets/133775440/e218aed3-7e04-4e88-9cd9-565ba4adad61

From empty tab

https://github.com/kids-first/kf-portal-ui/assets/133775440/304e2d40-805a-4aa3-a17e-c4babce6ac8e


[SKFP-971]: https://d3b.atlassian.net/browse/SKFP-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ