### PR TITLE
fix: SKFP-1070 update fhir server urls in dashboard widget

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/CaringForChildrenWithCovid/index.tsx
@@ -27,13 +27,13 @@ const FHIR: TFHIR[] = [
     id: 'kfApi',
     title: intl.get('screen.dashboard.cards.fhirDataResource.kfApi.title'),
     text: intl.get('screen.dashboard.cards.fhirDataResource.kfApi.description'),
-    url: 'https://kf-api-fhir-service.kidsfirstdrc.org/metadata',
+    url: 'https://fhir.kidsfirstdrc.org/metadata',
   },
   {
     id: 'caringApi',
     title: intl.getHTML('screen.dashboard.cards.fhirDataResource.caringApi.title'),
     text: intl.get('screen.dashboard.cards.fhirDataResource.caringApi.description'),
-    url: 'https://kf-api-fhir-service.kidsfirstdrc.org/Patient?_total=accurate&_has:ResearchSubject:individual:study=ResearchStudy/4873',
+    url: 'https://fhir.kidsfirstdrc.org/Patient?_total=accurate&_has:ResearchSubject:individual:study=ResearchStudy/4873',
     popoverText: intl.get('screen.dashboard.cards.fhirDataResource.caringApi.popoverText'),
   },
 ];


### PR DESCRIPTION
# FIX: update fhir server urls in dashboard widget

- closes [#SKFP-1070](https://d3b.atlassian.net/browse/SKFP-1070)

