### PR TITLE
fix: SKFP-1072 remove trismoy 21 exclusions from data exploration graphs

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -26,24 +26,11 @@ const addToQuery = (field: string, key: string) =>
     index: INDEXES.PARTICIPANT,
   });
 
-const excludes = [
-  'complete trisomy 21 (MONDO:0700030)',
-  'Down syndrome (MONDO:0008608)',
-  'mosaic translocation Down syndrome (MONDO:0700129)',
-  'mosaic trisomy 21 (MONDO:0700127)',
-  'partial segmental duplication (MONDO:0700130)',
-  'translocation Down syndrome (MONDO:0700128)',
-  'trisomy 21 (MONDO:0700126)',
-];
-
 const filterMondoData = (data: any[], key = 'label') => {
   let result = data as any[];
 
   // Exclude zero value
   result = result.filter((item) => item.value > 0);
-
-  // Excludes some values
-  result = result.filter((item) => !excludes.includes((item as any)[key]));
 
   // Unique
   result = uniqBy(result, key);


### PR DESCRIPTION
# FIX : remove trismoy 21 exclusions from data exploration graphs

- closes [#SKFP-1072](https://d3b.atlassian.net/browse/SKFP-1072)

## Description

![image](https://github.com/kids-first/kf-portal-ui/assets/156684667/4c36829c-eff1-4eb5-88b3-7b7b1bce7216)