### PR TITLE
fix: SKFP-1114 hide Sunburst MONDO & HPO by default

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -35,12 +35,14 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     title: intl.get('screen.dataExploration.tabs.summary.observed_phenotype.cardTitle'),
     id: OBSERVED_PHENOTYPE_ID,
     component: <SunburstGraphCard id={OBSERVED_PHENOTYPE_ID} field="observed_phenotype" />,
+    hidden: true,
     ...observedPhenotypeDefaultGridConfig,
   },
   {
     title: intl.get('screen.dataExploration.tabs.summary.mondo.cardTitle'),
     id: MONDO_ID,
     component: <SunburstGraphCard id={MONDO_ID} field="mondo" />,
+    hidden: true,
     ...mondoDefaultGridConfig,
   },
   {


### PR DESCRIPTION
# FIX : hide Sunburst MONDO & HPO by default

- closes [#SKFP-1114](https://d3b.atlassian.net/browse/SKFP-1114)