### PR TITLE
fix: skfp-1099 prevent crash from upload list when families_id is null

### DIFF
--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -50,9 +50,9 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
       return participants?.flatMap((participant) => {
         const matchedIds: string[] = ids.filter(
           (id: string) =>
-            participant.participant_id.toLocaleLowerCase() === id.toLocaleLowerCase() ||
-            participant.external_id.toLocaleLowerCase() === id.toLocaleLowerCase() ||
-            participant.families_id.toLocaleLowerCase() === id.toLocaleLowerCase(),
+            participant.participant_id?.toLocaleLowerCase() === id.toLocaleLowerCase() ||
+            participant.external_id?.toLocaleLowerCase() === id.toLocaleLowerCase() ||
+            participant.families_id?.toLocaleLowerCase() === id.toLocaleLowerCase(),
         );
 
         return matchedIds.map((id, index) => ({


### PR DESCRIPTION
# FIX : prevent crash from upload list when families_id is null

- closes [#SKFP-1099](https://d3b.atlassian.net/browse/SKFP-1099)

## Description

[![image](https://github.com/kids-first/kf-portal-ui/assets/156684667/6900817b-f3ac-4fec-8df7-2fbf73d48a67)