### PR TITLE
feat(pedcbioportal): SKFP-1154 add new pedcbioportal rules

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -28,6 +28,11 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
             files {
               hits {
                 total
+                edges {
+                  node {
+                    data_type
+                  }
+                }
               }
             }
             study {
@@ -147,6 +152,7 @@ export const GET_PARTICIPANT_ENTITY = gql`
                 total
                 edges {
                   node {
+                    data_type
                     data_category
                     sequencing_experiment {
                       hits {

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -17,6 +17,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
 import { Button, Dropdown, Menu, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
@@ -47,7 +48,7 @@ import {
   extractMondoTitleAndCode,
   extractPhenotypeTitleAndCode,
 } from 'views/DataExploration/utils/helper';
-import { mapStudyToPedcBioportal } from 'views/Studies/utils/helper';
+import { areFilesDataTypeValid, mapStudyToPedcBioportal } from 'views/Studies/utils/helper';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { ReportType } from 'services/api/reports/models';
@@ -223,8 +224,9 @@ const getDefaultColumns = (): ProColumnType[] => [
     title: intl.get('entities.participant.pedcBioPortal'),
     render: (record: ITableParticipantEntity) => {
       const studyId = mapStudyToPedcBioportal(record.study?.study_code);
+      const files = hydrateResults(record?.files?.hits?.edges ?? []);
 
-      if (!studyId || !record?.is_proband) {
+      if (!studyId || !record?.is_proband || !areFilesDataTypeValid(files)) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
 

--- a/src/views/ParticipantEntity/utils/summary.tsx
+++ b/src/views/ParticipantEntity/utils/summary.tsx
@@ -4,9 +4,11 @@ import { IEntityDescriptionsItem } from '@ferlab/ui/core/pages/EntityPage';
 import { Tag, Tooltip } from 'antd';
 import { FamilyType, IParticipantEntity } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
-import { mapStudyToPedcBioportal } from 'views/Studies/utils/helper';
+import { areFilesDataTypeValid, mapStudyToPedcBioportal } from 'views/Studies/utils/helper';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+
+import { hydrateResults } from '../../../graphql/models';
 
 import styles from '../styles/styles.module.scss';
 
@@ -59,6 +61,7 @@ export const getSummaryItems = (participant?: IParticipantEntity): IEntityDescri
       participant?.participant_id &&
       participant.study?.study_code &&
       participant?.is_proband &&
+      areFilesDataTypeValid(hydrateResults(participant?.files.hits.edges ?? [])) &&
       mapStudyToPedcBioportal(participant.study.study_code) ? (
         <ExternalLink
           href={`https://pedcbioportal.kidsfirstdrc.org/patient?studyId=${mapStudyToPedcBioportal(

--- a/src/views/Studies/utils/helper.ts
+++ b/src/views/Studies/utils/helper.ts
@@ -1,3 +1,12 @@
+import { IFileEntity } from '../../../graphql/files/models';
+
+const VALID_DATA_TYPES: string[] = [
+  'Somatic Simple Nucleotide Variations',
+  'Raw Gene Fusions',
+  'Gene Expression Quantification',
+  'Somatic Copy Number Variations',
+];
+
 export const StudyCodeMap: { [key: string]: string } = {
   'KF-MMC': 'aml_sd_pet7q6f2_2018',
   'KF-CHDALL': 'bllnos_sd_z6mwd3h0_2018',
@@ -8,3 +17,6 @@ export const StudyCodeMap: { [key: string]: string } = {
 };
 
 export const mapStudyToPedcBioportal = (studyCode: string) => StudyCodeMap[studyCode] || '';
+
+export const areFilesDataTypeValid = (files: IFileEntity[]): boolean =>
+  files.some((file) => VALID_DATA_TYPES.includes(file.data_type));


### PR DESCRIPTION
# FEAT

- closes #[1154](https://d3b.atlassian.net/browse/SKFP-1154)

## Description

Goal: CHOP noticed that certain pedcbioportal links in the Data Exploration – Participant tab and Participant Entity page are not redirecting to a valid participant. It seems like the rule that was provided to us was not accurate and need to be refined to the following. 

Recently we updated part of the rule in SKFP-1087: [Data Exploration] Update the study code to pedcbio StudyID mapping
TERMINÉ(E)
  which is still valid. But we will further refine what was done to limit the display of the pedcbioportal link to the following query:


[Data Type = Somatic Simple Nucleotide Variations OR Raw Gene Fusions OR Gene Expression Quantification OR Somatic Copy Number Variations

AND proband=true]



