### PR TITLE
Feat/skfp 1154/pedcbioportal rules

### DIFF
--- a/src/views/Studies/utils/helper.ts
+++ b/src/views/Studies/utils/helper.ts
@@ -13,7 +13,7 @@ export const StudyCodeMap: { [key: string]: string } = {
   'KF-OS': 'os_sd_zxjffmef_2015',
   'KF-TALL': 'tll_sd_aq9kvn5p_2019',
   CBTN: 'openpedcan_v15',
-  'KF-NBL': 'openpedcan_v15',
+  'KF-NBL': 'x01_fy16_nbl_maris',
 };
 
 export const mapStudyToPedcBioportal = (studyCode: string) => StudyCodeMap[studyCode] || '';


### PR DESCRIPTION
# FEAT 
- closes #[1154](https://d3b.atlassian.net/browse/SKFP-1154)

## Description

Le mapping de l'étude KF-NBL pour le studyId dans le URL devrait maintenant être studyId=x01_fy16_nbl_maris au lieu de studyId=openpedcan_v15



