### PR TITLE
fix: SKFP-1219 apply correct colors for empty icon

### DIFF
--- a/src/style/themes/kids-first/main.css
+++ b/src/style/themes/kids-first/main.css
@@ -61,7 +61,7 @@
   --sidebar-content-panel-close-icon-width: 16px;
   --grid-card-light-background-color: white;
   --grid-card-shade-background-color: var(--gray-2);
-  --empty-image-color: rgba(red(var(--gray-6)), green(var(--gray-6)), blue(var(--gray-6)), 50%);
+  --empty-image-color: var(--cyan-7); 
   --empty-content-color: var(--gray-6);
   --collapse-light-background-color: white;
   --collapse-shade-background-color: var(--gray-3);


### PR DESCRIPTION
# FIX : EMpty icon color

- closes https://d3b.atlassian.net/browse/SKFP-1219

## Description

https://d3b.atlassian.net/browse/SKFP-1219

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![Capture d’écran, le 2024-07-31 à 13 26 03](https://github.com/user-attachments/assets/cfaa1b87-09e3-4f4b-8122-b43df342b7ee)

### After
<img width="454" alt="image" src="https://github.com/user-attachments/assets/eee9e533-c1bc-4686-8f86-ddb7b6f04990">
