### PR TITLE
feat(participant): SKFP-1207 add historical diagnoses

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -178,6 +178,8 @@ export const GET_PARTICIPANT_ENTITY = gql`
                                 total
                                 edges {
                                   node {
+                                    mondo_display_term
+                                    source_text
                                     source_text_tumor_descriptor
                                     source_text_tumor_location
                                     ncit_display_term

--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -48,17 +48,15 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     ),
   },
   {
-    key: 'collection_ncit_anatomy_site',
-    title: intl.get('entities.biospecimen.anatomical_site_NCIT'),
+    key: 'mondo_display_term',
+    title: intl.get('entities.biospecimen.diagnoses.mondo_display_term'),
     defaultHidden: true,
-    dataIndex: 'collection_ncit_anatomy_site',
-    render: (collection_ncit_anatomy_site: string) => (
-      <OntologyTermWithLink
-        term={collection_ncit_anatomy_site}
-        type={'ncit'}
-        hrefWithoutCode={
-          'https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=22.07d&ns=ncit&code='
-        }
+    dataIndex: 'diagnoses',
+    render: (diagnoses: ArrangerResultsTree<IBiospecimenDiagnoses>) => (
+      <OntologyTermsWithLinksFromDiagnoses
+        dxs={diagnoses}
+        type="mondo"
+        hrefWithoutCode="http://purl.obolibrary.org/obo/MONDO_"
       />
     ),
   },
@@ -70,6 +68,27 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     render: (diagnoses: ArrangerResultsTree<IBiospecimenDiagnoses>) => (
       <OntologyTermsWithLinksFromDiagnoses
         dxs={diagnoses}
+        type="ncit"
+        hrefWithoutCode={
+          'https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=22.07d&ns=ncit&code='
+        }
+      />
+    ),
+  },
+  {
+    key: 'source_text',
+    title: intl.get('entities.biospecimen.diagnoses.source_text'),
+    defaultHidden: true,
+    render: (record: IBiospecimenEntity) => mergeBiosDiagnosesSpecificField(record, 'source_text'),
+  },
+  {
+    key: 'collection_ncit_anatomy_site',
+    title: intl.get('entities.biospecimen.anatomical_site_NCIT'),
+    defaultHidden: true,
+    dataIndex: 'collection_ncit_anatomy_site',
+    render: (collection_ncit_anatomy_site: string) => (
+      <OntologyTermWithLink
+        term={collection_ncit_anatomy_site}
         type={'ncit'}
         hrefWithoutCode={
           'https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=22.07d&ns=ncit&code='


### PR DESCRIPTION
# FEAT 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SKFP-1207)

## Description

Add Histological diagnosis columns to Biospecimen table as user-defined columns, above the anatomical site facets in the Participant entity page.

  Add Histological Diagnosis (MONDO) column as a user-defined column 
  Add Histological Diagnosis (NCIT) column as a user-defined column 
  Add Histological Diagnosis (Source Text) column as a user-defined column

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1207)


## Screenshot
### Before
![image](https://github.com/user-attachments/assets/18d7e495-7636-44ec-b4ff-a6f89ff46873)

### After
![image](https://github.com/user-attachments/assets/7f1a7d83-3504-4ef8-9d72-ba43416ca292)

