### PR TITLE
fix(participant): SKFP-1207 fix biospecimens tsv export

### DIFF
--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -181,7 +181,8 @@ const generateLocalTsvReport = createAsyncThunk<
       return thunkAPI.rejectWithValue('error');
     }
 
-    const doc: string = [visibleTitle, ...visibleRows]
+    const formattedVisibleRows = visibleRows.map((row: string[]) => row.map((r) => (r ? r : '--')));
+    const doc: string = [visibleTitle, ...formattedVisibleRows]
       .reduce((text, row) => text + '\n' + row.join('\t'), '')
       .trimStart();
 

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -110,7 +110,18 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
                 visible: x.visible,
                 key: x.key,
               })),
-              rows: biospecimens,
+              rows: biospecimens.map((biospecimen) => ({
+                ...biospecimen,
+                source_text: (biospecimen.diagnoses?.hits?.edges ?? [])
+                  .map((diagnose) => diagnose.node.source_text)
+                  .join('\n'),
+                mondo_display_term: (biospecimen.diagnoses?.hits?.edges ?? [])
+                  .map((diagnose) => diagnose.node.mondo_display_term)
+                  .join('\n'),
+                ncit_display_term: (biospecimen.diagnoses?.hits?.edges ?? [])
+                  .map((diagnose) => diagnose.node.ncit_display_term)
+                  .join('\n'),
+              })),
             }),
           ),
       }}

--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -61,7 +61,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     ),
   },
   {
-    key: 'diagnoses.ncit_display_term',
+    key: 'ncit_display_term',
     title: intl.get('entities.biospecimen.diagnoses.ncit_display_term'),
     defaultHidden: true,
     dataIndex: 'diagnoses',


### PR DESCRIPTION
# FIX 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SKFP-1207)

## Description
1. Afficher un double-tiret dans le fichier tsv s’il n’y a pas de données
2. Les données ne sont pas affichées dans le fichier tsv

[[JIRA LINK]](https://d3b.atlassian.net/browse/SKFP-1207)


## Screenshot
### Before
![image](https://github.com/user-attachments/assets/27dc9161-c186-47a9-8afa-2d0db66410a0)

### After
![image](https://github.com/user-attachments/assets/4fa4aeac-63b9-4317-a302-af574a3caa21)



