### PR TITLE
feat: SKFP-1313 adjust authorization icon and flow for controlled Imaging files governed by the Cavatica DRS

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1577,6 +1577,11 @@ const en = {
               disabledButtonTooltip: 'You must select at least 1 item',
             },
           },
+          undeterminedAuthorization: {
+            popoverTitle: 'Undetermined Authorization',
+            popoverContent:
+              'We are unable to determine the authorization status of these files. Depending on your dbGaP authorization status, the files in this dataset may or may not be accessible in your Cavatica project. Read more on <a href="{href}" style="color:#0369a1;text-decoration-line:underline;" target="_blank">applying for data access</a>.',
+          },
         },
       },
     },

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.module.css
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.module.css
@@ -10,3 +10,6 @@
 .dataFilesTabWrapper .authorizedLock {
   color: var(--green-7);
 }
+.dataFilesTabWrapper .authorizedUndetermined {
+  color: var(--orange-7);
+}

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { LockOutlined, SafetyOutlined, UnlockFilled } from '@ant-design/icons';
+import { LockOutlined, SafetyOutlined, UnlockFilled, WarningOutlined } from '@ant-design/icons';
 import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink/index';
 import ProTable from '@ferlab/ui/core/components/ProTable';
@@ -18,7 +18,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Tag, Tooltip } from 'antd';
+import { Popover, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useDataFiles } from 'graphql/files/actions';
 import {
@@ -85,6 +85,29 @@ export const getDefaultColumns = (
     align: 'center',
     defaultHidden: activePreset === PresetOptions.Datafiles,
     render: (record: IFileEntity) => {
+      if (
+        record.controlled_access.toLowerCase() === FileAccessType.CONTROLLED.toLowerCase() &&
+        record.access_urls.startsWith('drs://cavatica-ga4gh-api.sbgenomics.com/')
+      ) {
+        return (
+          <Popover
+            placement="top"
+            overlayStyle={{ maxWidth: '420px' }}
+            title={intl.get(
+              'screen.dataExploration.tabs.datafiles.undeterminedAuthorization.popoverTitle',
+            )}
+            content={intl.getHTML(
+              'screen.dataExploration.tabs.datafiles.undeterminedAuthorization.popoverContent',
+              {
+                href: 'https://kidsfirstdrc.org/help-center/accessing-controlled-data-via-dbgap/',
+              },
+            )}
+          >
+            <WarningOutlined className={styles.authorizedUndetermined} />
+          </Popover>
+        );
+      }
+
       const hasAccess = userHasAccessToFile(
         record,
         fenceAcls,


### PR DESCRIPTION
# FEAT: adjust authorization icon and flow for controlled Imaging files governed by the Cavatica DRS

- closes [#SKFP-1313](https://d3b.atlassian.net/browse/SKFP-1313)

## Description

![image](https://github.com/user-attachments/assets/4b2905bf-07ac-4c85-9c8b-56d2d6649492)
