### PR TITLE
fix(data files): SKFP-1315 add empty placeholder

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -87,7 +87,7 @@ export const getDefaultColumns = (
     render: (record: IFileEntity) => {
       if (
         record.controlled_access.toLowerCase() === FileAccessType.CONTROLLED.toLowerCase() &&
-        record.access_urls.startsWith('drs://cavatica-ga4gh-api.sbgenomics.com/')
+        record.access_urls?.startsWith('drs://cavatica-ga4gh-api.sbgenomics.com/')
       ) {
         return (
           <Popover
@@ -316,6 +316,7 @@ export const getDefaultColumns = (
     dataIndex: 'access_urls',
     defaultHidden: true,
     sorter: { multiple: 1 },
+    render: (access_urls: string) => access_urls || TABLE_EMPTY_PLACE_HOLDER,
   },
   // Imaging columns
   {


### PR DESCRIPTION
# FIX: Add empty placeholder to access url

## Description

[SKFP-1315](https://d3b.atlassian.net/browse/SKFP-1315)

Acceptance Criterias
- display empty placeholder

## Screenshot
### Before

### After
<img width="1507" alt="Capture d’écran, le 2024-10-07 à 09 57 14" src="https://github.com/user-attachments/assets/5eac40df-fdc7-40f1-9eaf-cbf063426f03">




[SKFP-1315]: https://d3b.atlassian.net/browse/SKFP-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ