### PR TITLE
fix(data explo): SKFP-1314 add double type to render facet

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -42,7 +42,7 @@ const generateAggregations = (extendedMappingFields: TExtendedMapping[]) => {
         dotToUnderscore(f.field) +
         ' {\n     buckets {\n      key\n        key_as_string\n        doc_count\n    }\n  }'
       );
-    } else if (['long', 'float', 'integer', 'date'].includes(f.type)) {
+    } else if (['long', 'float', 'integer', 'date', 'double'].includes(f.type)) {
       return dotToUnderscore(f.field) + '{\n    stats {\n  max\n   min\n    }\n    }';
     } else if (['boolean'].includes(f.type)) {
       return (


### PR DESCRIPTION
# FIX : Add double type to render facet

## Description

[SKFP-1314](https://d3b.atlassian.net/browse/SKFP-1314)

Acceptance Criterias
- Be able to open magnetic field strength facet

## Screenshot
### Before

### After
<img width="1543" alt="Capture d’écran, le 2024-10-07 à 16 35 14" src="https://github.com/user-attachments/assets/7c8acb05-1e45-4abe-ac9f-63410b05b1b5">



[SKFP-1314]: https://d3b.atlassian.net/browse/SKFP-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ