### PR TITLE
feat(cavatica): SKFP-1365 add warning modal when more than 10 000 are…

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1605,6 +1605,12 @@ const en = {
         datafiles: {
           title: 'Data Files ({count})',
           cavatica: {
+            maxFileReached: {
+              title: 'Maximum number exceeded',
+              description:
+                'A maximum of 10,000 items can be copied at a time. Please narrow your selection and try again.',
+              okText: 'Close',
+            },
             title: 'Connect to Cavatica',
             analyseInCavatica: 'Analyze in Cavatica',
             bulkImportLimit: {

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -589,6 +589,7 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
             />,
             <CavaticaAnalyzeButton
               disabled={selectedKeys.length === 0 && !selectedAllResults}
+              maxFileReached={hasTooManyFiles}
               type="primary"
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}


### PR DESCRIPTION
# feat(cavatica): add warning modal when more than 10 000 are selected

- Closes SKFP-1365

## Description
Currently, users who attempt to copy >10,000 files to cavatica have it capped at 10,000. Therefore we will add a modal prior to clicking the analyze in cavatica modal if their selection is >10,000 items in the Data Exploration – Data files tab..

Modal Details:

Title: Maximum number exceeded

Text: A maximum of 10,000 items can be exported copied at a time. Please narrow your selection and try again.

Button Label: Close

## Links
- [JIRA](https://d3b.atlassian.net/browse/SKFP-1365)

## Screenshot or Video
![2024-11-26_14-48_1](https://github.com/user-attachments/assets/b826735b-0d60-4a68-b58c-2a25bcda3984)
![2024-11-26_14-48](https://github.com/user-attachments/assets/b571521b-13d3-41fc-9473-b5c9a916ed64)

