### PR TITLE
fix(quickfilter): SKFP-1362 map icon to facet

### DIFF
--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -77,6 +77,7 @@ import BiospecimenUploadIds from './components/UploadIds/BiospecimenUploadIds';
 import FileUploadIds from './components/UploadIds/FileUploadIds';
 import ParticipantUploadIds from './components/UploadIds/ParticipantUploadIds';
 import {
+  getFieldCategoryIcon,
   getFieldWithoutPrefix,
   getIndexFromQFValueFacet,
   getSelectedOptionsByQuery,
@@ -405,7 +406,7 @@ const DataExploration = () => {
       headerTooltip: false,
       dictionary: getFacetsDictionary(),
       noDataInputOption: false,
-      categoryIcon: <UserOutlined className={styles.categoryIcon} />,
+      categoryIcon: getFieldCategoryIcon(option.key, { className: styles.categoryIcon }),
     });
 
     const filters =

--- a/src/views/DataExploration/utils/quickFilter.tsx
+++ b/src/views/DataExploration/utils/quickFilter.tsx
@@ -1,3 +1,5 @@
+import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
+import { AntdIconProps } from '@ant-design/icons/lib/components/AntdIcon';
 import { VisualType } from '@ferlab/ui/core/components/filters/types';
 import { CheckboxQFOption } from '@ferlab/ui/core/components/SidebarMenu/QuickFilter';
 import {
@@ -7,6 +9,17 @@ import {
 } from '@ferlab/ui/core/data/sqon/types';
 import { INDEXES } from 'graphql/constants';
 import { cloneDeep } from 'lodash';
+
+export const getFieldCategoryIcon = (facetKey: string, props: AntdIconProps): React.ReactNode => {
+  if (facetKey.startsWith('files__biospecimens__')) {
+    return <ExperimentOutlined {...props} />;
+  }
+  if (facetKey.startsWith('files__')) {
+    return <FileTextOutlined {...props} />;
+  }
+
+  return <UserOutlined {...props} />;
+};
 
 export const getIndexFromQFValueFacet = (facetKey: string): INDEXES => {
   if (facetKey.startsWith('files__biospecimens__')) return INDEXES.BIOSPECIMEN;


### PR DESCRIPTION
# fix(quickfilter): map icon to facet

- Closes SKFP-1362

## Description
Il semble que le compte affiché n’est pas celui des participants. L’icône dans le Quick Filter devrait donc refléter la bonne catégorie de données.
## Links
- [JIRA](https://d3b.atlassian.net/browse/SKFP-1362)


## Screenshot or Video
![image](https://github.com/user-attachments/assets/7a08031f-87ce-4a46-9092-ca1069377716)
