### PR TITLE
fix(summary): SKFP-1384 only filter data in grid

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
@@ -42,7 +42,9 @@ const DataCategoryGraphCard = () => {
   const dataCategoryResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__data_category.buckets,
     result?.data?.participant?.hits?.total,
-  )
+  );
+
+  const filteredDataCategoryResults = dataCategoryResults
     .sort((a, b) => a.value - b.value)
     .slice(0, 10);
 
@@ -98,7 +100,7 @@ const DataCategoryGraphCard = () => {
             <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
-              data={dataCategoryResults}
+              data={filteredDataCategoryResults}
               ariaLabel={intl.get(
                 'screen.dataExploration.tabs.summary.availableData.dataCategoryTitle',
               )}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
@@ -41,9 +41,9 @@ const DataTypeGraphCard = () => {
   const dataTypeResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__data_type.buckets,
     result?.data?.participant?.hits?.total,
-  )
-    .sort((a, b) => a.value - b.value)
-    .slice(0, 10);
+  );
+
+  const filteredTypeResults = dataTypeResults.sort((a, b) => a.value - b.value).slice(0, 10);
 
   return (
     <ResizableGridCard
@@ -95,7 +95,7 @@ const DataTypeGraphCard = () => {
             <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
-              data={dataTypeResults}
+              data={filteredTypeResults}
               ariaLabel={intl.get(
                 'screen.dataExploration.tabs.summary.availableData.dataTypeTitle',
               )}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
@@ -42,7 +42,9 @@ const SampleTypeGraphCard = () => {
   const sampleTypeResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__biospecimens__sample_type.buckets,
     result?.data?.participant?.hits?.total,
-  )
+  );
+
+  const filteredSampleTypeResults = sampleTypeResults
     .sort((a, b) => a.value - b.value)
     .slice(0, 10);
 
@@ -96,7 +98,7 @@ const SampleTypeGraphCard = () => {
             <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
-              data={sampleTypeResults}
+              data={filteredSampleTypeResults}
               axisLeft={{
                 legend: intl.get(
                   'screen.dataExploration.tabs.summary.graphs.sampleTypeGraph.legendAxisLeft',


### PR DESCRIPTION
# fix(summary): only filter data in grid

- Closes SKFP-1384

## Description
Le tsv devrait contenir toutes les données, pas seulement les 10 plus fréquentes.

## Links
- [JIRA](https://d3b.atlassian.net/browse/SKFP-1384)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/73e44d39-9584-4bc5-a0fe-1d9921923ece)
