### PR TITLE
fix(search): SKFP-1487 add check option data not defined

### DIFF
--- a/src/components/uiKit/search/GlobalSearch/Search/index.tsx
+++ b/src/components/uiKit/search/GlobalSearch/Search/index.tsx
@@ -65,7 +65,7 @@ const Search = <T,>({
         },
       });
 
-      setOptions(setCurrentOptions(data.data, search));
+      setOptions(setCurrentOptions(data?.data || [], search));
     }
   };
 


### PR DESCRIPTION
# fix(search): add check option data not defined

[SKFP-1487](https://d3b.atlassian.net/browse/SKFP-1487)

## Description
Sentru error

## Acceptance Criterias
Add check if data returned by arranger is defined.

## Screenshot or Video
### Before
<img width="1137" alt="Capture d’écran, le 2025-03-20 à 14 41 56" src="https://github.com/user-attachments/assets/82fb863b-4db8-477c-a066-2b84fbb4a5fc" />

### After
https://github.com/user-attachments/assets/e50de077-e167-4906-a08f-9defee08b134


[SKFP-1487]: https://d3b.atlassian.net/browse/SKFP-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ