### PR TITLE
feat(variant): SKFP-1464 update gene href

### DIFF
--- a/cypress/e2e/Consultation/PageVariant_2.cy.ts
+++ b/cypress/e2e/Consultation/PageVariant_2.cy.ts
@@ -21,7 +21,7 @@ describe('Page d\'un variant - Valider les liens disponibles', () => {
 
   it('Lien Ensembl du panneau Summary', () => {
     // data-cy="Summary_Ensembl_ExternalLink"
-    cy.get('a[class*="VariantEntity_ensemblLink"]').eq(0).should('have.attr', 'href', 'https://www.ensembl.org/id/ENST00000368285');
+    cy.get('a[class*="VariantEntity_ensemblLink"]').eq(0).should('have.attr', 'href', 'https://www.ensembl.org/id/ENSG00000196189');
   });
 
   it('Lien ClinVar du panneau Summary', () => {

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -171,7 +171,7 @@ export const getSummaryItems = (variant?: IVariantEntity) => {
                 (
                 <ExternalLink
                   className={style.ensemblLink}
-                  href={`https://www.ensembl.org/id/${pickedConsequence.node.ensembl_transcript_id}`}
+                  href={`https://www.ensembl.org/id/${geneWithPickedConsequence.ensembl_gene_id}`}
                 >
                   {intl.get('screen.variants.summary.ensembl')}
                 </ExternalLink>

--- a/src/views/VariantSomaticEntity/utils/summary.tsx
+++ b/src/views/VariantSomaticEntity/utils/summary.tsx
@@ -160,8 +160,8 @@ export const getSummaryItems = (variant?: IVariantSomaticEntity) => {
               <ExternalLink
                 className={style.symbolLink}
                 href={
-                  geneWithPickedConsequence.omim_gene_id
-                    ? `https://omim.org/entry/${geneWithPickedConsequence.omim_gene_id}`
+                  geneWithPickedConsequence.ensembl_gene_id
+                    ? `https://omim.org/entry/${geneWithPickedConsequence.ensembl_gene_id}`
                     : // eslint-disable-next-line max-len
                       `https://www.omim.org/search?index=entry&start=1&limit=10&sort=score+desc%2C+prefix_sort+desc&search=${geneWithPickedConsequence.symbol}`
                 }


### PR DESCRIPTION
# feat(variant): update gene href

- Closes SJFP-1464

## Description
Update the hyperlink on the ensembl button in the variant entity page. Currently it redirects to the transcript ensembl url but we want it to redirect to the gene ensembl url. 


## Links
- [JIRA](https://d3b.atlassian.net/browse/SJFP-1464)


## Screenshot or Video
![image](https://github.com/user-attachments/assets/22e1cca3-ea3a-49a4-acad-c01d3cfe0803)
![image](https://github.com/user-attachments/assets/fb171634-3d81-4732-8639-8dacc9886e89)
