### PR TITLE
SKFP-979 Add picked symbol to associated consequence/transcript

### DIFF
--- a/cypress/e2e/Consultation/PageVariant_1.cy.ts
+++ b/cypress/e2e/Consultation/PageVariant_1.cy.ts
@@ -104,6 +104,7 @@ describe('Page d\'un variant - Vérifier les informations affichées', () => {
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(0).contains('p.Arg713Gln').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).find('svg[class*="Cell_moderateImpact"]').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).contains('Missense').should('exist');
+    cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).find('span[class*="VariantEntity_pickedIcon"]').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(2).contains('c.2138G>A').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(3).find('span[class*="ant-typography"]').eq(0).contains('SIFT').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(3).find('span[class*="ant-typography"]').eq(1).contains('Tolerated ').should('exist');

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1517,6 +1517,7 @@ const en = {
         conservation: 'Conservation',
         phyloP17Way: 'PhyloP17Way',
         pickedTooltip: 'Gene with most deleterious consequence',
+        pickedConsequenceTooltip: 'Most deleterious consequence',
       },
       frequencies: {
         kfStudies: 'Kids First Studies',

--- a/src/views/VariantEntity/utils/consequence.tsx
+++ b/src/views/VariantEntity/utils/consequence.tsx
@@ -160,6 +160,9 @@ export const getExpandedColumns = (variant: IVariantEntity): ColumnType<any>[] =
           <Text className={style.consequence}>
             {removeUnderscoreAndCapitalize(consequence.consequence[0])}
           </Text>
+          <Tooltip title={intl.get('screen.variants.consequences.pickedConsequenceTooltip')}>
+            {consequence.picked && <CheckCircleFilled className={style.pickedIcon} />}
+          </Tooltip>
         </>
       );
     },


### PR DESCRIPTION
# Description
Currently, we only have the picked symbol on the gene with the most deleterious consequence, but we should also have the symbol for the most deleterious consequence itself (the one that is the highlight at the top of the page). 

# Links
https://d3b.atlassian.net/browse/SKFP-979

# Screenshot
![image](https://github.com/user-attachments/assets/ca08c122-dfd6-499f-a245-fc5248ddcc5e)

