### PR TITLE
fix(venn): SKFP-1524 fix an issue where the wrong tooltips was displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/core": "^7.26.9",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.24.5",
+        "@ferlab/ui": "^10.24.9",
         "@loadable/component": "^5.16.4",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@react-keycloak/core": "^3.2.0",
@@ -2998,9 +2998,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.24.5",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.5.tgz",
-      "integrity": "sha512-Mjeqd/E8GulN1RtOr8b+dkw05cVN9mRoxaz5XRhhZnZToBL2gBEPNARVExfTwVmrOmHg9OPtuf1ZapCvzZ30cg==",
+      "version": "10.24.9",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.9.tgz",
+      "integrity": "sha512-9gqX2hN7brC9sFRttUbSvoCsIFW1ndt+Np9TIxC+cjF06NVB+R+4tkGp7c6uI2NyzCvyB/cCo+7cWbKT85gcwA==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",
@@ -6173,7 +6173,6 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/accepts": {
@@ -6446,11 +6445,11 @@
       }
     },
     "node_modules/antd-img-crop": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/antd-img-crop/-/antd-img-crop-4.24.0.tgz",
-      "integrity": "sha512-RqY/XqvmUnHlj7oLV2kN/ytdZdHUFAZyM3TN+QlTlLrze1Q74isAePgG+QTkLAbrkR9L/IgVRpjsuH/nevpU7Q==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/antd-img-crop/-/antd-img-crop-4.25.0.tgz",
+      "integrity": "sha512-2bFno50sfEnIl0ttGjOCC32z82yvz/wb4+UMfd9akKQrcNnbuadlfzL9f5n37Vuqb5l9Tdw4U4V+3sMY9EWW7g==",
       "dependencies": {
-        "react-easy-crop": "^5.2.0",
+        "react-easy-crop": "^5.4.1",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
@@ -15490,7 +15489,6 @@
     },
     "node_modules/nopt": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abbrev": "1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.26.9",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.24.5",
+    "@ferlab/ui": "^10.24.9",
     "@loadable/component": "^5.16.4",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@react-keycloak/core": "^3.2.0",


### PR DESCRIPTION
# fix(venn): fix an issue where the wrong tooltips was displayed

- Closes SKFP-1524

## Description
Issue: Currently, when we hover on the Set Definitions in the Set Operations Analytics app, we get the set id which is not useful for the user. 

The correct behaviour is to see the same information in the set definition and see the full saved set name in the tooltip

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SKFP-1524)

## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/f46e1505-23fe-49ea-a44d-b88b3cb178c6)

### After
![image](https://github.com/user-attachments/assets/0d038fb2-a508-4780-bac3-09a01d9c1869)
![image](https://github.com/user-attachments/assets/b72c9e96-b577-4199-ac2b-2f6fd54cd478)
