### PR TITLE
feat(set): SKFP-1516 can now share saved set

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -19,6 +19,8 @@ export const MAIN_SCROLL_WRAPPER_ID = 'main-scroll-wrapper';
 
 export const FILTER_ID_QUERY_PARAM_KEY = 'filterId';
 export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
+export const SHARED_SET_ID_QUERY_PARAM_KEY = 'sharedSetId';
+export const SHARED_SET_TYPE_QUERY_PARAM_KEY = 'sharedSetType';
 
 export const DEFAULT_GRAVATAR_PLACEHOLDER = `${EnvironmentVariables.configFor(
   'WEB_ROOT',

--- a/src/middleware/AuthMiddleware.tsx
+++ b/src/middleware/AuthMiddleware.tsx
@@ -1,14 +1,25 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+// eslint-disable-next-line max-len
 import { SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY } from '@ferlab/ui/core/components/BiospecimenRequest/requestBiospecimen.utils';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { useKeycloak } from '@react-keycloak/web';
 
-import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
+import {
+  SHARED_FILTER_ID_QUERY_PARAM_KEY,
+  SHARED_SET_ID_QUERY_PARAM_KEY,
+  SHARED_SET_TYPE_QUERY_PARAM_KEY,
+} from 'common/constants';
+import { SET_TYPE_QB_ID_MAPPING } from 'common/queryBuilder';
 import { KidsFirstKeycloakTokenParsed } from 'common/tokenTypes';
 import Spinner from 'components/uiKit/Spinner';
 import useQueryParams from 'hooks/useQueryParams';
+import { SetType } from 'services/api/savedSet/models';
 import { useSavedFilter } from 'store/savedFilter';
 import { fetchSavedFilters, fetchSharedSavedFilter } from 'store/savedFilter/thunks';
+import { getSetFieldId } from 'store/savedSet';
 import { fetchSavedSet, fetchSharedBiospecimenRequest } from 'store/savedSet/thunks';
 import { useUser } from 'store/user';
 import { userActions } from 'store/user/slice';
@@ -34,11 +45,30 @@ const AuthMiddleware = ({ children }: Props) => {
       dispatch(fetchSavedSet());
       const sharedFilterId = params.get(SHARED_FILTER_ID_QUERY_PARAM_KEY);
       const biospecimenRequestId = params.get(SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY);
+      const sharedSetId = params.get(SHARED_SET_ID_QUERY_PARAM_KEY);
+      const sharedSetType = params.get(SHARED_SET_TYPE_QUERY_PARAM_KEY);
       if (sharedFilterId) {
         dispatch(fetchSharedSavedFilter(sharedFilterId));
       }
       if (biospecimenRequestId) {
         dispatch(fetchSharedBiospecimenRequest(biospecimenRequestId));
+      }
+      if (sharedSetId && sharedSetType) {
+        const setValue = `${SET_ID_PREFIX}${sharedSetId}`;
+
+        addQuery({
+          queryBuilderId: SET_TYPE_QB_ID_MAPPING[sharedSetType],
+          query: generateQuery({
+            newFilters: [
+              generateValueFilter({
+                field: getSetFieldId(sharedSetType as SetType),
+                value: [setValue],
+                index: sharedSetType,
+              }),
+            ],
+          }),
+          setAsActive: true,
+        });
       }
     } else {
       dispatch(userActions.setIsUserLoading(false));

--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
@@ -113,7 +113,6 @@ const BiospecimenRequests = ({ id, className = '' }: DashboardCardProps) => {
         );
       }}
       handleListItemShare={async (id: string) => {
-        // call back to change sharedpublicly boolean
         copy(
           `${window.location.protocol}//${window.location.host}` +
             `${STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}?${SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY}=${id}`,

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
@@ -8,6 +8,7 @@ import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQuery
 import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { Col, Modal, Row, Tag, Typography } from 'antd';
+import copy from 'copy-to-clipboard';
 import { formatDistance } from 'date-fns';
 import { INDEXES } from 'graphql/constants';
 import { SetActionType } from 'views/DataExploration/components/SetsManagementDropdown';
@@ -17,9 +18,11 @@ import {
   PARTICIPANTS_SAVED_SETS_FIELD,
 } from 'views/DataExploration/utils/constant';
 
+import { SHARED_SET_ID_QUERY_PARAM_KEY, SHARED_SET_TYPE_QUERY_PARAM_KEY } from 'common/constants';
 import { SET_TYPE_QB_ID_MAPPING } from 'common/queryBuilder';
 import { trackSetActions } from 'services/analytics';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
+import { globalActions } from 'store/global';
 import { getSetFieldId } from 'store/savedSet';
 import { deleteSavedSet } from 'store/savedSet/thunks';
 import { STATIC_ROUTES } from 'utils/routes';
@@ -113,6 +116,26 @@ const ListItem = ({ data, icon }: OwnProps) => {
             },
           })
         }
+        onShare={() => {
+          copy(
+            `${window.location.protocol}//${window.location.host}${redirectToPage(
+              data.setType,
+            )}?${SHARED_SET_ID_QUERY_PARAM_KEY}=${data.id}&${SHARED_SET_TYPE_QUERY_PARAM_KEY}=${
+              data.setType
+            }`,
+          );
+          dispatch(
+            globalActions.displayNotification({
+              type: 'success',
+              message: intl.get(
+                'screen.dashboard.cards.biospecimenRequest.shareLink.success.title',
+              ),
+              description: intl.get(
+                'screen.dashboard.cards.biospecimenRequest.shareLink.success.description',
+              ),
+            }),
+          );
+        }}
         extra={
           <Row gutter={8} className={styles.countDisplay}>
             <Col>


### PR DESCRIPTION
# feat(set): can now share saved set

- Closes SKFP-1516

## Description
 Add share link button to the saved sets widget across all entity types. A user will be able to copy the url for their saved set and share it with another user.

## Acceptance Criterias
<!-- List all acceptance criteria from the ticket -->

## Links
- [JIRA](https://d3b.atlassian.net/browse/SKFP-1516)

## Screenshot or Video

https://github.com/user-attachments/assets/bd0e16d1-4e7e-4838-80c4-5fce600ba604

