### PR TITLE
feat: skfp-1559 analytic for canvatica

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "kids-first-portal-ui",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/src/components/Cavatica/AnalyzeButton/index.tsx
+++ b/src/components/Cavatica/AnalyzeButton/index.tsx
@@ -122,7 +122,23 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
         dispatch(passportActions.setCavaticaBulkImportDataStatus(CAVATICA_ANALYSE_STATUS.unknow));
       }}
       handleImportBulkData={(value) => {
-        trackCavaticaAction(index);
+        // Extract study codes from authorized files
+        const studyCodes = Array.from(
+          new Set(
+            cavatica.bulkImportData.authorizedFiles
+              .filter((file) => file.study?.study_code)
+              .map((file) => file.study.study_code),
+          ),
+        );
+
+        // Track with additional metadata
+        trackCavaticaAction(index, {
+          studyCodes,
+          projectId: value.id,
+          projectName: value.title || value.name,
+          fileCount: cavatica.bulkImportData.authorizedFiles.length,
+        });
+
         dispatch(startBulkImportJob(value));
       }}
       createProjectModalProps={{

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -70,11 +70,37 @@ export const trackRequestBiospecimen = (action: string) => {
   }
 };
 
-export const trackCavaticaAction = (page: string) => {
+export const trackCavaticaAction = (
+  page: string,
+  options?: {
+    studyCodes?: string[];
+    projectId?: string;
+    projectName?: string;
+    fileCount?: number;
+  },
+) => {
   if (isGaActive) {
+    const baseAction = `Cavatica Analyze - ${capitalize(page)}`;
+
+    // Build additional details string
+    const details: string[] = [];
+    if (options?.studyCodes?.length) {
+      details.push(`Study: ${options.studyCodes.join(', ')}`);
+    }
+    if (options?.projectName) {
+      details.push(`Project: ${options.projectName}`);
+    }
+    if (options?.fileCount) {
+      details.push(`Files: ${options.fileCount}`);
+    }
+
+    const action = details.length > 0 ? `${baseAction} (${details.join(' | ')})` : baseAction;
+
     ReactGA.event({
       category: 'Cavatica',
-      action: `Cavatica Analyze - ${capitalize(page)}`,
+      action,
+      // You can also use custom dimensions/metrics if configured in GA
+      ...(options?.fileCount && { value: options.fileCount }),
     });
   }
 };


### PR DESCRIPTION
https://d3b.atlassian.net/browse/SKFP-1559

Goal: In our data exploration -- file tab, users can select one or more files and send them to their Cavatica project for cloud analysis via the bulk import API (DRS-based).  However, the comms team wants to track in Google Analytics the following:  

How many times users send files to Cavatica which is something we already do with the "Analyze in Cavatica" event in the data files tab.   However, they want to know which Study code the file is associated to   (e.g. Study code= CBTN) in the event of "Analyze in Cavatica" 

They also want to know which Cavatica project the user selected per “Analyze in Cavatica” event

File count per “Analyze in Cavatica” event ( you can select multiple files before clicking the button)

Therefore, we will augment the Google Analytics event when a user clicks the “Analyze in Cavatica” button, with relevant metadata passed in order to let them filter within Google Analytics something along the lines of “Give me the # of Analyze in cavatica events where the files pushed to Cavatica were associated to Study=CBTN”