### PR TITLE
feat(summary): SKFP-1605 reverse data in hpo and mondo graphs

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -66,7 +66,7 @@ const MostFrequentDiagnosisGraphCard = () => {
           return 0;
         },
       );
-      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)));
+      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)).reverse());
     });
   }, [JSON.stringify(sqon)]);
 

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -101,7 +101,7 @@ const MostFrequentPhenotypesGraphCard = () => {
           return 0;
         },
       );
-      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)));
+      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
     });
   }, [JSON.stringify(sqon)]);
 


### PR DESCRIPTION
# feat(summary): reverse data in hpo and mondo graphs

- [SKFP-1605](https://d3b.atlassian.net/browse/SKFP-1605)

## Description
Set graphs to descending order

## Acceptance Criterias
Reverse data in HPO and MONDO graphs.

## Screenshot or Video
### Before
<img width="1476" height="452" alt="Capture d’écran, le 2026-03-16 à 10 39 35" src="https://github.com/user-attachments/assets/9d3bfaec-b798-4825-8e7b-bfe8d827ebce" />

### After
<img width="1476" height="452" alt="Capture d’écran, le 2026-03-16 à 10 40 10" src="https://github.com/user-attachments/assets/6e0d14be-8306-444e-b123-5725e41922f4" />


[SKFP-1605]: https://d3b.atlassian.net/browse/SKFP-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ