### PR TITLE
feat(export): SKFP-1612 implement tsv export with new arranger

### DIFF
--- a/cypress/e2e/Telechargement/TableauBiospecimens.cy.ts
+++ b/cypress/e2e/Telechargement/TableauBiospecimens.cy.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
   cy.showColumn('External Sample ID');
   cy.showColumn('External Collection ID');
 
-  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/download', 1, false/*beVisible*/, 1);
+  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/export', 1, false/*beVisible*/, 1);
   cy.waitUntilFile(oneMinute);
 });
 

--- a/cypress/e2e/Telechargement/TableauFiles.cy.ts
+++ b/cypress/e2e/Telechargement/TableauFiles.cy.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
   cy.get('div[class*="ant-select-item-option-content"]').contains('50').clickAndWait({force: true});
   cy.wait(1000);
 
-  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/download', 1, false/*beVisible*/, 1);
+  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/export', 1, false/*beVisible*/, 1);
   cy.waitUntilFile(oneMinute);
 });
 

--- a/cypress/e2e/Telechargement/TableauParticipants.cy.ts
+++ b/cypress/e2e/Telechargement/TableauParticipants.cy.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
   cy.showColumn('Observed Phenotype (Source Text)');
   cy.wait(1000);
 
-  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/download', 1, false/*beVisible*/, 1);
+  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/export', 1, false/*beVisible*/, 1);
   cy.waitUntilFile(oneMinute);
 });
 

--- a/cypress/e2e/Telechargement/TableauStudies.cy.ts
+++ b/cypress/e2e/Telechargement/TableauStudies.cy.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   cy.visitStudiesPage();
   cy.wait(1000);
 
-  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/download', 1);
+  cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/export', 1);
   cy.waitUntilFile(oneMinute);
 });
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -145,6 +145,12 @@ const en = {
         },
       },
     },
+    exportModal: {
+      title: 'Maximum number exceeded',
+      content:
+        'A maximum of 10,000 items can be exported at a time. Please narrow your selection and try again.',
+      button: 'Close',
+    },
     notification: {
       genericError: 'An error occured',
     },

--- a/src/services/api/arranger/index.ts
+++ b/src/services/api/arranger/index.ts
@@ -21,6 +21,7 @@ import {
   ISuggestionPayload,
   Suggestion,
   SuggestionType,
+  TTsvReportConfig,
 } from './models';
 
 const ARRANGER_API_URL = EnvironmentVariables.configFor('ARRANGER_API');
@@ -112,6 +113,21 @@ const searchSuggestions = (type: SuggestionType, value: string) =>
     url: `${ARRANGER_API}/${type}Feature/suggestions/${value}`,
   });
 
+const generateTsv = (config: TTsvReportConfig) =>
+  sendRequest<string>({
+    method: 'POST',
+    url: `${ARRANGER_API}/export`,
+    responseType: 'text',
+    data: {
+      index: config.index,
+      fileName: config.fileName,
+      sqon: config.sqon,
+      sort: config.sort,
+      columns: config.columns,
+      fileType: 'tsv',
+    },
+  });
+
 export const ArrangerApi = {
   fetchStatistics,
   fetchStudiesStatistics,
@@ -122,4 +138,5 @@ export const ArrangerApi = {
   columnStates,
   fetchMatchParticipant,
   searchSuggestions,
+  generateTsv,
 };

--- a/src/services/api/arranger/models.ts
+++ b/src/services/api/arranger/models.ts
@@ -96,3 +96,18 @@ export interface ArrangerPhenotypes {
   type: string;
   aggregations_filter_themselves: boolean;
 }
+
+export type TTsvReportColumn = {
+  field: string;
+  header: string;
+};
+
+export type TTsvReportConfig = {
+  index: string;
+  fileName: string;
+  sqon: ISyntheticSqon;
+  sort: { field: string; order: string }[];
+  columns: TTsvReportColumn[];
+};
+
+export const MAX_ROW_EXPORTED = 10000;

--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -1,23 +1,18 @@
 import intl from 'react-intl-universal';
-import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { ProColumnType, TColumnStates } from '@ferlab/ui/core/components/ProTable/types';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import keycloak from 'auth/keycloak-api/keycloak';
 import { format } from 'date-fns';
 import { saveAs } from 'file-saver';
 import { INDEXES } from 'graphql/constants';
 import { capitalize, startCase } from 'lodash';
-import { v4 } from 'uuid';
 
 import { getDefaultContentType } from 'common/downloader';
 import { trackReportDownload } from 'services/analytics';
 import { ArrangerApi } from 'services/api/arranger';
-import { ArrangerColumnStateResults } from 'services/api/arranger/models';
 import { ReportApi } from 'services/api/reports';
 import { IDownloadTranslation, ReportConfig } from 'services/api/reports/models';
 import { globalActions } from 'store/global';
-
-import { getColumnStateQuery } from '../../graphql/reports/queries';
 
 import { TFetchTSVArgs } from './types';
 
@@ -106,22 +101,20 @@ const fetchTsvReport = createAsyncThunk<void, TFetchTSVArgs, { rejectValue: stri
       const formattedDate = format(new Date(), 'yyyy-MM-dd');
       const formattedFileName = `kidsfirst-${args.index}-table-${formattedDate}.tsv`;
 
-      const { data, error } = await ArrangerApi.columnStates({
-        query: getColumnStateQuery(args.index),
-        variables: {},
+      const sortIdField = idField(args.index);
+
+      const { data, response } = await ArrangerApi.generateTsv({
+        index: args.index,
+        fileName: formattedFileName,
+        sqon: args.sqon,
+        sort: sortIdField ? [{ field: sortIdField, order: SortDirection.Asc }] : [],
+        columns: buildVisibleColumns(args.columns, args.columnStates),
       });
-
-      if (error) {
-        showErrorReportNotif(thunkAPI);
-        thunkAPI.dispatch(globalActions.destroyMessages([messageKey]));
-        return thunkAPI.rejectWithValue('error');
-      }
-
-      const { downloadData, downloadError } = await fetchTsxReport(args, data!, formattedFileName);
 
       thunkAPI.dispatch(globalActions.destroyMessages([messageKey]));
 
-      if (downloadError) {
+      const isSuccess = !!response && response.status >= 200 && response.status < 300;
+      if (!isSuccess) {
         showErrorReportNotif(thunkAPI);
         return thunkAPI.rejectWithValue('error');
       }
@@ -135,7 +128,7 @@ const fetchTsvReport = createAsyncThunk<void, TFetchTSVArgs, { rejectValue: stri
       );
 
       saveAs(
-        new Blob([downloadData], {
+        new Blob([data!], {
           type: getDefaultContentType('text'),
         }),
         formattedFileName,
@@ -157,7 +150,7 @@ const generateLocalTsvReport = createAsyncThunk<
     rows: any[];
   },
   { rejectValue: string }
->('report/generate/tsv', async (args, thunkAPI) => {
+>('report/generate/localtsv', async (args, thunkAPI) => {
   // !! This function assumes that it is called only when the table is not empty. Said otherwise, data is never empty !!
   const messageKey = 'report_pending';
 
@@ -210,58 +203,25 @@ const idField = (index: string) => {
   }
 };
 
-const fetchTsxReport = async (
-  args: TFetchTSVArgs,
-  data: ArrangerColumnStateResults,
-  formattedFileName: string,
-) => {
-  let colStates = args.columnStates
-    ? args.columnStates
-    : args.columns.map((col, index) => ({
+const NON_EXPORTABLE_COLUMN_KEYS = ['lock'];
+
+const buildVisibleColumns = (columns: ProColumnType[], columnStates: TColumnStates | undefined) => {
+  const colStates = columnStates?.length
+    ? columnStates
+    : columns.map((col, index) => ({
         index,
-        key: col.key,
-        visible: col.defaultHidden === true ? false : true,
+        key: col.key as string,
+        visible: col.defaultHidden !== true,
       }));
-  colStates = colStates.filter(({ visible }) => !!visible);
 
-  const columnKeyOrdered = [...colStates].sort((a, b) => a.index - b.index).map(({ key }) => key);
-  const tsvColumnsConfig = data!.data[args.index].columnsState.state.columns.filter(({ field }) =>
-    colStates.find(({ key }) => key === field),
-  );
-  const tsvColumnsConfigWithHeader = tsvColumnsConfig.map((column) => ({
-    ...column,
-    Header: getTitleFromColumns(args.columns, column.field),
-  }));
-
-  const sortIdField = idField(args.index);
-
-  const params = new URLSearchParams({
-    params: JSON.stringify({
-      files: [
-        {
-          fileName: formattedFileName,
-          fileType: 'tsv',
-          sqon: args.sqon,
-          sort: sortIdField ? [{ field: sortIdField, order: SortDirection.Asc }] : [],
-          index: args.index,
-          columns: tsvColumnsConfigWithHeader.sort((a, b) =>
-            columnKeyOrdered.indexOf(a.field) > columnKeyOrdered.indexOf(b.field) ? 1 : -1,
-          ),
-        },
-      ],
-    }),
-    httpHeaders: JSON.stringify({
-      authorization: `Bearer ${keycloak.token}`,
-    }),
-    downloadKey: v4(),
-  });
-
-  const { data: downloadData, error: downloadError } = await ArrangerApi.download(params);
-
-  return {
-    downloadData,
-    downloadError,
-  };
+  return [...colStates]
+    .filter(({ visible }) => !!visible)
+    .filter(({ key }) => !NON_EXPORTABLE_COLUMN_KEYS.includes(key))
+    .sort((a, b) => a.index - b.index)
+    .map(({ key }) => ({
+      field: key,
+      header: getTitleFromColumns(columns, key),
+    }));
 };
 
 const getTitleFromColumns = (columns: ProColumnType[], field: string) => {

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { CheckOutlined, DownloadOutlined } from '@ant-design/icons';
+import { CheckOutlined, CloseCircleOutlined, DownloadOutlined } from '@ant-design/icons';
 import RequestBiospecimenButton from '@ferlab/ui/core/components/BiospecimenRequest/RequestBiospecimenButton';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
@@ -16,7 +16,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Button, Tooltip } from 'antd';
+import { Button, Modal, Tooltip } from 'antd';
 import keycloak from 'auth/keycloak-api/keycloak';
 import { AxiosRequestConfig } from 'axios';
 import { useBiospecimen } from 'graphql/biospecimens/actions';
@@ -26,6 +26,7 @@ import { ArrangerResultsTree } from 'graphql/models';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { IStudyEntity } from 'graphql/studies/models';
 import EnvironmentVariables from 'helpers/EnvVariables';
+import { isEmpty } from 'lodash';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import {
   BIOSPECIMENS_SAVED_SETS_FIELD,
@@ -46,6 +47,7 @@ import AgeCell from 'components/AgeCell';
 import { OntologyTermsWithLinksFromDiagnoses, OntologyTermWithLink } from 'components/Cells';
 import useApi from 'hooks/useApi';
 import { trackRequestBiospecimen } from 'services/analytics';
+import { MAX_ROW_EXPORTED } from 'services/api/arranger/models';
 import { ReportType } from 'services/api/reports/models';
 import { SetType } from 'services/api/savedSet/models';
 import { fetchReport, fetchTsvReport } from 'store/report/thunks';
@@ -496,7 +498,19 @@ const BioSpecimenTab = ({ sqon }: OwnProps) => {
               },
             }),
           ),
-        onTableExportClick: () =>
+        onTableExportClick: () => {
+          const nbRowsToExport =
+            selectedAllResults || isEmpty(selectedKeys) ? results.total : selectedKeys.length;
+          if (nbRowsToExport > MAX_ROW_EXPORTED) {
+            Modal.error({
+              title: intl.get('global.exportModal.title'),
+              icon: <CloseCircleOutlined />,
+              content: intl.get('global.exportModal.content'),
+              okText: intl.get('global.exportModal.button'),
+            });
+            return;
+          }
+
           dispatch(
             fetchTsvReport({
               columnStates: userInfo?.config.data_exploration?.tables?.biospecimens?.columns,
@@ -504,7 +518,8 @@ const BioSpecimenTab = ({ sqon }: OwnProps) => {
               index: INDEXES.BIOSPECIMEN,
               sqon: getCurrentSqon(),
             }),
-          ),
+          );
+        },
         extra: [
           <RequestBiospecimenButton
             additionalHandleClick={() => trackRequestBiospecimen('open modal')}

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { LockOutlined, SafetyOutlined, UnlockFilled, WarningOutlined } from '@ant-design/icons';
+import {
+  CloseCircleOutlined,
+  LockOutlined,
+  SafetyOutlined,
+  UnlockFilled,
+  WarningOutlined,
+} from '@ant-design/icons';
 import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink/index';
 import ProTable from '@ferlab/ui/core/components/ProTable';
@@ -18,7 +24,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Popover, Tag, Tooltip } from 'antd';
+import { Modal, Popover, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useDataFiles } from 'graphql/files/actions';
 import {
@@ -29,7 +35,7 @@ import {
   ITableFileEntity,
 } from 'graphql/files/models';
 import { joinUniqueCleanWords } from 'helpers';
-import { capitalize } from 'lodash';
+import { capitalize, isEmpty } from 'lodash';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import {
   DATA_EXPLORATION_QB_ID,
@@ -46,6 +52,7 @@ import { MAX_ITEMS_QUERY, TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { FENCE_NAMES } from 'common/fenceTypes';
 import CavaticaAnalyzeButton from 'components/Cavatica/AnalyzeButton';
 import DownloadFileManifestModal from 'components/uiKit/reports/DownloadFileManifestModal';
+import { MAX_ROW_EXPORTED } from 'services/api/arranger/models';
 import { SetType } from 'services/api/savedSet/models';
 import { useAllFencesAcl, useFenceAuthentification } from 'store/fences';
 import { useCavaticaPassport } from 'store/passport';
@@ -578,7 +585,19 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
             setSelectedKeys(keys);
             setSelectedRows(rows);
           },
-          onTableExportClick: () =>
+          onTableExportClick: () => {
+            const nbRowsToExport =
+              selectedAllResults || isEmpty(selectedKeys) ? results.total : selectedKeys.length;
+            if (nbRowsToExport > MAX_ROW_EXPORTED) {
+              Modal.error({
+                title: intl.get('global.exportModal.title'),
+                icon: <CloseCircleOutlined />,
+                content: intl.get('global.exportModal.content'),
+                okText: intl.get('global.exportModal.button'),
+              });
+              return;
+            }
+
             dispatch(
               fetchTsvReport({
                 columnStates: userInfo?.config.data_exploration?.tables?.[activePreset]?.columns,
@@ -591,7 +610,8 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
                 index: INDEXES.FILE,
                 sqon: getCurrentSqon(),
               }),
-            ),
+            );
+          },
           onColumnSortChange: (newState) =>
             dispatch(
               updateUserConfig({

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { DownloadOutlined } from '@ant-design/icons';
+import { CloseCircleOutlined, DownloadOutlined } from '@ant-design/icons';
 import ColorTag, { ColorTagType } from '@ferlab/ui/core/components/ColorTag';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import ProTable from '@ferlab/ui/core/components/ProTable';
@@ -19,7 +19,7 @@ import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
 import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Button, Dropdown, Tag, Tooltip } from 'antd';
+import { Button, Dropdown, Modal, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useParticipants } from 'graphql/participants/actions';
 import {
@@ -32,7 +32,7 @@ import {
   ITableParticipantEntity,
 } from 'graphql/participants/models';
 import { makeUniqueCleanWords } from 'helpers';
-import { capitalize } from 'lodash';
+import { capitalize, isEmpty } from 'lodash';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import {
   DATA_EXPLORATION_QB_ID,
@@ -48,6 +48,7 @@ import { areFilesDataTypeValid, mapStudyToPedcBioportal } from 'views/Studies/ut
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { OntologyTermsWithLinks, OntologyTermsWithLinksFromDiagnoses } from 'components/Cells';
+import { MAX_ROW_EXPORTED } from 'services/api/arranger/models';
 import { ReportType } from 'services/api/reports/models';
 import { SetType } from 'services/api/savedSet/models';
 import { fetchReport, fetchTsvReport } from 'store/report/thunks';
@@ -523,7 +524,19 @@ const ParticipantsTab = ({ sqon }: OwnProps) => {
               },
             }),
           ),
-        onTableExportClick: () =>
+        onTableExportClick: () => {
+          const nbRowsToExport =
+            selectedAllResults || isEmpty(selectedKeys) ? results.total : selectedKeys.length;
+          if (nbRowsToExport > MAX_ROW_EXPORTED) {
+            Modal.error({
+              title: intl.get('global.exportModal.title'),
+              icon: <CloseCircleOutlined />,
+              content: intl.get('global.exportModal.content'),
+              okText: intl.get('global.exportModal.button'),
+            });
+            return;
+          }
+
           dispatch(
             fetchTsvReport({
               columnStates: userInfo?.config.data_exploration?.tables?.participants?.columns,
@@ -531,7 +544,8 @@ const ParticipantsTab = ({ sqon }: OwnProps) => {
               index: INDEXES.PARTICIPANT,
               sqon: getCurrentSqon(),
             }),
-          ),
+          );
+        },
         onSelectAllResultsChange: setSelectedAllResults,
         onSelectedRowsChange: (keys, rows) => {
           setSelectedKeys(keys);

--- a/src/views/Studies/components/PageContent/index.tsx
+++ b/src/views/Studies/components/PageContent/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { CloseCircleOutlined } from '@ant-design/icons';
 import ProLabel from '@ferlab/ui/core/components/ProLabel';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import SummarySumCell from '@ferlab/ui/core/components/ProTable/SummarySumCell';
@@ -21,12 +22,13 @@ import { generateQuery, isEmptySqon } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import { Input, Space, Typography } from 'antd';
+import { Input, Modal, Space, Typography } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useStudies } from 'graphql/studies/actions';
 import { IStudyEntity } from 'graphql/studies/models';
 import { cloneDeep } from 'lodash';
 
+import { MAX_ROW_EXPORTED } from 'services/api/arranger/models';
 import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
@@ -235,6 +237,16 @@ const PageContent = ({ defaultColumns = [] }: OwnProps) => {
                 ),
               enableTableExport: true,
               onTableExportClick: () => {
+                if (data.length > MAX_ROW_EXPORTED) {
+                  Modal.error({
+                    title: intl.get('global.exportModal.title'),
+                    icon: <CloseCircleOutlined />,
+                    content: intl.get('global.exportModal.content'),
+                    okText: intl.get('global.exportModal.button'),
+                  });
+                  return;
+                }
+
                 dispatch(
                   fetchTsvReport({
                     columnStates: userInfo?.config.study?.tables?.study?.columns,


### PR DESCRIPTION
# feat(export): implement tsv export with new arranger

- [SKFP-1612](https://d3b.atlassian.net/browse/SKFP-1612)

## Description
Back upgrade arranger and TSV export not workin anymore.

## Acceptance Criterias

- Export as TSV works at all entry points listed above
- Selected rows → only those rows exported
- No selection / Select all results → all matching rows exported
- Only currently visible columns are included in the export
- File Authorization column excluded from Data Files TSV; Data Access column included with correct values
- Multi-value fields are comma-separated within a single cell, matching current behaviour
- When results exceed 10,000 rows, the warning modal is displayed and no download is initiated
- In-progress and error notification states are displayed correctly during valid exports

## Screenshot or Video

### After

#### Studies
<img width="1372" height="199" alt="Capture d’écran, le 2026-07-09 à 11 38 39" src="https://github.com/user-attachments/assets/080b40ba-032e-4853-ba28-1a89eabf9207" />

#### Participants
<img width="1525" height="201" alt="Capture d’écran, le 2026-07-09 à 11 39 47" src="https://github.com/user-attachments/assets/2395ec5d-c8ff-400d-86c0-c7cd3176f4d4" />

#### Biospecimens
<img width="1559" height="588" alt="Capture d’écran, le 2026-07-09 à 11 40 49" src="https://github.com/user-attachments/assets/7ef659b1-7776-4bc9-bdd3-6a2c0fcada9e" />

#### Data files
<img width="983" height="588" alt="Capture d’écran, le 2026-07-09 à 11 54 54" src="https://github.com/user-attachments/assets/3d9a58fb-ada2-4022-b161-4a3ff99d0882" />

#### Data files - Imaging
<img width="1528" height="588" alt="Capture d’écran, le 2026-07-09 à 11 55 06" src="https://github.com/user-attachments/assets/159be15e-68cb-404a-aefc-981c5fd33f6c" />

#### Errors with and without selection
<img width="1720" height="588" alt="Capture d’écran, le 2026-07-09 à 11 40 26" src="https://github.com/user-attachments/assets/f3f075cb-e3e8-4e7d-a343-7b363ecb4c9b" />
<img width="1720" height="588" alt="Capture d’écran, le 2026-07-09 à 11 40 06" src="https://github.com/user-attachments/assets/9742ed1f-6842-48c8-9873-46a537f1eae7" />


[SKFP-1612]: https://d3b.atlassian.net/browse/SKFP-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ