### PR TITLE
fix(summary): SKFP-1620 refresh chart when adding a filter

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -53,7 +53,7 @@ const MostFrequentDiagnosisGraphCard = () => {
 
   useEffect(() => {
     setMondoLoading(true);
-    phenotypeStore.current?.fetch({ field: 'mondo', sqon }).then(() => {
+    phenotypeStore.current?.fetch({ field: 'mondo', sqon, filterThemselves: true }).then(() => {
       setMondoLoading(false);
       const flattenMondoTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
         (a, b) => {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -88,21 +88,23 @@ const MostFrequentPhenotypesGraphCard = () => {
 
   useEffect(() => {
     setPhenotypesLoading(true);
-    phenotypeStore.current?.fetch({ field: 'observed_phenotype', sqon }).then(() => {
-      setPhenotypesLoading(false);
-      const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
-        (a, b) => {
-          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
-            return -1;
-          }
-          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
-            return 1;
-          }
-          return 0;
-        },
-      );
-      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
-    });
+    phenotypeStore.current
+      ?.fetch({ field: 'observed_phenotype', sqon, filterThemselves: true })
+      .then(() => {
+        setPhenotypesLoading(false);
+        const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+          (a, b) => {
+            if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+              return -1;
+            }
+            if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+              return 1;
+            }
+            return 0;
+          },
+        );
+        setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
+      });
   }, [JSON.stringify(sqon)]);
 
   return (


### PR DESCRIPTION
# fix(summary): refresh chart when adding a filter

- [SKFP-1620](https://d3b.atlassian.net/browse/SKFP-1620)

## Description
Most frequent charts are not refresh after adding a filter in QB.

## Acceptance Criterias
- charts refresh data

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->

### After

https://github.com/user-attachments/assets/8df2d823-df1c-4ab2-975a-1ca622764ebc


[SKFP-1620]: https://d3b.atlassian.net/browse/SKFP-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ