### PR TITLE
fix(apollo): SKFP-1622 apollo cache warning and cache extended mappings

### DIFF
--- a/src/hooks/graphql/useGetExtendedMappings.ts
+++ b/src/hooks/graphql/useGetExtendedMappings.ts
@@ -4,9 +4,6 @@ import { INDEX_EXTENDED_MAPPING } from 'graphql/queries';
 import { useLazyResultQueryOnLoadOnly } from 'hooks/graphql/useLazyResultQuery';
 
 const useGetExtendedMappings = (index: string): IExtendedMappingResults => {
-  // An index mapping only changes when Arranger is redeployed, so it is safe to
-  // serve from the cache: one network call per index for the whole session
-  // instead of one per mounted view.
   const { loading, result } = useLazyResultQueryOnLoadOnly<any>(INDEX_EXTENDED_MAPPING(index), {
     fetchPolicy: 'cache-first',
   });

--- a/src/hooks/graphql/useGetExtendedMappings.ts
+++ b/src/hooks/graphql/useGetExtendedMappings.ts
@@ -4,8 +4,11 @@ import { INDEX_EXTENDED_MAPPING } from 'graphql/queries';
 import { useLazyResultQueryOnLoadOnly } from 'hooks/graphql/useLazyResultQuery';
 
 const useGetExtendedMappings = (index: string): IExtendedMappingResults => {
+  // An index mapping only changes when Arranger is redeployed, so it is safe to
+  // serve from the cache: one network call per index for the whole session
+  // instead of one per mounted view.
   const { loading, result } = useLazyResultQueryOnLoadOnly<any>(INDEX_EXTENDED_MAPPING(index), {
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'cache-first',
   });
 
   return {

--- a/src/provider/ApolloProvider.tsx
+++ b/src/provider/ApolloProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import keycloak from 'auth/keycloak-api/keycloak';
+import { INDEXES } from 'graphql/constants';
 import EnvironmentVariables from 'helpers/EnvVariables';
 import { IProvider } from 'provider/types';
 
@@ -30,10 +31,26 @@ const getAuthLink = () =>
     },
   }));
 
+// Each Arranger index is exposed as a root field returning an object with no id,
+// and addTypename is false so there is no __typename either. Apollo cannot
+// normalize those objects, so it replaces them wholesale on every write, losing
+// sibling entries such as a hits(...) or aggregations(...) already cached under
+// different arguments. A shallow merge keeps them side by side.
+const rootIndexFields = Object.fromEntries(
+  Object.values(INDEXES).map((index) => [index, { merge: true }]),
+);
+
 // Single client (and cache), instantiated once for the whole session so the
 // InMemoryCache is not thrown away on every render.
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
-  cache: new InMemoryCache({ addTypename: false }),
+  cache: new InMemoryCache({
+    addTypename: false,
+    typePolicies: {
+      Query: {
+        fields: rootIndexFields,
+      },
+    },
+  }),
   link: getAuthLink().concat(arrangerLink),
 });
 

--- a/src/provider/ApolloProvider.tsx
+++ b/src/provider/ApolloProvider.tsx
@@ -31,10 +31,9 @@ const getAuthLink = () =>
     },
   }));
 
-// Each Arranger index is exposed as a root field returning an object with no id,
-// and addTypename is false so there is no __typename either. Apollo cannot
-// normalize those objects, so it replaces them wholesale on every write, losing
-// sibling entries such as a hits(...) or aggregations(...) already cached under
+// Each Arranger index is exposed as a root field returning an object with no id.
+// Apollo cannot normalize those objects, so it replaces them wholesale on every write,
+// losing sibling entries such as a hits(...) or aggregations(...) already cached under
 // different arguments. A shallow merge keeps them side by side.
 const rootIndexFields = Object.fromEntries(
   Object.values(INDEXES).map((index) => [index, { merge: true }]),


### PR DESCRIPTION
# fix(apollo): clean

- [SKFP-1622](https://d3b.atlassian.net/browse/SKFP-1622)

## Description
Fix apollo cache warning and extended mappings.

## Acceptance Criterias

- Don't see anymore apollo warning in consol
- Reduce extended mapping call to back and use cache

## Tests

- Console: Apollo warning gone on startup.
- Network → Search for ExtendedMapping, sequence Studies → Data Exploration → Studies: counters stay at 1 per index (2 before).
- Facets on the 5 Data Exploration panels plus Studies, Variants, Variants Somatic, Set Operations: correct widget per field type, no stuck spinner, quick filter working.

[SKFP-1622]: https://d3b.atlassian.net/browse/SKFP-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ